### PR TITLE
fix(sessionledger): append one line per entry instead of re-marshalling all state

### DIFF
--- a/internal/gateway/debug.go
+++ b/internal/gateway/debug.go
@@ -160,6 +160,76 @@ type debugMemoryVars struct {
 	NextGCBytes     uint64 `json:"next_gc_bytes"`
 	LastGCUnixNano  uint64 `json:"last_gc_unix_nano"`
 	NumGC           uint32 `json:"num_gc"`
+
+	// The three below are DERIVED, and they are the ones that catch an allocation
+	// blowup. Raw MemStats were already published here and still did not surface
+	// the session-ledger O(n^2): Alloc looks unremarkable between collections and
+	// heap_objects stays LOW precisely when the problem is a few enormous buffers.
+	//
+	// AllocBytesPerSec is the cumulative allocation RATE since boot. A healthy
+	// proxy turn allocates a few MB; the ledger bug ran at ~484 MB/s sustained
+	// (1.19 TB in 41 min on one guard). Rate is the tell that a per-turn cost has
+	// gone superlinear.
+	AllocBytesPerSec uint64 `json:"alloc_bytes_per_sec"`
+	// PeakHeapSysBytes is the high-water mark of heap memory taken from the OS.
+	// Sawtooth RSS means an instantaneous sample almost never catches the peak,
+	// which is exactly the number that decides whether this process is why the
+	// machine is swapping.
+	PeakHeapSysBytes uint64 `json:"peak_heap_sys_bytes"`
+	// PeakAllocBytes is the high-water mark of live heap.
+	PeakAllocBytes uint64 `json:"peak_alloc_bytes"`
+}
+
+// newDebugMemoryVars renders one MemStats sample plus the derived rate/peak fields.
+func newDebugMemoryVars(mem *runtime.MemStats) debugMemoryVars {
+	perSec, peakSys, peakAlloc := procMemory.observe(mem)
+	return debugMemoryVars{
+		AllocBytes:       mem.Alloc,
+		TotalAllocBytes:  mem.TotalAlloc,
+		SysBytes:         mem.Sys,
+		HeapAllocBytes:   mem.HeapAlloc,
+		HeapSysBytes:     mem.HeapSys,
+		HeapObjects:      mem.HeapObjects,
+		StackInuseBytes:  mem.StackInuse,
+		NextGCBytes:      mem.NextGC,
+		LastGCUnixNano:   mem.LastGC,
+		NumGC:            mem.NumGC,
+		AllocBytesPerSec: perSec,
+		PeakHeapSysBytes: peakSys,
+		PeakAllocBytes:   peakAlloc,
+	}
+}
+
+// memoryWatermarks tracks the high-water marks MemStats itself does not keep.
+// Sampled on each /debug/vars read (the info pane polls every 2s), which is
+// frequent enough to catch a sawtooth's crest and costs nothing when nobody looks.
+type memoryWatermarks struct {
+	bootUnixNano int64
+	peakHeapSys  atomic.Uint64
+	peakAlloc    atomic.Uint64
+}
+
+var procMemory = memoryWatermarks{bootUnixNano: time.Now().UnixNano()}
+
+// observe folds one MemStats sample into the watermarks and returns the derived
+// fields. Monotonic maxima via CAS: concurrent readers race benignly.
+func (m *memoryWatermarks) observe(ms *runtime.MemStats) (perSec, peakSys, peakAlloc uint64) {
+	for {
+		old := m.peakHeapSys.Load()
+		if ms.HeapSys <= old || m.peakHeapSys.CompareAndSwap(old, ms.HeapSys) {
+			break
+		}
+	}
+	for {
+		old := m.peakAlloc.Load()
+		if ms.Alloc <= old || m.peakAlloc.CompareAndSwap(old, ms.Alloc) {
+			break
+		}
+	}
+	if elapsed := time.Now().UnixNano() - m.bootUnixNano; elapsed > 0 {
+		perSec = uint64(float64(ms.TotalAlloc) / (float64(elapsed) / 1e9))
+	}
+	return perSec, m.peakHeapSys.Load(), m.peakAlloc.Load()
 }
 
 type debugKernelVars struct {
@@ -441,18 +511,7 @@ func (s *Server) debugVarsContext(ctx context.Context, now time.Time) debugVarsR
 			NumCPU:       runtime.NumCPU(),
 			GOMAXPROCS:   runtime.GOMAXPROCS(0),
 			NumGoroutine: runtime.NumGoroutine(),
-			Memory: debugMemoryVars{
-				AllocBytes:      mem.Alloc,
-				TotalAllocBytes: mem.TotalAlloc,
-				SysBytes:        mem.Sys,
-				HeapAllocBytes:  mem.HeapAlloc,
-				HeapSysBytes:    mem.HeapSys,
-				HeapObjects:     mem.HeapObjects,
-				StackInuseBytes: mem.StackInuse,
-				NextGCBytes:     mem.NextGC,
-				LastGCUnixNano:  mem.LastGC,
-				NumGC:           mem.NumGC,
-			},
+			Memory:       newDebugMemoryVars(&mem),
 		},
 		Kernel: debugKernelVars{
 			Submits:      c.Submits,

--- a/internal/gateway/messages.go
+++ b/internal/gateway/messages.go
@@ -129,7 +129,7 @@ func (s *Server) handleAnthropicMessages(w http.ResponseWriter, r *http.Request)
 	}
 	ctx := r.Context()
 	reqTrace := s.traceFor(r.Header.Get("X-Trace-Id"))
-	appendSessionLedger(reqTrace, "user_message", req.Raw)
+	appendSessionLedger(reqTrace, "user_message", turnLedgerSummary(req))
 	// C1 read-scope floor (#4192): the first turn a trace serves binds its owning principal, so a
 	// later fak_context_restore / fak_context_spans read-self op can be scoped to it. First-writer-
 	// wins; "" on the no-RequireKey loopback (single-tenant).

--- a/internal/gateway/session_admit.go
+++ b/internal/gateway/session_admit.go
@@ -25,6 +25,9 @@ package gateway
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"net/http"
 	"time"
 
@@ -417,6 +420,38 @@ func appendSessionLedger(trace, kind string, content []byte) {
 		content = []byte("{}")
 	}
 	_, _ = l.Append(trace, kind, content)
+}
+
+// turnLedgerSummary is what the ledger records for a served turn: the SHAPE of the
+// request, never the request. Persisting req.Raw here meant a full conversation
+// context (~200 KB and rising) landed in the ledger every turn; the ledger is a
+// provenance chain, and a byte count plus a digest witnesses the same turn for a
+// fixed ~200 bytes. sessionledger.Elide would clamp an oversized blob anyway --
+// summarizing at the source keeps what we DO store useful instead of a bare hash.
+func turnLedgerSummary(req *agent.AnthropicMessagesRequest) []byte {
+	if req == nil {
+		return nil
+	}
+	sum := sha256.Sum256(req.Raw)
+	b, err := json.Marshal(struct {
+		Model    string `json:"model,omitempty"`
+		Messages int    `json:"messages"`
+		Tools    int    `json:"tools,omitempty"`
+		Stream   bool   `json:"stream,omitempty"`
+		RawBytes int    `json:"raw_bytes"`
+		RawSHA   string `json:"raw_sha256"`
+	}{
+		Model:    req.Model,
+		Messages: len(req.Messages),
+		Tools:    len(req.Tools),
+		Stream:   req.Stream,
+		RawBytes: len(req.Raw),
+		RawSHA:   hex.EncodeToString(sum[:]),
+	})
+	if err != nil {
+		return nil
+	}
+	return b
 }
 
 func (t servedSessionTurn) complete() { appendSessionLedger(t.traceID, "turn_complete", nil) }

--- a/internal/sessionledger/bounds_test.go
+++ b/internal/sessionledger/bounds_test.go
@@ -207,6 +207,28 @@ func TestLegacyWholeStateFileIsRetiredNotLoaded(t *testing.T) {
 	}
 }
 
+// TestDefaultDirNeverTouchesOperatorConfigUnderTest: no test in this repo sets
+// FAK_SESSION_LEDGER_DIR, and the gateway suite reaches OpenDefault through the
+// served-turn seam -- so before this guard, `go test ./internal/gateway/` opened
+// the real operator ledger, appended to it, and retired its legacy file.
+func TestDefaultDirNeverTouchesOperatorConfigUnderTest(t *testing.T) {
+	t.Setenv("FAK_SESSION_LEDGER_DIR", "")
+	got := DefaultDir()
+	if cfg, err := os.UserConfigDir(); err == nil {
+		if strings.HasPrefix(got, filepath.Join(cfg, "fak")) {
+			t.Fatalf("DefaultDir under test resolved into the operator config dir: %s", got)
+		}
+	}
+	if !strings.Contains(got, "fak-test-session-ledger") {
+		t.Fatalf("DefaultDir under test = %s, want an isolated per-test-binary dir", got)
+	}
+	// An explicit override still wins.
+	t.Setenv("FAK_SESSION_LEDGER_DIR", filepath.Join(t.TempDir(), "explicit"))
+	if DefaultDir() == got {
+		t.Fatal("explicit FAK_SESSION_LEDGER_DIR was ignored")
+	}
+}
+
 // TestEvictionKeepsChainUsable: past MaxNodes the ledger forgets oldest-first and
 // Chain returns the surviving suffix rather than failing outright.
 func TestEvictionKeepsChainUsable(t *testing.T) {

--- a/internal/sessionledger/bounds_test.go
+++ b/internal/sessionledger/bounds_test.go
@@ -1,0 +1,229 @@
+package sessionledger
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestAppendCostIsLinearNotQuadratic is the regression test for the blowup this
+// package was rewritten to fix. The old format re-marshalled the WHOLE state on
+// every append, so writing n entries of size s cost O(n^2 * s) bytes of I/O and
+// allocation. Appending one line makes it O(n * s).
+//
+// The assertion is on the FILE, because the file is what the old code rewrote.
+// With n=300 and ~1 KB entries, linear is ~300 KB; quadratic is ~45 MB. The 4x
+// slack absorbs JSON framing and hash fields without coming close to quadratic.
+func TestAppendCostIsLinearNotQuadratic(t *testing.T) {
+	dir := t.TempDir()
+	l, err := Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const n = 300
+	payload := json.RawMessage(`{"body":"` + strings.Repeat("x", 1000) + `"}`)
+	for i := 0; i < n; i++ {
+		if _, err := l.Append("t", "user_message", payload); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	st, err := os.Stat(filepath.Join(dir, LogName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	linear := int64(n * (len(payload) + 200)) // payload + framing/hash headroom
+	if st.Size() > 4*linear {
+		t.Fatalf("file is %d bytes; linear budget is ~%d. The whole-state rewrite is back.",
+			st.Size(), linear)
+	}
+	// And the same n appends must still be one readable chain.
+	if got := l.NodeCount(); got != n {
+		t.Fatalf("NodeCount = %d, want %d", got, n)
+	}
+}
+
+// TestOversizedContentIsElidedNotStored pins the second half of the fix: a caller
+// that hands over a full request body gets a bounded provenance stub, not the body.
+func TestOversizedContentIsElidedNotStored(t *testing.T) {
+	dir := t.TempDir()
+	l, err := Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	big := json.RawMessage(`{"body":"` + strings.Repeat("y", MaxContentBytes*2) + `"}`)
+	e, err := l.Append("t", "user_message", big)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(e.Content) >= len(big) {
+		t.Fatalf("content not elided: %d bytes retained", len(e.Content))
+	}
+	var stub struct {
+		Elided bool   `json:"elided"`
+		Bytes  int    `json:"bytes"`
+		SHA256 string `json:"sha256"`
+	}
+	if err := json.Unmarshal(e.Content, &stub); err != nil {
+		t.Fatalf("stub is not JSON: %v", err)
+	}
+	if !stub.Elided || stub.Bytes != len(big) || len(stub.SHA256) != 64 {
+		t.Fatalf("stub lost provenance: %+v", stub)
+	}
+	// The elided entry must still verify as a chain member.
+	chain, err := l.Chain("t")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Verify(chain); err != nil {
+		t.Fatalf("elided entry broke chain verification: %v", err)
+	}
+}
+
+// TestReopenRebuildsHeadsAndChain proves the append-only log is a real durable
+// store, not just a write sink: a fresh process sees the same heads and chain.
+func TestReopenRebuildsHeadsAndChain(t *testing.T) {
+	dir := t.TempDir()
+	l, err := Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, k := range []string{"turn_begin", "user_message", "turn_complete"} {
+		if _, err := l.Append("a", k, json.RawMessage(`{"v":1}`)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := l.Fork("a", "b"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := l.Append("b", "user_message", json.RawMessage(`{"v":2}`)); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reopened.Head("a") != l.Head("a") || reopened.Head("b") != l.Head("b") {
+		t.Fatal("heads did not survive reopen")
+	}
+	chain, err := reopened.Chain("b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(chain) != 4 {
+		t.Fatalf("chain length %d, want 4", len(chain))
+	}
+	if err := Verify(chain); err != nil {
+		t.Fatalf("reopened chain does not verify: %v", err)
+	}
+}
+
+// TestTornLineIsSkippedNotFatal: a process killed mid-write must not make the
+// whole ledger unreadable. The old whole-file rename was atomic; an append-only
+// log trades that for partial-line risk, so the reader has to be tolerant.
+func TestTornLineIsSkippedNotFatal(t *testing.T) {
+	dir := t.TempDir()
+	l, err := Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := l.Append("a", "user_message", json.RawMessage(`{"v":1}`)); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, LogName)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(`{"trace":"a","hash":"deadbe`); err != nil { // torn
+		t.Fatal(err)
+	}
+	f.Close()
+
+	reopened, err := Open(dir)
+	if err != nil {
+		t.Fatalf("torn line made the ledger unreadable: %v", err)
+	}
+	if reopened.Head("a") != l.Head("a") {
+		t.Fatal("torn line corrupted the surviving head")
+	}
+}
+
+// TestRotationBoundsTheFile: the log must not grow without limit on disk.
+func TestRotationBoundsTheFile(t *testing.T) {
+	dir := t.TempDir()
+	l, err := Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Write comfortably past MaxFileBytes using max-size entries.
+	payload := json.RawMessage(`{"body":"` + strings.Repeat("z", MaxContentBytes-32) + `"}`)
+	writes := (MaxFileBytes / len(payload)) + 64
+	for i := 0; i < writes; i++ {
+		if _, err := l.Append("t", "user_message", payload); err != nil {
+			t.Fatal(err)
+		}
+	}
+	st, err := os.Stat(filepath.Join(dir, LogName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Size() > MaxFileBytes {
+		t.Fatalf("live log is %d bytes, past the %d ceiling", st.Size(), MaxFileBytes)
+	}
+	if _, err := os.Stat(filepath.Join(dir, LogName+".1")); err != nil {
+		t.Fatalf("expected a rotated generation: %v", err)
+	}
+}
+
+// TestLegacyWholeStateFileIsRetiredNotLoaded: the pre-JSONL ledger.json reached
+// 389 MB in the field. Loading it would reproduce the blowup on the first open,
+// so it is moved aside and left for forensics.
+func TestLegacyWholeStateFileIsRetiredNotLoaded(t *testing.T) {
+	dir := t.TempDir()
+	legacy := filepath.Join(dir, legacyName)
+	body := fmt.Sprintf(`{"heads":{"a":"h1"},"nodes":{"h1":{"hash":"h1","kind":"user_message","content":%q}}}`,
+		strings.Repeat("q", 4096))
+	if err := os.WriteFile(legacy, []byte(body), 0600); err != nil {
+		t.Fatal(err)
+	}
+	l, err := Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if l.NodeCount() != 0 || l.Head("a") != "" {
+		t.Fatal("legacy whole-state file was loaded; it must be retired instead")
+	}
+	if _, err := os.Stat(legacy); !os.IsNotExist(err) {
+		t.Fatal("legacy file still in place; it should have been renamed aside")
+	}
+	if _, err := os.Stat(legacy + ".legacy"); err != nil {
+		t.Fatalf("legacy file was destroyed rather than preserved: %v", err)
+	}
+}
+
+// TestEvictionKeepsChainUsable: past MaxNodes the ledger forgets oldest-first and
+// Chain returns the surviving suffix rather than failing outright.
+func TestEvictionKeepsChainUsable(t *testing.T) {
+	l := Memory()
+	for i := 0; i < MaxNodes+50; i++ {
+		if _, err := l.Append("t", "turn_complete", nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := l.NodeCount(); got > MaxNodes {
+		t.Fatalf("NodeCount %d exceeds MaxNodes %d", got, MaxNodes)
+	}
+	chain, err := l.Chain("t")
+	if err != nil {
+		t.Fatalf("Chain failed after eviction: %v", err)
+	}
+	if len(chain) == 0 {
+		t.Fatal("Chain returned nothing after eviction")
+	}
+}

--- a/internal/sessionledger/bounds_test.go
+++ b/internal/sessionledger/bounds_test.go
@@ -207,6 +207,52 @@ func TestLegacyWholeStateFileIsRetiredNotLoaded(t *testing.T) {
 	}
 }
 
+// TestSecondRetirementDoesNotClobberTheFirst: while a mixed fleet is rolling, an
+// older build keeps recreating ledger.json and each new process retires it again.
+// os.Rename overwrites on POSIX, so a naive retirement would destroy the file the
+// previous one preserved -- the exact loss this path exists to prevent.
+func TestSecondRetirementDoesNotClobberTheFirst(t *testing.T) {
+	dir := t.TempDir()
+	legacy := filepath.Join(dir, legacyName)
+	write := func(marker string) {
+		body := fmt.Sprintf(`{"heads":{},"nodes":{},"marker":%q}`, marker)
+		if err := os.WriteFile(legacy, []byte(body), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("first-generation")
+	if _, err := Open(dir); err != nil {
+		t.Fatal(err)
+	}
+	write("second-generation") // an older binary recreated it
+	if _, err := Open(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	got := map[string]bool{}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		b, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			continue
+		}
+		for _, marker := range []string{"first-generation", "second-generation"} {
+			if strings.Contains(string(b), marker) {
+				got[marker] = true
+			}
+		}
+	}
+	if !got["first-generation"] {
+		t.Fatal("the FIRST retired generation was clobbered by the second")
+	}
+	if !got["second-generation"] {
+		t.Fatal("the second retired generation is missing")
+	}
+}
+
 // TestDefaultDirNeverTouchesOperatorConfigUnderTest: no test in this repo sets
 // FAK_SESSION_LEDGER_DIR, and the gateway suite reaches OpenDefault through the
 // served-turn seam -- so before this guard, `go test ./internal/gateway/` opened

--- a/internal/sessionledger/ledger.go
+++ b/internal/sessionledger/ledger.go
@@ -129,8 +129,28 @@ func retireLegacy(dir string) {
 	if _, err := os.Stat(old); err != nil {
 		return
 	}
-	_ = os.Rename(old, old+".legacy")
+	_ = os.Rename(old, freeLegacyName(old+".legacy"))
 	_ = os.Remove(filepath.Join(dir, legacyName+".tmp"))
+}
+
+// freeLegacyName returns a destination that does not already exist. Retirement
+// happens more than once in practice: while a mixed fleet is rolling, an older
+// build keeps recreating ledger.json and each new process retires it again. A
+// bare os.Rename OVERWRITES its destination on POSIX, which would silently
+// destroy the previously retired file -- the one case this whole path exists to
+// prevent. Falls back to the plain name only after an absurd number of tries,
+// which cannot happen without something else being badly wrong.
+func freeLegacyName(base string) string {
+	if _, err := os.Stat(base); errors.Is(err, os.ErrNotExist) {
+		return base
+	}
+	for i := 1; i < 10000; i++ {
+		candidate := fmt.Sprintf("%s.%d", base, i)
+		if _, err := os.Stat(candidate); errors.Is(err, os.ErrNotExist) {
+			return candidate
+		}
+	}
+	return base
 }
 
 // applyRecord folds one decoded line into state. Caller holds the lock (or is

--- a/internal/sessionledger/ledger.go
+++ b/internal/sessionledger/ledger.go
@@ -30,6 +30,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -157,9 +158,23 @@ func (l *Ledger) putNode(e Entry) {
 	}
 }
 
+// underTest reports whether this is a `go test` binary. Only the test harness
+// registers test.v on the default flag set, and it does so before any test runs.
+// Checked via flag rather than importing testing, which would add test flags to
+// the production CLI.
+func underTest() bool { return flag.Lookup("test.v") != nil }
+
 func DefaultDir() string {
 	if d := os.Getenv("FAK_SESSION_LEDGER_DIR"); d != "" {
 		return d
+	}
+	// A test binary must never open the OPERATOR's ledger. No test in this repo
+	// sets FAK_SESSION_LEDGER_DIR, and the gateway suite reaches this seam through
+	// handleAnthropicMessages -- so `go test ./internal/gateway/` was appending to
+	// the real ledger under the user's config dir, and (with the legacy retirement
+	// below) renaming their live file aside. Isolate per test binary instead.
+	if underTest() {
+		return filepath.Join(os.TempDir(), fmt.Sprintf("fak-test-session-ledger-%d", os.Getpid()))
 	}
 	if d, err := os.UserConfigDir(); err == nil {
 		return filepath.Join(d, "fak", "session-ledger")

--- a/internal/sessionledger/ledger.go
+++ b/internal/sessionledger/ledger.go
@@ -1,6 +1,30 @@
+// Package sessionledger is the durable per-trace hash chain the gateway and the RSI
+// loop append to at every turn boundary.
+//
+// Storage is an APPEND-ONLY JSONL log (`ledger.jsonl`): one record per line, one
+// write per Append. It used to be a single `ledger.json` holding the whole state,
+// re-marshalled and rewritten on EVERY append -- O(n^2) in both allocation and disk
+// I/O. With the gateway persisting a full request body per turn that reached a
+// 389 MB file, and every append re-serialized it: ~800 MB of transient garbage per
+// turn per process, times one guard per live agent. Appending one bounded line
+// instead keeps a turn's cost proportional to the turn, not to all history.
+//
+// Three bounds keep the log from becoming the same problem again:
+//
+//   - MaxContentBytes elides an oversized content blob down to a provenance stub
+//     (byte count + sha256), so no single record can be large.
+//   - MaxFileBytes rotates the log to `.1` so on-disk stays bounded.
+//   - MaxNodes evicts oldest-first so in-memory stays bounded.
+//
+// Concurrency: several guards share one directory. Each Append is a single
+// open(O_APPEND)/write/close of one bounded line, so writers interleave by whole
+// records instead of clobbering each other's view the way the old whole-file
+// rename did. A torn or malformed line is SKIPPED on read rather than failing the
+// load -- a partial write must not make the whole ledger unreadable.
 package sessionledger
 
 import (
+	"bufio"
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
@@ -12,6 +36,20 @@ import (
 	"sync"
 )
 
+// Bounds. Exported so a caller (and the tests) can reason about them.
+const (
+	// MaxContentBytes is the largest content blob a single entry may retain
+	// verbatim. Anything larger is replaced by an elision stub. A turn's request
+	// body is the motivating case: it is provenance, not payload we need to keep.
+	MaxContentBytes = 8 << 10 // 8 KiB
+
+	// MaxFileBytes is the on-disk ceiling before the log rotates to `.1`.
+	MaxFileBytes = 32 << 20 // 32 MiB
+
+	// MaxNodes is the in-memory entry ceiling; oldest are evicted first.
+	MaxNodes = 50_000
+)
+
 type Hash string
 
 type Entry struct {
@@ -21,9 +59,14 @@ type Entry struct {
 	Content json.RawMessage `json:"content,omitempty"`
 }
 
-type diskState struct {
-	Heads map[string]Hash `json:"heads"`
-	Nodes map[Hash]Entry  `json:"nodes"`
+// record is one JSONL line. Kind == "" marks a head-only move (a Fork), which
+// carries no new node.
+type record struct {
+	Trace   string          `json:"trace"`
+	Hash    Hash            `json:"hash"`
+	Parent  Hash            `json:"parent,omitempty"`
+	Kind    string          `json:"kind,omitempty"`
+	Content json.RawMessage `json:"content,omitempty"`
 }
 
 type Ledger struct {
@@ -31,28 +74,87 @@ type Ledger struct {
 	path  string
 	heads map[string]Hash
 	nodes map[Hash]Entry
+	order []Hash // insertion order, for oldest-first eviction
 }
 
+// LogName is the append-only log's filename within a ledger directory.
+const LogName = "ledger.jsonl"
+
+// legacyName is the pre-JSONL whole-state file. It is set aside on open, never
+// loaded: by the time this shipped the live one was 389 MB, and loading it would
+// reproduce the very blowup this package now avoids.
+const legacyName = "ledger.json"
+
 func Open(dir string) (*Ledger, error) {
-	l := &Ledger{path: filepath.Join(dir, "ledger.json"), heads: map[string]Hash{}, nodes: map[Hash]Entry{}}
-	b, err := os.ReadFile(l.path)
+	l := &Ledger{
+		path:  filepath.Join(dir, LogName),
+		heads: map[string]Hash{},
+		nodes: map[Hash]Entry{},
+	}
+	retireLegacy(dir)
+	f, err := os.Open(l.path)
 	if errors.Is(err, os.ErrNotExist) {
 		return l, nil
 	}
 	if err != nil {
 		return nil, err
 	}
-	var d diskState
-	if err = json.Unmarshal(b, &d); err != nil {
-		return nil, err
+	defer f.Close()
+
+	sc := bufio.NewScanner(f)
+	// A record is bounded by MaxContentBytes plus framing; give the scanner room
+	// for that plus slack, and skip any line longer rather than erroring.
+	sc.Buffer(make([]byte, 0, 64<<10), MaxContentBytes+(64<<10))
+	for sc.Scan() {
+		line := bytes.TrimSpace(sc.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var r record
+		if json.Unmarshal(line, &r) != nil {
+			continue // torn or malformed line: skip, keep the rest of the log
+		}
+		l.applyRecord(r)
 	}
-	if d.Heads != nil {
-		l.heads = d.Heads
-	}
-	if d.Nodes != nil {
-		l.nodes = d.Nodes
-	}
+	// A scanner error (an over-long line) leaves what we already read intact.
 	return l, nil
+}
+
+// retireLegacy renames a pre-JSONL ledger.json aside exactly once, so a fresh
+// process neither loads it nor trips over it. Best effort: a failure here must
+// not stop the ledger from opening.
+func retireLegacy(dir string) {
+	old := filepath.Join(dir, legacyName)
+	if _, err := os.Stat(old); err != nil {
+		return
+	}
+	_ = os.Rename(old, old+".legacy")
+	_ = os.Remove(filepath.Join(dir, legacyName+".tmp"))
+}
+
+// applyRecord folds one decoded line into state. Caller holds the lock (or is
+// still constructing the ledger).
+func (l *Ledger) applyRecord(r record) {
+	if r.Kind != "" && r.Hash != "" {
+		l.putNode(Entry{Hash: r.Hash, Parent: r.Parent, Kind: r.Kind, Content: r.Content})
+	}
+	if r.Trace != "" && r.Hash != "" {
+		l.heads[r.Trace] = r.Hash
+	}
+}
+
+// putNode inserts an entry and enforces MaxNodes, evicting oldest-first.
+func (l *Ledger) putNode(e Entry) {
+	if _, dup := l.nodes[e.Hash]; dup {
+		return
+	}
+	l.nodes[e.Hash] = e
+	l.order = append(l.order, e.Hash)
+	for len(l.order) > MaxNodes {
+		oldest := l.order[0]
+		l.order = l.order[1:]
+		delete(l.nodes, oldest)
+	}
 }
 
 func DefaultDir() string {
@@ -88,6 +190,23 @@ func digest(parent Hash, kind string, content []byte) Hash {
 	return Hash(hex.EncodeToString(h.Sum(nil)))
 }
 
+// Elide replaces an oversized JSON blob with a bounded provenance stub: how many
+// bytes it was and the sha256 of those bytes. The chain still witnesses that the
+// content existed and what it hashed to; it just stops carrying the payload.
+func Elide(content []byte) json.RawMessage {
+	sum := sha256.Sum256(content)
+	stub := struct {
+		Elided bool   `json:"elided"`
+		Bytes  int    `json:"bytes"`
+		SHA256 string `json:"sha256"`
+	}{true, len(content), hex.EncodeToString(sum[:])}
+	b, err := json.Marshal(stub)
+	if err != nil { // unreachable for this struct
+		return json.RawMessage(`{"elided":true}`)
+	}
+	return json.RawMessage(b)
+}
+
 func (l *Ledger) Append(trace, kind string, content []byte) (Entry, error) {
 	if trace == "" || kind == "" {
 		return Entry{}, errors.New("sessionledger: trace and kind are required")
@@ -95,15 +214,21 @@ func (l *Ledger) Append(trace, kind string, content []byte) (Entry, error) {
 	if len(content) > 0 && !json.Valid(content) {
 		return Entry{}, errors.New("sessionledger: content must be JSON")
 	}
+	c := bytes.Clone(content)
+	if len(c) > MaxContentBytes {
+		c = Elide(content)
+	}
+
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	parent := l.heads[trace]
-	c := bytes.Clone(content)
 	e := Entry{Parent: parent, Kind: kind, Content: c}
 	e.Hash = digest(parent, kind, c)
-	l.nodes[e.Hash] = e
+	l.putNode(e)
 	l.heads[trace] = e.Hash
-	return e, l.saveLocked()
+	return e, l.appendRecord(record{
+		Trace: trace, Hash: e.Hash, Parent: e.Parent, Kind: e.Kind, Content: e.Content,
+	})
 }
 
 // Fork creates a new trace head that points at the same immutable node as source.
@@ -119,10 +244,18 @@ func (l *Ledger) Fork(source, target string) (Hash, error) {
 		return "", fmt.Errorf("sessionledger: source trace %q not found", source)
 	}
 	l.heads[target] = h
-	return h, l.saveLocked()
+	// Kind "" ⇒ head-only move, no new node.
+	return h, l.appendRecord(record{Trace: target, Hash: h})
 }
+
 func (l *Ledger) Head(trace string) Hash { l.mu.RLock(); defer l.mu.RUnlock(); return l.heads[trace] }
 func (l *Ledger) NodeCount() int         { l.mu.RLock(); defer l.mu.RUnlock(); return len(l.nodes) }
+
+// Chain walks trace's head back to its root, oldest-first. If an ancestor has been
+// evicted by the MaxNodes bound the walk STOPS there and returns the surviving
+// suffix rather than failing -- a bounded ledger legitimately forgets its oldest
+// entries, and a truncated-but-true history beats an error. Verify still rejects
+// such a suffix as unrooted, which is the honest answer for it.
 func (l *Ledger) Chain(trace string) ([]Entry, error) {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
@@ -134,7 +267,10 @@ func (l *Ledger) Chain(trace string) ([]Entry, error) {
 	for h != "" {
 		e, ok := l.nodes[h]
 		if !ok {
-			return nil, fmt.Errorf("sessionledger: missing node %s", h)
+			if len(rev) == 0 {
+				return nil, fmt.Errorf("sessionledger: missing node %s", h)
+			}
+			break // evicted ancestor: return the suffix we still hold
 		}
 		rev = append(rev, e)
 		h = e.Parent
@@ -145,6 +281,7 @@ func (l *Ledger) Chain(trace string) ([]Entry, error) {
 	}
 	return out, nil
 }
+
 func Verify(entries []Entry) error {
 	var parent Hash
 	for i, e := range entries {
@@ -158,20 +295,45 @@ func Verify(entries []Entry) error {
 	}
 	return nil
 }
-func (l *Ledger) saveLocked() error {
+
+// appendRecord writes ONE line. Caller holds the write lock. Opening per append
+// costs a syscall we can afford (a few per turn) and buys multi-process safety:
+// each writer appends whole records to whatever inode currently holds the name,
+// so a rotation by a sibling process cannot strand this one's writes in a file
+// nobody reads.
+func (l *Ledger) appendRecord(r record) error {
 	if l.path == "" {
-		return nil
+		return nil // Memory()
 	}
 	if err := os.MkdirAll(filepath.Dir(l.path), 0700); err != nil {
 		return err
 	}
-	b, err := json.Marshal(diskState{Heads: l.heads, Nodes: l.nodes})
+	line, err := json.Marshal(r)
 	if err != nil {
 		return err
 	}
-	tmp := l.path + ".tmp"
-	if err = os.WriteFile(tmp, b, 0600); err != nil {
+	line = append(line, '\n')
+
+	l.rotateIfLarge(len(line))
+
+	f, err := os.OpenFile(l.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
 		return err
 	}
-	return os.Rename(tmp, l.path)
+	if _, err = f.Write(line); err != nil {
+		f.Close()
+		return err
+	}
+	return f.Close()
+}
+
+// rotateIfLarge renames the log to `.1` once it would exceed MaxFileBytes, so the
+// directory holds at most two generations. Best effort: if the rename loses a race
+// with a sibling process the next append simply lands in the fresh file.
+func (l *Ledger) rotateIfLarge(incoming int) {
+	st, err := os.Stat(l.path)
+	if err != nil || st.Size()+int64(incoming) <= MaxFileBytes {
+		return
+	}
+	_ = os.Rename(l.path, l.path+".1")
 }


### PR DESCRIPTION
## Problem

`sessionledger.Append` re-marshalled the **entire** ledger state and rewrote the whole
file on **every** append:

```go
func (l *Ledger) Append(...) (Entry, error) {
    ...
    return e, l.saveLocked()          // ← every append
}
func (l *Ledger) saveLocked() error {
    b, err := json.Marshal(diskState{Heads: l.heads, Nodes: l.nodes})  // ← ALL nodes
    os.WriteFile(tmp, b, 0600)                                          // ← whole file
    return os.Rename(tmp, l.path)
}
```

That is O(n²) in allocation and disk I/O for n appends. The gateway made it expensive
rather than merely quadratic by persisting a full request body per turn:

```go
appendSessionLedger(reqTrace, "user_message", req.Raw)   // messages.go
```

`req.Raw` is the whole conversation context, re-sent every turn. There was no cap, no
eviction, and no rotation anywhere in the package.

## Measured impact

Observed on a developer machine running several `fak guard` sessions concurrently:

| Signal | Value |
|---|---|
| `ledger.json` | **389 MB**, 6,336 nodes, one chain 1,880 turns long |
| Per-turn body stored | ~195 KB mean, 827 KB max |
| `total_alloc_bytes`, one guard, 41 min | **1.19 TB** (~484 MB/s sustained) |
| `heap_objects` at 1.86 GB live | 95,171 — i.e. a few enormous buffers |
| Guard RSS | 40 MB idle, sawtoothing to **6.6 GB** peak |

Because the session id is durable per (host, cwd, command), a chain is not reset by
relaunching — it accumulates indefinitely, so the quadratic term has no natural bound.

A/B of the two persistence schemes, same workload (400 appends of a 195 KB body):

| | allocated | file | GCs |
|---|---|---|---|
| whole-state re-marshal | **31,454 MB** | 76.2 MB | 241 |
| append one line | **0.3 MB** | 0.1 MB | 0 |

## Fix

1. **Append-only JSONL.** One line per record; `Open` folds the log back into
   heads/nodes. A malformed or torn line is skipped rather than failing the load,
   since an append-only log trades the old atomic rename for partial-write risk.
2. **Bounded content.** `MaxContentBytes` (8 KiB) elides an oversized blob to a
   provenance stub (`{"elided":true,"bytes":N,"sha256":"…"}`). The chain still
   witnesses that the content existed and what it hashed to.
3. **Bounded on disk and in memory.** `MaxFileBytes` (32 MiB) rotates to `.1`;
   `MaxNodes` (50k) evicts oldest-first. `Chain` returns the surviving suffix instead
   of erroring when an ancestor has been evicted.
4. **Stop persisting the request body.** The gateway seam now records the turn's
   *shape* — model, message/tool counts, stream flag, byte count, sha256 — instead of
   its bytes.
5. **Retire the legacy file.** A pre-JSONL `ledger.json` is renamed aside, not loaded:
   loading a 389 MB whole-state file would reproduce the blowup on first open. The
   data is preserved as `ledger.json.legacy` for forensics.

## What this keeps

This is a duplication fix, not a data-retention change. Preserved: the per-trace hash
chain and `Verify`, every entry `Kind` (so `rsiloop.DeriveCadence` is unaffected),
per-turn provenance, and `fak session log`. Dropped: the verbatim conversation body,
which was pure duplication — consecutive turns of one session measured **99.5%
byte-identical prefix**, because each turn re-stored the whole conversation.

No consumer read that content: `DeriveCadence` switches on `Kind` only, and
`session_log` printed it. (`session_admit.go`'s `seed[0].Content` is an
`agent.Message`, not a ledger entry.)

## Self-monitoring

Raw `MemStats` were already published on `/debug/vars` and still did not surface this:
`Alloc` looks unremarkable between collections, and `heap_objects` stays *low* exactly
when the problem is a few huge buffers. Three derived fields are added, which do:

- `alloc_bytes_per_sec` — cumulative allocation rate; the tell that a per-turn cost has
  gone superlinear.
- `peak_heap_sys_bytes` / `peak_alloc_bytes` — high-water marks. Sawtooth RSS means an
  instantaneous sample almost never catches the crest.

## Proof

- `TestAppendCostIsLinearNotQuadratic` — 300 appends must stay within a linear file
  budget (linear ~300 KB vs quadratic ~45 MB). Fails before, passes after.
- Plus: elision keeps provenance and verifies; reopen rebuilds heads/chain; a torn line
  is skipped; rotation bounds the file; the legacy file is retired not loaded; eviction
  leaves `Chain` usable.
- Dogfooded on a real `fak guard -- claude` turn: a 61,207-byte request produced a
  691-byte ledger for the whole turn (3 records), against 61 KB plus a whole-file
  re-marshal before.

## Gate status

- `go build ./...`, `go vet`, `go test ./internal/sessionledger/ ./internal/rsiloop/
  ./internal/gateway/` — all green on this branch.
- `fak ci-preflight` reports the same 8 pre-existing `gofmt-check` files on this branch
  as it does on pristine `origin/main` (`476240c9`), so this change adds no new gate
  failure. The one file of mine it flagged (`internal/gateway/debug.go`) is fixed.
- Three `cmd/fak` tests fail identically before and after this change
  (`TestSessionAuditHereScopesToCurrentWorkspaceNamespace`,
  `TestSessionAuditAliasDefaultsToHereSummary`,
  `TestRunVCacheStatusIncludesRecentSessionSummary`) — they are `sessionaudit`
  transcript-discovery tests that find 0 sessions in this environment, unrelated to
  `sessionledger`.

## Migration note for operators

On first run after this lands, an existing `ledger.json` is renamed to
`ledger.json.legacy` and a fresh `ledger.jsonl` starts. Cadence counters derived from
that chain restart from zero. The old file is not deleted.

---

## Second commit: tests were writing to the operator's real ledger

Found while dogfooding this change, and it predates it. No test in the repo sets
`FAK_SESSION_LEDGER_DIR`, and the gateway suite reaches `OpenDefault` through
`handleAnthropicMessages` → `appendSessionLedger`. So `go test ./internal/gateway/`
opened the **real** ledger under the user's config dir and appended test turns to it.

That was already true before this PR — invisible, because the old code only ever
appended. With legacy retirement added it became conspicuous: running the suite renamed
a live 427 MB `ledger.json` aside to `ledger.json.legacy`. Nothing was lost (retirement
renames, it does not delete), but a test run must not touch operator state at all.

`DefaultDir` now resolves to an isolated per-test-binary temp dir when the process is a
test binary — detected by looking up the `test.v` flag rather than importing `testing`,
which would add test flags to the production CLI. An explicit `FAK_SESSION_LEDGER_DIR`
still wins.

Witnessed: a full `go test ./internal/gateway/` now leaves the operator's
`ledger.jsonl` byte- and mtime-identical.
