### PR TITLE
fix(gateway): retry an in-band Anthropic error frame instead of dying on an opaque 502

### DIFF
--- a/internal/agent/anthropic_inband.go
+++ b/internal/agent/anthropic_inband.go
@@ -1,0 +1,126 @@
+package agent
+
+// anthropic_inband.go classifies the OTHER way an Anthropic upstream refuses a streamed
+// turn, and the one the retry loop in anthropic_stream.go structurally could not see:
+// the upstream answers HTTP 200 + text/event-stream and THEN refuses IN-BAND with an SSE
+// `error` frame instead of a message_start.
+//
+// The retry loop decides on r.StatusCode, so a 200 escapes it entirely — the refusal
+// arrives later, inside the SSE reader, as an onEvent verdict. An in-band
+// `overloaded_error` is exactly as transient as the HTTP 529 the status path already
+// retries, so before this classification existed the flagship `fak guard -- claude`
+// stream died on the FIRST in-band refusal: one upstream hit, no retry, no buffered
+// fallback, and an opaque 502 whose `server_error` type had lost the upstream's own
+// retryable signal. UpstreamInBandError is how the SSE reader hands that verdict back to
+// the retry loop so the re-send happens where it is still invisible to the client.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// UpstreamInBandError is an Anthropic SSE `error` frame that arrived on an otherwise-200
+// stream BEFORE anything was relayed to the client. Status is the HTTP status the frame's
+// error type corresponds to (anthropicInBandStatus), which is what makes the frame
+// comparable to a non-200: the ordinary retryableStatus policy then decides it, so an
+// in-band overload and an HTTP 529 get the same backoff, and an in-band request error and
+// an HTTP 400 both surface immediately.
+//
+// It is deliberately NOT an UpstreamStatusError: the distinction matters to the retry loop
+// (an in-band refusal was read from a 200 body, so the loop must re-send rather than
+// return), and StatusError() converts it at the boundary where a terminal answer is owed.
+type UpstreamInBandError struct {
+	// Type is the upstream's own error type verbatim ("overloaded_error",
+	// "api_error", …), or "" when the frame carried none.
+	Type string
+	// Message is the upstream's error text, for the OPERATOR LOG only — like
+	// UpstreamStatusError.Body it is not meant to cross the trust boundary verbatim
+	// to a possibly-unauthenticated downstream caller.
+	Message string
+	// Status is Type mapped onto the equivalent HTTP status, so one retry policy
+	// covers both the status path and this one.
+	Status int
+}
+
+// Error formats the frame as "planner: in-band HTTP <status> (<type>): <message>", keeping
+// it distinguishable in an operator log from the status path's "planner: HTTP <status>".
+func (e *UpstreamInBandError) Error() string {
+	t := e.Type
+	if t == "" {
+		t = "unlabeled"
+	}
+	return fmt.Sprintf("planner: in-band HTTP %d (%s): %s", e.Status, t, e.Message)
+}
+
+// Retryable reports whether re-sending can plausibly clear this in-band refusal, under the
+// SAME closed policy the status path uses (retryableStatus): an overload/throttle/transient
+// yes, a request error no.
+func (e *UpstreamInBandError) Retryable() bool { return retryableStatus(e.Status) }
+
+// StatusError converts the frame into the UpstreamStatusError the rest of the stack already
+// knows how to surface — so an exhausted in-band overload reaches the client as the honest
+// 529 + overloaded_error rather than the opaque 502 + server_error it used to be flattened
+// into. RetryAfter is empty by construction: an in-band frame carries no response header.
+func (e *UpstreamInBandError) StatusError() *UpstreamStatusError {
+	return &UpstreamStatusError{Status: e.Status, Body: truncate([]byte(e.Message), 400)}
+}
+
+// anthropicInBandStatus maps an Anthropic error `type` onto the HTTP status the same
+// condition would carry had the upstream refused before the stream opened, so the single
+// retryableStatus policy covers both paths.
+//
+// An UNRECOGNIZED type maps to 500 — i.e. RETRYABLE. That direction is deliberate and
+// matches the 403 arm's reasoning in retry.go: an in-band refusal arrives on a request the
+// upstream already ACCEPTED (a malformed request is rejected with a real 4xx before the
+// stream ever opens), so an unlabeled in-band failure is far more likely a capacity flap
+// than a permanent error, and the bounded attempt/time budget still ends the turn promptly
+// if it is not.
+func anthropicInBandStatus(errType string) int {
+	switch strings.ToLower(strings.TrimSpace(errType)) {
+	case "invalid_request_error":
+		return http.StatusBadRequest // 400
+	case "authentication_error":
+		return http.StatusUnauthorized // 401
+	case "billing_error":
+		return http.StatusPaymentRequired // 402
+	case "permission_error":
+		return http.StatusForbidden // 403
+	case "not_found_error":
+		return http.StatusNotFound // 404
+	case "request_too_large":
+		return http.StatusRequestEntityTooLarge // 413
+	case "timeout_error":
+		return http.StatusRequestTimeout // 408, retryable
+	case "rate_limit_error":
+		return http.StatusTooManyRequests // 429, retryable
+	case "overloaded_error":
+		return statusOverloaded // 529, retryable
+	case "api_error":
+		return http.StatusInternalServerError // 500, retryable
+	}
+	return http.StatusInternalServerError // unlabeled: treat as a transient the loop may clear
+}
+
+// NewAnthropicInBandError parses an Anthropic SSE `error` frame's raw `data:` payload into
+// the typed verdict a StreamAnthropicRaw onEvent callback returns when the frame arrived
+// before anything was relayed to the client. The frame shape is
+// {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}; a payload
+// that does not parse (or carries no inner type) still yields a non-nil error with the
+// unlabeled 500 mapping, so a malformed frame is retried-then-surfaced rather than silently
+// treated as a served turn.
+func NewAnthropicInBandError(data []byte) *UpstreamInBandError {
+	var frame struct {
+		Error struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	_ = json.Unmarshal(data, &frame) // a malformed frame keeps the zero values (unlabeled)
+	return &UpstreamInBandError{
+		Type:    frame.Error.Type,
+		Message: frame.Error.Message,
+		Status:  anthropicInBandStatus(frame.Error.Type),
+	}
+}

--- a/internal/agent/anthropic_inband_test.go
+++ b/internal/agent/anthropic_inband_test.go
@@ -1,0 +1,97 @@
+package agent
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+)
+
+// TestAnthropicInBandStatusMapping pins the in-band error `type` -> HTTP status table, and
+// with it the retry verdict each type inherits from retryableStatus. The table IS the
+// policy: get a status wrong and either a transient overload stops being retried (the bug
+// this classification exists to fix) or a permanent request error burns the whole attempt
+// budget against the upstream.
+func TestAnthropicInBandStatusMapping(t *testing.T) {
+	for _, tc := range []struct {
+		errType   string
+		want      int
+		retryable bool
+	}{
+		{"overloaded_error", 529, true},
+		{"api_error", http.StatusInternalServerError, true},
+		{"rate_limit_error", http.StatusTooManyRequests, true},
+		{"timeout_error", http.StatusRequestTimeout, true},
+		{"invalid_request_error", http.StatusBadRequest, false},
+		{"authentication_error", http.StatusUnauthorized, false},
+		{"billing_error", http.StatusPaymentRequired, false},
+		{"permission_error", http.StatusForbidden, false},
+		{"not_found_error", http.StatusNotFound, false},
+		{"request_too_large", http.StatusRequestEntityTooLarge, false},
+		// Case/whitespace robustness: the mapping must not depend on the provider's casing.
+		{"  OVERLOADED_ERROR ", 529, true},
+		// An UNLABELED frame is deliberately retryable — an in-band refusal rides a request
+		// the upstream already accepted, so a capacity flap is likelier than a hard error.
+		{"", http.StatusInternalServerError, true},
+		{"something_new_from_the_provider", http.StatusInternalServerError, true},
+	} {
+		got := anthropicInBandStatus(tc.errType)
+		if got != tc.want {
+			t.Errorf("anthropicInBandStatus(%q) = %d, want %d", tc.errType, got, tc.want)
+		}
+		e := &UpstreamInBandError{Type: tc.errType, Status: got}
+		if e.Retryable() != tc.retryable {
+			t.Errorf("%q (HTTP %d): Retryable() = %v, want %v", tc.errType, got, e.Retryable(), tc.retryable)
+		}
+	}
+}
+
+// TestNewAnthropicInBandErrorParsesFrame checks the wire shape is read from the real
+// Anthropic frame, and that a frame fak cannot parse still yields a retryable verdict
+// rather than being mistaken for a served turn.
+func TestNewAnthropicInBandErrorParsesFrame(t *testing.T) {
+	e := NewAnthropicInBandError([]byte(`{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`))
+	if e.Type != "overloaded_error" || e.Message != "Overloaded" || e.Status != 529 {
+		t.Fatalf("parsed = %+v, want {overloaded_error Overloaded 529}", e)
+	}
+	if !e.Retryable() {
+		t.Error("an overloaded_error frame must be retryable")
+	}
+
+	// Garbage in, still a usable (and retryable) verdict out.
+	for _, raw := range []string{`not json at all`, `{}`, `{"error":{}}`, ``} {
+		g := NewAnthropicInBandError([]byte(raw))
+		if g == nil {
+			t.Fatalf("NewAnthropicInBandError(%q) = nil, want a non-nil unlabeled verdict", raw)
+		}
+		if g.Status != http.StatusInternalServerError || !g.Retryable() {
+			t.Errorf("NewAnthropicInBandError(%q) = %+v, want an unlabeled retryable 500", raw, g)
+		}
+	}
+}
+
+// TestUpstreamInBandErrorStatusErrorSurfaces pins the conversion the gateway relies on: an
+// exhausted in-band overload must reach the client as the honest 529 (which
+// upstreamErrorStatus renders as overloaded_error), and must be reachable via errors.As
+// through the wrapping rs.exhausted applies.
+func TestUpstreamInBandErrorStatusErrorSurfaces(t *testing.T) {
+	ib := NewAnthropicInBandError([]byte(`{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`))
+	se := ib.StatusError()
+	if se.Status != 529 {
+		t.Fatalf("StatusError().Status = %d, want 529", se.Status)
+	}
+	if se.RetryAfter != "" {
+		t.Errorf("StatusError().RetryAfter = %q, want empty — an in-band frame carries no response header", se.RetryAfter)
+	}
+
+	// The retry loop records an in-band retryable through the SAME keepsake as a non-200,
+	// so exhaustion surfaces a *UpstreamStatusError the gateway can find.
+	var rs retryState
+	rs.noteRetryableStatus(ib.Status, []byte(ib.Message), http.Header{}, 400)
+	var found *UpstreamStatusError
+	if !errors.As(rs.exhausted("planner: streaming failed after retries"), &found) {
+		t.Fatal("exhausted() did not carry an *UpstreamStatusError")
+	}
+	if found.Status != 529 {
+		t.Errorf("exhausted status = %d, want 529", found.Status)
+	}
+}

--- a/internal/agent/anthropic_stream.go
+++ b/internal/agent/anthropic_stream.go
@@ -47,7 +47,18 @@ type AnthropicSSEEvent struct {
 // 408/5xx transient) is RETRIED here with backoff+jitter+Retry-After — BEFORE any onEvent
 // call, where the retry is invisible to the client — exactly as Complete/CompleteStream
 // do, so a real Anthropic 429/529 window no longer collapses the flagship stream to the
-// slower buffered fallback on the first hit. A connection or non-retryable status failure
+// slower buffered fallback on the first hit.
+//
+// An IN-BAND refusal is retried on the same budget (#5491). An overloaded Anthropic may
+// answer 200 + text/event-stream and then send an SSE `error` frame instead of a
+// message_start; because the loop's own decision is made on the HTTP status, that refusal
+// is only visible to the CALLER's onEvent, which reports it back by returning an
+// *UpstreamInBandError. A retryable one (overloaded_error and friends — see
+// anthropic_inband.go) re-sends here, still invisibly; a request error surfaces at once with
+// the upstream's real status. onEvent MUST only return that type while nothing has been
+// relayed to the client, since a re-send is what it asks for.
+//
+// A connection or non-retryable status failure
 // (or a retryable one that survived every attempt) surfaces BEFORE any onEvent call, so the
 // caller can still fall back to the buffered path having sent the client nothing AND
 // without a second generation having been billed (a non-200 produced no tokens). Once
@@ -116,7 +127,9 @@ func (p *HTTPPlanner) StreamAnthropicRaw(ctx context.Context, rawBody []byte, ap
 	accountFailoverPending := false
 	maxAttempts, deadline, budgetOn := retryBounds(time.Now())
 	var rs retryState // shared between-attempt truth (#1358, #1362) — see retry_state.go
-	var resp *http.Response
+	// served is set once an attempt produced a genuinely relayed turn, so the loop can tell
+	// "the budget ran out" apart from "we are done" without a nil-response sentinel.
+	served := false
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		if attempt > 0 {
 			// Surface the retry BEFORE the otherwise-invisible backoff sleep (the same hook the
@@ -159,7 +172,32 @@ func (p *HTTPPlanner) StreamAnthropicRaw(ctx context.Context, rawBody []byte, ap
 				notifyAccountFailover(p, AccountFailoverRecovered, attempt)
 				accountFailoverPending = false
 			}
-			resp = r
+			// A 200 is not yet a SERVED turn. An overloaded Anthropic also refuses IN-BAND:
+			// 200 + text/event-stream, then an SSE `error` frame instead of a message_start.
+			// That refusal is invisible to the status check above, so relayAnthropicStream
+			// reports it back as an *UpstreamInBandError (the caller's onEvent verdict that
+			// nothing has reached the client yet) and a retryable one re-sends HERE — the only
+			// place the re-send is still invisible. Without this the flagship
+			// `fak guard -- claude` stream died on the first in-band overload: one upstream hit,
+			// no retry, no fallback (#5491).
+			serr := relayAnthropicStream(r, onEvent)
+			var ib *UpstreamInBandError
+			if errors.As(serr, &ib) {
+				if ib.Retryable() {
+					// Recorded exactly like a retryable non-200 so the shared backoff, the
+					// #1358 keepsake, and the exhaustion message all behave identically. An
+					// in-band frame carries no response header, hence the empty Header.
+					rs.noteRetryableStatus(ib.Status, []byte(ib.Message), http.Header{}, 400)
+					continue
+				}
+				// A request error no retry can fix: surface the honest status now, converted
+				// to the shape the gateway already knows how to render.
+				return ib.StatusError()
+			}
+			if serr != nil {
+				return serr
+			}
+			served = true
 			break
 		}
 		raw, _ := io.ReadAll(io.LimitReader(r.Body, 4096))
@@ -229,15 +267,25 @@ func (p *HTTPPlanner) StreamAnthropicRaw(ctx context.Context, rawBody []byte, ap
 		}
 		return &UpstreamStatusError{Status: r.StatusCode, Body: truncate(raw, 400), RetryAfter: r.Header.Get("Retry-After")}
 	}
-	if resp == nil {
+	if !served {
 		return rs.exhausted("planner: streaming failed after retries")
 	}
+	return nil
+}
+
+// relayAnthropicStream frames one 200 upstream response as Anthropic SSE and pumps it into
+// onEvent, owning the body. Split out of StreamAnthropicRaw so the read happens INSIDE the
+// retry loop: an in-band `error` frame that arrives before anything is relayed to the client
+// is a retryable attempt outcome, not a terminal one, and only a per-attempt read can hand it
+// back to the loop (#5491). Any error onEvent returns propagates unchanged — including the
+// *UpstreamInBandError the loop keys its re-send on.
+func relayAnthropicStream(resp *http.Response, onEvent func(AnthropicSSEEvent) error) error {
 	defer resp.Body.Close()
 	// The gateway only takes this path against the real Anthropic API, but guard anyway:
 	// an upstream that ignores stream and replies with one buffered JSON body cannot be
 	// framed as SSE, so surface that as unsupported BEFORE any event (the caller falls
 	// back to the buffered path) rather than emit a malformed stream.
-	if !upstreamStreamsSSE(resp) {
+	if ct := resp.Header.Get("Content-Type"); ct != "" && !strings.Contains(ct, "event-stream") {
 		return ErrStreamingUnsupported
 	}
 	// Wrap the body in an idle-read deadline so an upstream that opens the stream and then

--- a/internal/gateway/messages_stream_passthrough.go
+++ b/internal/gateway/messages_stream_passthrough.go
@@ -196,21 +196,6 @@ func (p *anthropicPassthrough) flushHeldTools() {
 	}
 }
 
-// relayBlockEvent forwards one upstream content-block event under the CLIENT-side index
-// this relay assigned to that upstream block, and reports that index. The renumbering is
-// the whole point: held tool_use blocks never reach the client, so upstream indices are
-// not contiguous downstream and an event replayed with its upstream index would address
-// the wrong block. An upstream index with no client index is a held block — nothing is
-// relayed and ok is false.
-func (p *anthropicPassthrough) relayBlockEvent(event string, data json.RawMessage, upstreamIdx int) (clientIdx int, ok bool) {
-	oi, ok := p.passIdx[upstreamIdx]
-	if !ok {
-		return 0, false
-	}
-	relayWithIndex(p.send, event, data, oi)
-	return oi, true
-}
-
 // onEvent is the per-SSE-event relay callback handed to StreamAnthropicRaw. It opens the
 // client stream on message_start (after arming the inbound result floor once), holds and
 // renumbers content blocks, batches held tool_use blocks at message_delta, and forwards
@@ -306,7 +291,8 @@ func (p *anthropicPassthrough) onEvent(ev agent.AnthropicSSEEvent) error {
 			ta.args.WriteString(d.Delta.PartialJSON) // accumulate off-wire
 			return nil
 		}
-		if _, ok := p.relayBlockEvent("content_block_delta", ev.Data, d.Index); ok {
+		if oi, ok := p.passIdx[d.Index]; ok {
+			relayWithIndex(p.send, "content_block_delta", ev.Data, oi)
 			// Accumulate relayed assistant TEXT off-wire so a mid-stream worker death can
 			// replay exactly what the client already saw as a prefill turn (#3353). Only
 			// text_delta is captured — thinking deltas are not prefill-replayable.
@@ -325,7 +311,8 @@ func (p *anthropicPassthrough) onEvent(ev agent.AnthropicSSEEvent) error {
 		if _, held := p.toolBuf[d.Index]; held {
 			return nil // emitted (or dropped) as a batch at message_delta
 		}
-		if oi, ok := p.relayBlockEvent("content_block_stop", ev.Data, d.Index); ok {
+		if oi, ok := p.passIdx[d.Index]; ok {
+			relayWithIndex(p.send, "content_block_stop", ev.Data, oi)
 			if p.openClientBlock == oi {
 				p.openClientBlock = -1 // block closed cleanly; nothing dangling to close on death
 			}
@@ -364,10 +351,16 @@ func (p *anthropicPassthrough) onEvent(ev agent.AnthropicSSEEvent) error {
 			p.send("error", ev.Data)
 			return nil
 		}
-		p.s.logf("gateway: upstream error before stream start (messages)")
-		writeErr(p.w, http.StatusBadGateway, "upstream model error")
-		p.wroteError = true
-		return errPassthroughResponded
+		// An `error` frame BEFORE message_start: the upstream accepted the request with a 200
+		// and then refused in-band — the overload path Anthropic takes instead of an HTTP 529.
+		// Nothing has been relayed to the client yet, so this is NOT terminal: hand the frame
+		// back to StreamAnthropicRaw's retry loop, which re-sends a retryable one invisibly and,
+		// once the budget is spent, surfaces the upstream's OWN status/type (a 529 →
+		// overloaded_error) instead of the opaque 502 + server_error this used to write here —
+		// which both dropped the retry and stripped the signal a client needs to back off
+		// correctly (#5491). Writing nothing is what keeps that retry invisible.
+		p.s.logf("gateway: upstream error frame before stream start (messages); returning to the retry loop")
+		return agent.NewAnthropicInBandError(ev.Data)
 	}
 	return nil
 }
@@ -452,7 +445,12 @@ func (s *Server) streamAnthropicPassthroughLive(w http.ResponseWriter, r *http.R
 			// open — handled by the return false below.
 			var statusErr *agent.UpstreamStatusError
 			if errors.As(err, &statusErr) {
-				s.surfaceUpstreamStatus(w, err, "upstream model error (messages passthrough; surfaced, not re-tried via buffered)")
+				status, code, msg := upstreamErrorStatus(err)
+				if ra := upstreamRetryAfter(err); ra != "" {
+					w.Header().Set("Retry-After", ra)
+				}
+				s.logf("gateway: upstream model error (messages passthrough; surfaced, not re-tried via buffered): %v", err)
+				writeErrCode(w, status, code, msg)
 				return true
 			}
 			s.logf("gateway: anthropic passthrough stream did not open (%v); falling back to buffered", err)

--- a/internal/gateway/messages_stream_passthrough_errorframe_test.go
+++ b/internal/gateway/messages_stream_passthrough_errorframe_test.go
@@ -1,0 +1,186 @@
+package gateway
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/anthony-chaudhary/fak/internal/abi"
+)
+
+// newErrorFrameServer builds a gateway fronting `upstream` on the Anthropic wire, the
+// same fixture shape the sibling rate-limit retry test uses.
+func newErrorFrameServer(t *testing.T, upstreamURL string) *httptest.Server {
+	t.Helper()
+	abi.ResetForTest()
+	abi.RegisterRegionBackend(inlineBackend{})
+	abi.RegisterEngine("test", echoEngine{})
+	abi.RegisterAdjudicator(0, toolAdj{})
+
+	srv, err := New(Config{EngineID: "test", Model: "claude-test", BaseURL: upstreamURL, Provider: "anthropic", APIKey: "k", VDSO: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(srv.Close)
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func postStreamingMessages(t *testing.T, ts *httptest.Server) *http.Response {
+	t.Helper()
+	inbound := []byte(`{"model":"claude-test","max_tokens":64,"stream":true,"messages":[{"role":"user","content":"hi"}]}`)
+	req, _ := http.NewRequest("POST", ts.URL+"/v1/messages", bytes.NewReader(inbound))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	t.Cleanup(func() { resp.Body.Close() })
+	return resp
+}
+
+// TestAnthropicMessagesPassthroughStreamHTTP502IsRetried is the control for the
+// error-frame test below: a real HTTP 502 IS in retryableStatus, so the streaming
+// passthrough must retry it to the pinned attempt budget before surfacing anything.
+// If this control ever goes red, the 502 complaint is about the STATUS path, not the
+// in-band error-frame path.
+func TestAnthropicMessagesPassthroughStreamHTTP502IsRetried(t *testing.T) {
+	t.Setenv("FAK_PLANNER_MAX_ATTEMPTS", "3")
+
+	var hits int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.Header().Set("Retry-After", "0") // honored as a zero wait => the test does not sleep
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer upstream.Close()
+
+	resp := postStreamingMessages(t, newErrorFrameServer(t, upstream.URL))
+	io.Copy(io.Discard, resp.Body)
+
+	if got := atomic.LoadInt32(&hits); got != 3 {
+		t.Fatalf("upstream hit %d times, want 3 (a real HTTP 502 is retryableStatus)", got)
+	}
+}
+
+// TestAnthropicMessagesPassthroughStreamErrorFrameBeforeStartIsRetried pins the OTHER
+// way an overloaded Anthropic upstream refuses a streamed turn: HTTP 200 +
+// text/event-stream, then an in-band SSE `error` frame as the FIRST event, before any
+// message_start. That is exactly as transient as the 529 the status path already
+// retries — but the retry loop in StreamAnthropicRaw decides purely on r.StatusCode, so
+// a 200 escapes it and the error frame reaches onEvent, which (pre-fix) flattened it
+// into a bare 502 and marked the response written. Net effect for a live
+// `fak guard -- claude` session: ONE upstream hit, no retry, no buffered fallback, and
+// an opaque 502 whose `server_error` type has lost the upstream's own overloaded_error
+// signal — the turn just dies.
+//
+// The decisive assertion is the upstream hit COUNT: a retried transient must be tried
+// more than once.
+func TestAnthropicMessagesPassthroughStreamErrorFrameBeforeStartIsRetried(t *testing.T) {
+	t.Setenv("FAK_PLANNER_MAX_ATTEMPTS", "3")
+
+	var hits int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		// Anthropic's in-band overload refusal, as the very first frame.
+		io.WriteString(w, "event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\",\"message\":\"Overloaded\"}}\n\n")
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}))
+	defer upstream.Close()
+
+	resp := postStreamingMessages(t, newErrorFrameServer(t, upstream.URL))
+	body, _ := io.ReadAll(resp.Body)
+
+	if got := atomic.LoadInt32(&hits); got != 3 {
+		t.Errorf("upstream hit %d times, want 3 — an in-band overloaded_error frame before message_start is as transient as a 529 and must be retried, not surfaced on the first hit", got)
+	}
+
+	// And once the budget IS spent, the client must still be able to tell an overload
+	// apart from a generic server crash: the upstream's own error type survives.
+	var env struct {
+		Error struct {
+			Type string `json:"type"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("error envelope did not decode: %v (body %q)", err, body)
+	}
+	if env.Error.Type != "overloaded_error" {
+		t.Errorf("error type = %q, want overloaded_error (a flattened 502/server_error loses the upstream's retryable signal; status was %d, body %q)", env.Error.Type, resp.StatusCode, body)
+	}
+}
+
+// TestAnthropicMessagesPassthroughStreamInBandRequestErrorIsNotRetried is the other half of
+// the in-band classification: only the TRANSIENT family earns a re-send. An in-band
+// invalid_request_error is a request error no retry can fix, so it must be surfaced on the
+// FIRST hit — with the upstream's real 400, not a 502 and not an overload's backoff.
+// Without this the "retry an in-band error" fix would turn every malformed request into a
+// full attempt-budget burst against the upstream.
+func TestAnthropicMessagesPassthroughStreamInBandRequestErrorIsNotRetried(t *testing.T) {
+	t.Setenv("FAK_PLANNER_MAX_ATTEMPTS", "3")
+
+	var hits int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, "event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"bad\"}}\n\n")
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}))
+	defer upstream.Close()
+
+	resp := postStreamingMessages(t, newErrorFrameServer(t, upstream.URL))
+	body, _ := io.ReadAll(resp.Body)
+
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Errorf("upstream hit %d times, want 1 — an in-band invalid_request_error is not retryable", got)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("client status = %d, want 400 (the upstream's own status, body %q)", resp.StatusCode, body)
+	}
+}
+
+// TestAnthropicMessagesPassthroughStreamErrorFrameAfterStartStillRelays guards the
+// boundary the fix must NOT cross. Once message_start has been relayed the client owns a
+// live 200 SSE stream, so a later error frame cannot be retried (the status is already
+// sent) and must keep being forwarded verbatim as a terminal SSE error — the pre-existing
+// behavior. A fix that routed EVERY error frame back into the retry loop would silently
+// break mid-stream termination, so this test is the one that would catch it.
+func TestAnthropicMessagesPassthroughStreamErrorFrameAfterStartStillRelays(t *testing.T) {
+	var hits int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"m1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-test\",\"content\":[],\"stop_reason\":null,\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n")
+		io.WriteString(w, "event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\",\"message\":\"Overloaded\"}}\n\n")
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}))
+	defer upstream.Close()
+
+	resp := postStreamingMessages(t, newErrorFrameServer(t, upstream.URL))
+	body, _ := io.ReadAll(resp.Body)
+
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Errorf("upstream hit %d times, want 1 — a POST-message_start error frame cannot be retried, the client already owns the 200", got)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("client status = %d, want 200 (the stream had already opened)", resp.StatusCode)
+	}
+	if !bytes.Contains(body, []byte("overloaded_error")) {
+		t.Errorf("relayed stream lost the terminal error frame; body = %q", body)
+	}
+}


### PR DESCRIPTION
Fixes #5491.

## The defect

Anthropic refuses a streamed turn in two different ways, and the streaming passthrough only retried one of them.

A **status** refusal (`429`/`503`/`529`/`5xx`) is caught by `retryableStatus` and retried by `StreamAnthropicRaw` with backoff before any byte reaches the client. That works.

An **in-band** refusal does not. The upstream answers `200` + `text/event-stream` and then sends an SSE `error` frame as its first event:

```
event: error
data: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}
```

The retry loop decides on `r.StatusCode`, so a `200` breaks out of it; the refusal only surfaces later, inside the SSE reader, in the gateway's event callback — which wrote a hardcoded `502` and set `p.wroteError = true`. That single line cost three things at once: the retry (the loop was already exited), the buffered fallback (`p.wroteError` short-circuits it), and the upstream's own error type (`errType(502)` is `server_error`, so a client that would back off on `overloaded_error` had nothing to branch on).

Net effect on a live `fak guard -- claude` session: one upstream hit, no retry, and an opaque 502. Intermittent by nature, because which refusal shape a given overloaded moment takes is the upstream's choice.

## The fix

Make an in-band refusal a retryable *attempt outcome* rather than a terminal one, reusing the retry machinery that already exists instead of adding a second policy beside it.

- **`internal/agent/anthropic_inband.go` (new)** — `UpstreamInBandError` carries the frame's error type mapped onto the HTTP status the same condition would have carried had the upstream refused before the stream opened. That mapping is the whole point: retryability is then decided by the *existing* `retryableStatus`, so an in-band overload and an HTTP 529 cannot drift apart. An unrecognized type maps to a retryable 500 — deliberately, and for the reason the 403 arm already documents: an in-band refusal rides a request the upstream already accepted, so an unlabeled one is likelier a capacity flap than a hard error, and the bounded budget still ends the turn promptly if it is not.
- **`internal/agent/anthropic_stream.go`** — the SSE read moves *inside* the retry loop (extracted as `relayAnthropicStream`), which is what lets a pre-start in-band refusal be handed back to the loop at all. A retryable one is recorded through the same `rs.noteRetryableStatus` keepsake as a non-200, so the shared backoff, the last-real-status keepsake, and the exhaustion message all behave identically — and an exhausted in-band overload surfaces as the honest `529`, which `upstreamErrorStatus` already renders as `overloaded_error`.
- **`internal/gateway/messages_stream_passthrough.go`** — the pre-start `error` branch returns the typed error instead of writing a 502. Writing nothing is what keeps the retry invisible.

A frame arriving **after** `message_start` is untouched: the client already owns a live 200 stream, so it can only be forwarded as a terminal SSE error.

## Tests

`internal/gateway/messages_stream_passthrough_errorframe_test.go` — four cases, each keyed on the upstream **hit count**, which is what actually distinguishes "retried" from "died":

| case | before | after |
|---|---|---|
| real HTTP `502` (control) | 3 hits | 3 hits |
| in-band `overloaded_error` | **1 hit, `502`/`server_error`** | **3 hits, `529`/`overloaded_error`** |
| in-band `invalid_request_error` | 1 hit, `502` | 1 hit, `400` — not retried |
| `error` frame after `message_start` | relayed | relayed (unchanged) |

The control matters: it proves the retry machinery was healthy all along and only this entry path bypassed it. The `invalid_request_error` case is the guard against the obvious over-correction — retrying *every* in-band error would turn a malformed request into a full attempt-budget burst against the upstream. The post-`message_start` case is the guard against the other one.

`internal/agent/anthropic_inband_test.go` pins the type→status table (the policy surface), case/whitespace robustness, the unlabeled-is-retryable default, malformed-frame handling, and that an exhausted in-band error is reachable via `errors.As` as an `*UpstreamStatusError` through the wrapping `rs.exhausted` applies.

## Verification

```
go build ./...                                            # clean
go vet ./internal/agent/ ./internal/gateway/              # clean
go test ./internal/agent/ ./internal/gateway/ -timeout 30m
    ok  internal/agent    53.6s
    ok  internal/gateway  15.3s
```

Both touched packages pass in full, including the pre-existing
`TestAnthropicMessagesPassthroughStreamRateLimitedSurfacesNoBufferedDoubleHit`, which pins the
status-path behavior this change deliberately leaves alone.

## Not covered here

A refusal arriving **mid-stream**, after content has been relayed, still cannot be retried — the status is already sent. That is warm-continue's territory (`canWarmContinue`), which is gated off by default and out of scope for this fix.
