### PR TITLE
fix(guard): fold the reasoning posture into guard's one --settings so an inline copy stops discarding the hook stack (fak cmd)

### DIFF
--- a/cmd/fak/accounts_launch.go
+++ b/cmd/fak/accounts_launch.go
@@ -77,8 +77,8 @@ const (
 )
 
 // resolveUltracodePosture folds the --ultracode knob and the work class into the single boolean
-// buildLaunchArgv needs: whether to emit --settings '{"ultracode":true}'. This is the
-// posture→ultracode table (#5016) that replaced a blanket default-on bool:
+// buildLaunchArgv needs: whether this launch runs in ultracode. This is the posture→ultracode
+// table (#5016), re-keyed on ATTENDANCE:
 //
 //	posture  work kind  ultracode  why
 //	-------  ---------  ---------  -------------------------------------------------------
@@ -86,13 +86,21 @@ const (
 //	off      (any)      OFF        operator disabled it; an explicit posture always wins
 //	auto     rigor      ON         verified-before-relayed work earns the orchestration tax
 //	auto     grind      OFF        mechanical work never recovers the wall-clock cost
-//	auto     unknown    OFF        conservative: unclassifiable work probably needs no rigor
+//	auto     unknown    ON         a USER-INITIATED launch: a human is waiting on the answer
 //
-// `auto` is the default. The interactive launcher has no work class to hand in, so a bare
-// `fak accounts launch` resolves auto→unknown→OFF: lean and fast by default, with --ultracode=on
-// as the operator's explicit opt-in. `true`/`false` stay accepted as on/off aliases so a script
-// written against the old bool flag keeps working. An unrecognized posture is a loud error rather
-// than a silent default — the same fail-on-bad-mode discipline normalizeManagedCacheMode uses.
+// `auto` is the default, and the unknown row is the interactive launcher's own row — this
+// launcher has no work class to hand in because it is a human at a keyboard typing
+// `fak accounts launch`. That is exactly the case that SHOULD pay the orchestration tax: the
+// question is usually the hard one the operator could not answer themselves, and the
+// wall-clock is time they already agreed to spend by asking. The conservative-OFF this row
+// used to hold was reasoning about UNATTENDED work, and unattended work does not come through
+// here — it comes through the headless dispatch path, where `fak guard` resolves the same
+// attendance axis to xhigh instead (guard_effort.go). So: user-initiated ⇒ ultracode,
+// agent session ⇒ xhigh, one axis, decided at each of the two launch surfaces.
+//
+// `true`/`false` stay accepted as on/off aliases so a script written against the old bool flag
+// keeps working. An unrecognized posture is a loud error rather than a silent default — the
+// same fail-on-bad-mode discipline normalizeManagedCacheMode uses.
 func resolveUltracodePosture(posture string, kind ultracodeWorkKind) (bool, error) {
 	switch strings.ToLower(strings.TrimSpace(posture)) {
 	case "on", "true":
@@ -100,7 +108,7 @@ func resolveUltracodePosture(posture string, kind ultracodeWorkKind) (bool, erro
 	case "off", "false":
 		return false, nil
 	case "", "auto":
-		return kind == ultracodeKindRigor, nil
+		return kind != ultracodeKindGrind, nil
 	default:
 		return false, fmt.Errorf("invalid --ultracode %q: want auto|on|off", posture)
 	}
@@ -197,11 +205,17 @@ func buildLaunchArgv(fakBin string, o launchOpts) []string {
 			agentCmd = append(agentCmd, "--model", o.model)
 		}
 	}
-	// Ultracode (workflow mode) is Claude-only and session-only: emit --settings for a Claude
-	// launch so a fak launch defaults to the same workflow-on posture the `f` shortcut sets.
+	// Ultracode (workflow mode) is Claude-only and session-only. It rides an INLINE --settings
+	// only on an UNGUARDED launch. Under `fak guard` it must instead be relayed as the guard
+	// flag `--effort ultracode` (below), because Claude Code's --settings is LAST-WINS rather
+	// than merged: guard puts its own hook-settings FILE on the child argv, and an inline
+	// `--settings '{"ultracode":true}'` sitting later on that argv silently discards the whole
+	// file — the deny-all auto-continue Stop hook, the task-handoff gate, the toolproc journal,
+	// the SessionStart affordance and the PreCompact coherence gate all vanish. Relaying
+	// through guard keeps exactly ONE --settings on the argv, with ultracode merged into it.
 	// Gated on the agent being Claude exactly as launchSkipPermsFlag gates, since --settings is
 	// a Claude-specific flag; other agents get nothing.
-	if o.ultracode {
+	if o.ultracode && !o.useGuard {
 		switch guardAgentBaseName(o.command) {
 		case "claude", "claude-code":
 			agentCmd = append(agentCmd, "--settings", ultracodeSettingsArg)
@@ -217,6 +231,20 @@ func buildLaunchArgv(fakBin string, o launchOpts) []string {
 	// keeps the argv byte-identical to a launch that never configured a posture.
 	argv := []string{fakBin, "guard"}
 	argv = append(argv, o.guardCacheArgs...)
+	// Relay the RESOLVED ultracode posture to guard, which owns the single --settings file and
+	// merges the key into it. It is pinned in BOTH directions so the launcher's explicit answer
+	// always wins over guard's own attendance default: on ⇒ `ultracode`, off ⇒ `off` (leave the
+	// seat's own reasoning default alone), never left to `auto`. Claude-only, matching the
+	// inline form above — guard's posture installer no-ops on a non-Claude child anyway, but
+	// keeping the argv identical for other agents means no behavior change there at all.
+	switch guardAgentBaseName(o.command) {
+	case "claude", "claude-code":
+		mode := guardPreCompactModeOff
+		if o.ultracode {
+			mode = guardEffortModeUltracode
+		}
+		argv = append(argv, "--effort", mode)
+	}
 	argv = append(argv, "--")
 	return append(argv, agentCmd...)
 }

--- a/cmd/fak/accounts_launch_test.go
+++ b/cmd/fak/accounts_launch_test.go
@@ -24,17 +24,17 @@ func TestBuildLaunchArgv(t *testing.T) {
 		{
 			name: "guard on, skip-perms on (the default)",
 			opts: launchOpts{command: "claude", useGuard: true, skipPermissions: true},
-			want: []string{fakBin, "guard", "--", "claude", "--dangerously-skip-permissions"},
+			want: []string{fakBin, "guard", "--effort", "off", "--", "claude", "--dangerously-skip-permissions"},
 		},
 		{
 			name: "guard on, skip-perms on, with passthrough",
 			opts: launchOpts{command: "claude", useGuard: true, skipPermissions: true, passthrough: []string{"--resume", "abc"}},
-			want: []string{fakBin, "guard", "--", "claude", "--dangerously-skip-permissions", "--resume", "abc"},
+			want: []string{fakBin, "guard", "--effort", "off", "--", "claude", "--dangerously-skip-permissions", "--resume", "abc"},
 		},
 		{
 			name: "guard on, skip-perms off (Claude prompts)",
 			opts: launchOpts{command: "claude", useGuard: true, skipPermissions: false},
-			want: []string{fakBin, "guard", "--", "claude"},
+			want: []string{fakBin, "guard", "--effort", "off", "--", "claude"},
 		},
 		{
 			name: "guard off, skip-perms on (direct, no kernel hop)",
@@ -72,43 +72,46 @@ func TestBuildLaunchArgv(t *testing.T) {
 			want: []string{fakBin, "guard", "--", "opencode"},
 		},
 		{
-			// Ultracode injects the session-only --settings for Claude, after the bypass flag
-			// and before any passthrough — parity with the `f` shortcut's workflow-on default.
-			name: "claude ultracode on adds --settings after the bypass flag",
+			// Under guard, ultracode is RELAYED as the guard flag `--effort ultracode` rather
+			// than an inline child --settings: Claude's --settings is last-wins, so a second
+			// occurrence would discard guard's whole hook-settings file. Guard merges the key
+			// into that one file instead (guard_effort.go).
+			name: "claude ultracode on relays the guard --effort posture, not an inline --settings",
 			opts: launchOpts{command: "claude", useGuard: true, skipPermissions: true, ultracode: true},
-			want: []string{fakBin, "guard", "--", "claude", "--dangerously-skip-permissions", "--settings", `{"ultracode":true}`},
+			want: []string{fakBin, "guard", "--effort", "ultracode", "--", "claude", "--dangerously-skip-permissions"},
 		},
 		{
-			name: "claude ultracode on with passthrough keeps --settings before passthrough",
+			name: "claude ultracode on with passthrough keeps the posture on the guard argv",
 			opts: launchOpts{command: "claude", useGuard: true, skipPermissions: true, ultracode: true, passthrough: []string{"-p", "hi"}},
-			want: []string{fakBin, "guard", "--", "claude", "--dangerously-skip-permissions", "--settings", `{"ultracode":true}`, "-p", "hi"},
+			want: []string{fakBin, "guard", "--effort", "ultracode", "--", "claude", "--dangerously-skip-permissions", "-p", "hi"},
 		},
 		{
-			// Ultracode is Claude-specific; --settings is never handed to a non-Claude agent.
-			name: "codex ultracode on gets no --settings",
+			// Ultracode is Claude-specific; neither the inline --settings nor the relayed
+			// guard --effort posture is handed to a non-Claude agent.
+			name: "codex ultracode on gets no --settings and no --effort relay",
 			opts: launchOpts{command: "codex", useGuard: true, skipPermissions: true, ultracode: true},
 			want: []string{fakBin, "guard", "--", "codex", "--dangerously-bypass-approvals-and-sandbox"},
 		},
 		{
 			// The default model is pinned via --model for a Claude launch, after the
-			// bypass flag and before ultracode's --settings — so a switched seat starts on
-			// the configured default regardless of its own saved default.
+			// bypass flag — so a switched seat starts on the configured default regardless
+			// of its own saved default. The reasoning posture rides the guard argv instead.
 			name: "claude default model adds --model after the bypass flag",
 			opts: launchOpts{command: "claude", useGuard: true, skipPermissions: true, model: defaultLaunchModel},
-			want: []string{fakBin, "guard", "--", "claude", "--dangerously-skip-permissions", "--model", defaultLaunchModel},
+			want: []string{fakBin, "guard", "--effort", "off", "--", "claude", "--dangerously-skip-permissions", "--model", defaultLaunchModel},
 		},
 		{
-			// --model precedes --settings, and both precede any passthrough — so a caller's own
-			// `-- --model x` still comes later.
-			name: "claude model + ultracode order: --model then --settings then passthrough",
+			// --model precedes any passthrough — so a caller's own `-- --model x` still comes
+			// later — while the ultracode posture rides the guard segment before `--`.
+			name: "claude model + ultracode order: posture on guard argv, --model then passthrough",
 			opts: launchOpts{command: "claude", useGuard: true, skipPermissions: true, ultracode: true, model: defaultLaunchModel, passthrough: []string{"--model", "sonnet"}},
-			want: []string{fakBin, "guard", "--", "claude", "--dangerously-skip-permissions", "--model", defaultLaunchModel, "--settings", `{"ultracode":true}`, "--model", "sonnet"},
+			want: []string{fakBin, "guard", "--effort", "ultracode", "--", "claude", "--dangerously-skip-permissions", "--model", defaultLaunchModel, "--model", "sonnet"},
 		},
 		{
 			// An empty model opts out: the seat's own saved default stands (no --model emitted).
 			name: "claude empty model omits --model",
 			opts: launchOpts{command: "claude", useGuard: true, skipPermissions: true, model: ""},
-			want: []string{fakBin, "guard", "--", "claude", "--dangerously-skip-permissions"},
+			want: []string{fakBin, "guard", "--effort", "off", "--", "claude", "--dangerously-skip-permissions"},
 		},
 		{
 			// --model is Claude-specific: a Claude model id is never handed to a non-Claude agent.
@@ -121,7 +124,7 @@ func TestBuildLaunchArgv(t *testing.T) {
 			// `--` so guard parses them and the agent never sees them.
 			name: "claude managed-cache posture rides the guard argv before --",
 			opts: launchOpts{command: "claude", useGuard: true, skipPermissions: true, guardCacheArgs: []string{"--api-key-env", "ANTHROPIC_API_KEY", "--managed-cache", "on"}},
-			want: []string{fakBin, "guard", "--api-key-env", "ANTHROPIC_API_KEY", "--managed-cache", "on", "--", "claude", "--dangerously-skip-permissions"},
+			want: []string{fakBin, "guard", "--api-key-env", "ANTHROPIC_API_KEY", "--managed-cache", "on", "--effort", "off", "--", "claude", "--dangerously-skip-permissions"},
 		},
 		{
 			// With guard OFF there is no guard process to carry the posture, so the flags are
@@ -217,9 +220,9 @@ func TestRunAccountsLaunchDryRun(t *testing.T) {
 		}
 	}
 	// stdout echoes the scriptable command: it must be the guard wrap, carrying the on-by-default
-	// managed-cache posture before `--`.
+	// managed-cache posture AND the relayed ultracode posture before `--`.
 	gotOut := strings.TrimSpace(out.String())
-	if !strings.Contains(gotOut, "guard --managed-cache on -- claude --dangerously-skip-permissions") {
+	if !strings.Contains(gotOut, "guard --managed-cache on --effort ultracode -- claude --dangerously-skip-permissions") {
 		t.Fatalf("dry-run stdout command = %q", gotOut)
 	}
 	if strings.Contains(gotErr, seat) {
@@ -281,11 +284,15 @@ func TestRunAccountsLaunchExecSeam(t *testing.T) {
 		t.Fatalf("argv not a guard wrap: %#v", gotArgv)
 	}
 	joined := strings.Join(gotArgv, " ")
-	if !strings.Contains(joined, "guard --managed-cache on --") {
-		t.Fatalf("argv missing on-by-default managed-cache posture before --: %#v", gotArgv)
+	if !strings.Contains(joined, "guard --managed-cache on --effort ultracode --") {
+		t.Fatalf("argv missing on-by-default managed-cache + ultracode posture before --: %#v", gotArgv)
 	}
-	// The default posture is --ultracode=auto, which an unclassified launch resolves to OFF
-	// (#5016), so a bare launch carries no ultracode --settings.
+	// The default posture is --ultracode=auto, and an unclassified launch is a USER-INITIATED
+	// one, so it resolves to ON — relayed to guard as `--effort ultracode` on the guard segment
+	// above, never as an inline child --settings (which would clobber guard's hook file).
+	if strings.Contains(joined, ultracodeSettingsArg) {
+		t.Fatalf("guarded launch must not carry an inline ultracode --settings (it clobbers guard's hook settings): %q", joined)
+	}
 	wantTail := "claude --dangerously-skip-permissions --model " + defaultLaunchModel + " --resume xyz"
 	if !strings.HasSuffix(joined, wantTail) {
 		t.Fatalf("argv tail wrong: %q", joined)
@@ -404,8 +411,8 @@ func TestRunAccountsLaunchFallsBackWhenDefaultOpusUnavailable(t *testing.T) {
 	t.Cleanup(func() { accountsLaunchRun = orig })
 
 	// --ultracode=on is explicit here: the point of this test is that the posture RIDES the
-	// fallback hop, and the default (auto -> off for an unclassified launch, #5016) would emit no
-	// --settings to check.
+	// fallback hop. It is relayed as the guard flag `--effort ultracode`, not an inline
+	// --settings, so that is what the fallback argv must still carry.
 	var out, errb bytes.Buffer
 	rc := runAccounts(&out, &errb, []string{"launch", "--name", "gem8-seat", "--ultracode=on", "--registry", regPath, "--home", home})
 	if rc != 0 {
@@ -418,7 +425,7 @@ func TestRunAccountsLaunchFallsBackWhenDefaultOpusUnavailable(t *testing.T) {
 	if !strings.Contains(first, "--model "+defaultLaunchModel) {
 		t.Fatalf("primary launch did not use default Opus model: %q", first)
 	}
-	for _, want := range []string{"--model " + defaultLaunchFallbackFirst(), "--settings " + ultracodeSettingsArg} {
+	for _, want := range []string{"--model " + defaultLaunchFallbackFirst(), "--effort " + guardEffortModeUltracode} {
 		if !strings.Contains(second, want) {
 			t.Fatalf("fallback launch missing %q:\n%s", want, second)
 		}
@@ -792,16 +799,20 @@ func TestRunAccountsLaunchDirectNoGuard(t *testing.T) {
 	if rc != 0 {
 		t.Fatalf("launch --guard=false rc=%d stderr=%s", rc, errb.String())
 	}
-	// Default --ultracode=auto + an unclassified launch => no ultracode --settings (#5016).
-	want := []string{"claude", "--dangerously-skip-permissions", "--model", defaultLaunchModel}
+	// Default --ultracode=auto + an unclassified (user-initiated) launch => ultracode ON. With
+	// guard OFF there is no guard process to relay the posture to and no hook-settings file to
+	// clobber, so the INLINE --settings is the correct — and only — carrier here.
+	want := []string{"claude", "--dangerously-skip-permissions", "--model", defaultLaunchModel, "--settings", ultracodeSettingsArg}
 	if !reflect.DeepEqual(gotArgv, want) {
 		t.Fatalf("direct launch argv = %#v, want %#v", gotArgv, want)
 	}
 }
 
-// TestResolveUltracodePosture pins the posture x work-class table #5016 documents: an explicit
-// on/off always wins, and `auto` earns ultracode ONLY for rigor-class work — grind and the
-// unclassified/interactive case stay OFF for latency.
+// TestResolveUltracodePosture pins the posture x work-class table: an explicit on/off always
+// wins, and `auto` earns ultracode for everything EXCEPT grind — including the unclassified
+// case, which is the interactive launcher's own row (a human at a keyboard is user-initiated
+// work, and user-initiated work is what the orchestration tax is for). Unattended work does not
+// arrive here; it comes through the headless dispatch path, where guard resolves xhigh.
 func TestResolveUltracodePosture(t *testing.T) {
 	cases := []struct {
 		posture string
@@ -809,12 +820,13 @@ func TestResolveUltracodePosture(t *testing.T) {
 		want    bool
 		wantErr bool
 	}{
-		// auto routes per work class.
+		// auto routes per work class: only GRIND opts out.
 		{"auto", ultracodeKindRigor, true, false},
 		{"auto", ultracodeKindGrind, false, false},
-		{"auto", ultracodeKindUnknown, false, false},
+		{"auto", ultracodeKindUnknown, true, false},
 		{"", ultracodeKindRigor, true, false}, // empty normalizes to auto
-		{"", ultracodeKindUnknown, false, false},
+		{"", ultracodeKindUnknown, true, false},
+		{"Auto", ultracodeKindUnknown, true, false},
 		// An explicit posture wins over the work class in BOTH directions.
 		{"on", ultracodeKindUnknown, true, false},
 		{"on", ultracodeKindGrind, true, false},
@@ -843,22 +855,23 @@ func TestResolveUltracodePosture(t *testing.T) {
 	}
 }
 
-// TestRunAccountsLaunchUltracodePosture pins #5016: --ultracode is a three-value posture
-// auto|on|off (default auto), and the ultracode --settings arg is emitted ONLY when the posture
-// resolves ON. A bare launch carries no work class, so auto resolves to the conservative OFF —
-// replacing the blanket default-on that made every seat pay the orchestration tax.
+// TestRunAccountsLaunchUltracodePosture pins the launcher's end-to-end posture contract:
+// --ultracode is a three-value posture auto|on|off (default auto), it is RELAYED to guard as
+// `--effort ultracode|off` (never as an inline child --settings, which would clobber guard's
+// hook-settings file), and a bare user-initiated launch defaults ON. The relay is pinned in BOTH
+// directions so an explicit --ultracode=off still beats guard's own attendance default.
 func TestRunAccountsLaunchUltracodePosture(t *testing.T) {
 	cases := []struct {
 		name    string
 		args    []string
 		wantArg bool
 	}{
-		{"default (auto) + unclassified launch omits ultracode", nil, false},
-		{"explicit auto + unclassified launch omits ultracode", []string{"--ultracode=auto"}, false},
+		{"default (auto) + user-initiated launch gets ultracode", nil, true},
+		{"explicit auto + user-initiated launch gets ultracode", []string{"--ultracode=auto"}, true},
 		{"explicit on forces ultracode", []string{"--ultracode=on"}, true},
-		{"explicit off omits ultracode", []string{"--ultracode=off"}, false},
+		{"explicit off pins the posture off", []string{"--ultracode=off"}, false},
 		{"legacy bool true still forces ultracode", []string{"--ultracode=true"}, true},
-		{"legacy bool false still omits ultracode", []string{"--ultracode=false"}, false},
+		{"legacy bool false still pins the posture off", []string{"--ultracode=false"}, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -881,8 +894,16 @@ func TestRunAccountsLaunchUltracodePosture(t *testing.T) {
 				t.Fatalf("launch rc=%d stderr=%s", rc, errb.String())
 			}
 			joined := strings.Join(gotArgv, " ")
-			if got := strings.Contains(joined, ultracodeSettingsArg); got != tc.wantArg {
-				t.Fatalf("ultracode --settings present = %v, want %v\nargv: %s", got, tc.wantArg, joined)
+			wantRelay := "--effort " + guardPreCompactModeOff
+			if tc.wantArg {
+				wantRelay = "--effort " + guardEffortModeUltracode
+			}
+			if !strings.Contains(joined, wantRelay) {
+				t.Fatalf("guard posture relay %q missing\nargv: %s", wantRelay, joined)
+			}
+			// The inline form is the clobbering one and must never appear on a GUARDED argv.
+			if strings.Contains(joined, ultracodeSettingsArg) {
+				t.Fatalf("guarded launch must not carry an inline ultracode --settings\nargv: %s", joined)
 			}
 		})
 	}

--- a/cmd/fak/guard.go
+++ b/cmd/fak/guard.go
@@ -142,6 +142,7 @@ func cmdGuard(argv []string) {
 	taskHandoffLive := fs.Bool("task-handoff-live", false, "after a valid handoff with next_steps, the Stop hook runs fak task handoff --live before allowing the clean stop")
 	operatorDirected := fs.String("operator-directed", guardOperatorDirectedModeWarn, "Claude Code Stop hook that catches a HEADLESS turn ending by asking a human (\"do you want me to push?\", \"waiting for your approval\") — a question no one is there to answer, so the work stalls: off|shadow|warn|enforce. WARN by default (soak: prints the choicetriage remediation, allows the stop); enforce BLOCKS a resolvable ask and feeds the remediation back so the agent acts, while routing a HUMAN_RESIDUAL wall as a typed escalation. Auto-OFF for an attended interactive child the operator did not gate explicitly (a human can always ask); never blocks an interactive session.")
 	splitMode := fs.String("split", "auto", "the default-launch UI: open a 20% `fak info` pane BESIDE the 80% interactive agent pane so the live cache/token economy + the kernel floor's safety counters stay on screen (a bare `fak guard -- claude` hands the whole terminal to Claude, hiding fak). auto|on|off. AUTO (default): enable ONLY for an attended interactive launch inside a splittable terminal context (tmux; Windows Terminal via $WT_SESSION; on macOS, iTerm2 gets an inline split and Apple Terminal — which has no split panes — a companion fak-info window, both via osascript); no-op for headless/piped/CI/plain-terminal launches (zero behavior change there). on forces it (prints a recipe if no host is found); off disables. The pane polls THIS guard's own loopback gateway (auth-exempt on loopback); the bearer is never placed on a pane command line.")
+	effortMode := fs.String("effort", guardEffortModeAuto, "the DEFAULT reasoning posture handed to a Claude child, decided by attendance: auto|ultracode|xhigh|off. AUTO (default): an attended interactive child gets ULTRACODE (xhigh reasoning + dynamic multi-agent workflow orchestration — a human is waiting on the hard question), while a headless `-p` fleet worker gets XHIGH (strong per-message reasoning without the orchestration wall-clock/spend tax nobody is watching). ultracode|xhigh force one posture; off leaves the seat's own default alone. A child that already pinned its own `--effort` (or an inline --settings naming ultracode) is left untouched. FAK_GUARD_EFFORT sets it without editing an argv. Claude children only; ultracode is MERGED into guard's single --settings file because Claude's --settings is last-wins, not merged.")
 	splitWhere := fs.String("split-where", "bottom", "with --split: place the 20% fak-info pane as a \"bottom\" strip or a \"right\" column")
 	splitInterval := fs.Duration("split-interval", 2*time.Second, "with --split: refresh interval for the fak-info pane")
 	splitDryRun := fs.Bool("split-dry-run", false, "preview the --split 80/20 plan (resolved multiplexer, geometry, and the exact `fak info` pane command) and EXIT, without bringing up the gateway, spawning a pane, or launching the agent. Use it to see what --split will do before handing the terminal to the agent.")
@@ -1230,11 +1231,32 @@ func cmdGuard(argv []string) {
 	sessionStartManaged := guardSessionStartManaged(command)
 	// Thread the guard trace id into the hook argv so the running SessionStart hook holds both
 	// ids and can record the A1 uuid<->trace identity join (#4112/#4113).
-	command, _, err = installGuardSessionStartHook(command, os.Getenv(guardSessionStartEnvMode), sessionStartManaged, sessionStartSettings, guardTraceID)
+	var sessionStartInstall guardSessionStartInstall
+	command, sessionStartInstall, err = installGuardSessionStartHook(command, os.Getenv(guardSessionStartEnvMode), sessionStartManaged, sessionStartSettings, guardTraceID)
 	if err != nil {
 		cancel()
 		fmt.Fprintf(os.Stderr, "fak guard: Claude SessionStart hook setup failed: %v\n", err)
 		os.Exit(1)
+	}
+	// The DEFAULT reasoning posture, decided by attendance (guard_effort.go): an attended
+	// interactive child gets ultracode, a headless `-p` fleet worker gets xhigh. It runs LAST
+	// of the settings writers so the ultracode key is merged into whatever file the hook
+	// installers above ended up with — a later hook merge would round-trip the struct and, but
+	// for the field living on guardPreCompactClaudeSettings, drop the key. Same
+	// guardChildInteractive signal the task-handoff and operator-directed gates key on.
+	effortSettings := sessionStartSettings
+	if p := strings.TrimSpace(sessionStartInstall.SettingsPath); p != "" {
+		effortSettings = p
+	}
+	var effortInstall guardEffortInstall
+	command, effortInstall, err = installGuardEffortPosture(command, guardEffortEffectiveMode(*effortMode, guardSetFlags["effort"], os.Getenv), effortSettings)
+	if err != nil {
+		cancel()
+		fmt.Fprintf(os.Stderr, "fak guard: reasoning posture setup failed: %v\n", err)
+		os.Exit(1)
+	}
+	if !*quiet {
+		fmt.Fprintf(os.Stderr, "fak guard: reasoning posture = %s\n", guardEffortWord(effortInstall, guardChildInteractive(command)))
 	}
 	// First-class `fak guard -- codex`: Codex reads custom upstreams from `-c`
 	// provider overrides, not OPENAI_BASE_URL. Repoint only Codex children, after the

--- a/cmd/fak/guard_effort.go
+++ b/cmd/fak/guard_effort.go
@@ -1,0 +1,296 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// guard_effort.go — the reasoning posture a guarded session gets BY DEFAULT, decided by
+// ATTENDANCE rather than by one global settings.json value.
+//
+// The two postures are not interchangeable, and which one is right depends on who is
+// waiting for the answer:
+//
+//   - ULTRACODE (xhigh per-message reasoning PLUS dynamic multi-agent workflow
+//     orchestration) is the right default for a USER-INITIATED session. A human is at the
+//     keyboard, the question is usually the hard one they could not answer themselves, and
+//     the orchestration tax is paid in wall-clock the human already accepted by asking.
+//   - XHIGH (the strongest per-message reasoning short of ultracode) is the right default
+//     for an AGENT session — a headless `-p` fleet worker. Nobody is watching, the work is
+//     usually a bounded leaf off a dispatch queue, and ultracode's fan-out buys rigor the
+//     worker's own verify step already provides while multiplying its wall-clock and spend.
+//
+// Why this cannot be a settings.json value: `~/.claude/settings.json` is ONE file shared by
+// every session on the host, so `"ultracode": true` there leaks the orchestration tax into
+// every fleet worker, and `false` denies it to the human. Guard is the only seam that knows
+// which kind of session it is about to launch (guardChildInteractive — the same `-p` signal
+// the task-handoff and operator-directed gates already key on), so guard is where the
+// posture is resolved.
+//
+// HOW each posture is emitted differs, and the difference is load-bearing:
+//
+//   - xhigh rides the child's own `--effort xhigh` flag. It is a plain repeatable-safe flag.
+//   - ultracode has NO CLI flag; it is only a settings key, so it must be MERGED into the
+//     one --settings file the guard hook installers already wrote. It must NOT be handed as
+//     a second `--settings '{"ultracode":true}'`: Claude Code's --settings is LAST-WINS, not
+//     merged (verified against the CLI: with two --settings, keys from the first are dropped
+//     entirely), so a second occurrence would silently discard the guard's ENTIRE hook stack
+//     — the deny-all auto-continue Stop hook, the task-handoff gate, the toolproc journal,
+//     the SessionStart affordance, and the PreCompact coherence gate. Merging into the same
+//     file keeps exactly one --settings on the argv and both halves alive.
+const (
+	// guardEffortModeAuto resolves by attendance: interactive ⇒ ultracode, headless ⇒ xhigh.
+	guardEffortModeAuto = "auto"
+	// guardEffortModeUltracode forces ultracode regardless of attendance.
+	guardEffortModeUltracode = "ultracode"
+	// guardEffortModeXHigh forces xhigh regardless of attendance.
+	guardEffortModeXHigh = "xhigh"
+
+	// guardEffortEnvMode lets an orchestrator pin the posture without editing an argv.
+	// The flag wins when the operator set it explicitly.
+	guardEffortEnvMode = "FAK_GUARD_EFFORT"
+
+	// guardEffortLevelXHigh is the value handed to the child's --effort flag. It is one of
+	// the levels the CLI actually admits (low|medium|high|xhigh|max) — "ultracode" is NOT
+	// an --effort level, which is why it travels as a settings key instead.
+	guardEffortLevelXHigh = "xhigh"
+)
+
+// guardEffortInstall records what the posture resolver did, for the launch readout and tests.
+type guardEffortInstall struct {
+	Applied      bool
+	Mode         string // the normalized mode that was requested (auto|ultracode|xhigh|off)
+	Posture      string // the RESOLVED posture actually emitted (ultracode|xhigh); "" when none
+	SettingsPath string // the --settings file ultracode was merged into; "" for the xhigh path
+	Reason       string // why nothing was applied (disabled|non-claude-child|child-pinned)
+}
+
+// normalizeGuardEffortMode folds the posture knob to its canonical token, failing LOUD on an
+// unrecognized value rather than silently defaulting — the same discipline
+// normalizeGuardToolprocMode and normalizeManagedCacheMode use. An empty knob is `auto`.
+func normalizeGuardEffortMode(mode string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "", guardEffortModeAuto:
+		return guardEffortModeAuto, nil
+	case guardEffortModeUltracode:
+		return guardEffortModeUltracode, nil
+	case guardEffortModeXHigh:
+		return guardEffortModeXHigh, nil
+	case guardPreCompactModeOff:
+		return guardPreCompactModeOff, nil
+	default:
+		return "", fmt.Errorf("invalid --effort mode %q (want auto, ultracode, xhigh, or off)", mode)
+	}
+}
+
+// guardEffortEffectiveMode resolves the posture knob from the flag and the environment. An
+// EXPLICITLY-set flag always wins; otherwise FAK_GUARD_EFFORT speaks; otherwise the flag's
+// own default stands. Mirrors guardTaskHandoffEffectiveMode's flag-beats-env precedence.
+func guardEffortEffectiveMode(flagMode string, flagSet bool, getenv func(string) string) string {
+	if flagSet {
+		return flagMode
+	}
+	if getenv != nil {
+		if env := strings.TrimSpace(getenv(guardEffortEnvMode)); env != "" {
+			return env
+		}
+	}
+	return flagMode
+}
+
+// guardEffortPosture folds the mode and the attendance signal into the single posture to
+// emit. This is the attendance table:
+//
+//	mode       child         posture    why
+//	---------  ------------  ---------  --------------------------------------------------
+//	ultracode  (any)         ultracode  operator forced it; an explicit mode always wins
+//	xhigh      (any)         xhigh      operator forced it; an explicit mode always wins
+//	off        (any)         (none)     no posture emitted; the seat's own default stands
+//	auto       interactive   ultracode  a human is waiting: buy the orchestration rigor
+//	auto       headless -p   xhigh      an unattended worker: strong reasoning, no fan-out tax
+//
+// An unrecognized mode returns no posture; callers normalize first and surface the error.
+func guardEffortPosture(mode string, interactive bool) string {
+	switch mode {
+	case guardEffortModeUltracode:
+		return guardEffortModeUltracode
+	case guardEffortModeXHigh:
+		return guardEffortModeXHigh
+	case guardEffortModeAuto:
+		if interactive {
+			return guardEffortModeUltracode
+		}
+		return guardEffortModeXHigh
+	default: // off, or anything unnormalized
+		return ""
+	}
+}
+
+// guardEffortChildPinned reports whether the child argv ALREADY carries its own reasoning
+// posture, in which case guard emits nothing — an explicit per-launch choice outranks a
+// default. Two forms count: the child's own `--effort <level>` flag, and an inline
+// `--settings` JSON naming ultracode (what a pre-guard launcher or an operator hands
+// directly). Only the guard-flag segment is excluded: this scans the CHILD argv, which is
+// already the post-`--` tail by the time an installer sees it.
+func guardEffortChildPinned(command []string) bool {
+	for _, a := range command {
+		name, val, hasEq := strings.Cut(a, "=")
+		switch name {
+		case "--effort":
+			return true
+		case "--settings":
+			if hasEq && guardEffortSettingsNamesUltracode(val) {
+				return true
+			}
+		default:
+			// `--settings <json>`: the value is the NEXT token, handled below.
+		}
+	}
+	for i := 0; i+1 < len(command); i++ {
+		if command[i] == "--settings" && guardEffortSettingsNamesUltracode(command[i+1]) {
+			return true
+		}
+	}
+	return false
+}
+
+// guardEffortSettingsNamesUltracode reports whether a --settings value is INLINE JSON that
+// names the ultracode key. A file path is not inline JSON and returns false (guard wrote
+// those itself; treating one as a pin would make the installer self-suppress on re-entry).
+func guardEffortSettingsNamesUltracode(v string) bool {
+	s := strings.TrimSpace(v)
+	if !strings.HasPrefix(s, "{") {
+		return false
+	}
+	var probe map[string]any
+	if err := json.Unmarshal([]byte(s), &probe); err != nil {
+		return false
+	}
+	_, ok := probe["ultracode"]
+	return ok
+}
+
+// installGuardEffortPosture emits the resolved default reasoning posture onto the child.
+//
+// xhigh appends `--effort xhigh` to the child argv. ultracode MERGES `"ultracode": true`
+// into existingSettingsPath — the file the PreCompact/Stop/toolproc/SessionStart installers
+// already wrote and already put on the argv — so the session carries exactly ONE --settings
+// and the hook stack survives (see the last-wins note at the top of this file). With no such
+// file (every hook installer off, or a non-guard-hooked child) it writes its own settings
+// file and injects the single --settings itself.
+//
+// No-op, with a Reason, for: mode=off, a non-Claude child (--effort/--settings are
+// Claude-specific, exactly as the hook installers gate), and a child that already pinned its
+// own posture.
+func installGuardEffortPosture(command []string, mode, existingSettingsPath string) ([]string, guardEffortInstall, error) {
+	normalized, err := normalizeGuardEffortMode(mode)
+	if err != nil {
+		return command, guardEffortInstall{}, err
+	}
+	install := guardEffortInstall{Mode: normalized}
+	if normalized == guardPreCompactModeOff {
+		install.Reason = "disabled"
+		return command, install, nil
+	}
+	if !guardPreCompactIsClaudeCommand(command) {
+		install.Reason = "non-claude-child"
+		return command, install, nil
+	}
+	if guardEffortChildPinned(command) {
+		install.Reason = "child-pinned"
+		return command, install, nil
+	}
+	posture := guardEffortPosture(normalized, guardChildInteractive(command))
+	if posture == "" {
+		install.Reason = "disabled"
+		return command, install, nil
+	}
+	install.Posture = posture
+	if posture == guardEffortModeXHigh {
+		install.Applied = true
+		return append(append([]string{}, command...), "--effort", guardEffortLevelXHigh), install, nil
+	}
+
+	// ultracode: settings-key only, so merge rather than add a second --settings.
+	if path := strings.TrimSpace(existingSettingsPath); path != "" {
+		if err := mergeGuardUltracodeIntoSettings(path); err != nil {
+			return command, install, err
+		}
+		install.Applied = true
+		install.SettingsPath = path
+		return command, install, nil // command already carries --settings; do NOT inject it again.
+	}
+	dir, err := guardSessionTempDir("effort")
+	if err != nil {
+		return command, install, err
+	}
+	return installGuardEffortPostureAt(command, normalized, dir)
+}
+
+// installGuardEffortPostureAt is the no-lookup half of installGuardEffortPosture for the
+// case where guard must write its OWN settings file (no hook installer produced one). dir is
+// injected so a test never touches the real session temp directory.
+func installGuardEffortPostureAt(command []string, mode, dir string) ([]string, guardEffortInstall, error) {
+	normalized, err := normalizeGuardEffortMode(mode)
+	if err != nil {
+		return command, guardEffortInstall{}, err
+	}
+	install := guardEffortInstall{Mode: normalized}
+	posture := guardEffortPosture(normalized, guardChildInteractive(command))
+	if posture != guardEffortModeUltracode {
+		return command, install, errors.New("guard effort: own-settings path is for the ultracode posture only")
+	}
+	if strings.TrimSpace(dir) == "" {
+		return command, install, errors.New("empty effort posture settings directory")
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return command, install, err
+	}
+	path := filepath.Join(dir, "claude-effort-settings.json")
+	on := true
+	if err := writeGuardHookSettings(path, guardPreCompactClaudeSettings{Ultracode: &on}); err != nil {
+		return command, install, err
+	}
+	install.Applied = true
+	install.Posture = posture
+	install.SettingsPath = path
+	return appendClaudeSettingsArg(command, path), install, nil
+}
+
+// mergeGuardUltracodeIntoSettings sets `"ultracode": true` on an existing guard settings
+// file, preserving every other key (the hooks the installers wrote), so one --settings
+// carries both the hook stack and the posture.
+func mergeGuardUltracodeIntoSettings(path string) error {
+	settings, err := readGuardHookSettings(path)
+	if err != nil {
+		return err
+	}
+	on := true
+	settings.Ultracode = &on
+	return writeGuardHookSettings(path, settings)
+}
+
+// guardEffortWord renders the resolved posture for the guard launch readout, so an operator
+// can see WHICH default fired and WHY without re-deriving the attendance table.
+func guardEffortWord(install guardEffortInstall, interactive bool) string {
+	if !install.Applied {
+		reason := install.Reason
+		if reason == "" {
+			reason = "not applied"
+		}
+		return fmt.Sprintf("off (--effort=%s; %s)", install.Mode, reason)
+	}
+	attendance := "headless -p child"
+	if interactive {
+		attendance = "attended interactive child"
+	}
+	if install.Posture == guardEffortModeUltracode {
+		return fmt.Sprintf("ultracode (--effort=%s; %s — xhigh reasoning + workflow orchestration, merged into %s)",
+			install.Mode, attendance, filepath.Base(install.SettingsPath))
+	}
+	return fmt.Sprintf("xhigh (--effort=%s; %s — strong reasoning, no orchestration tax)", install.Mode, attendance)
+}

--- a/cmd/fak/guard_effort_mirror_test.go
+++ b/cmd/fak/guard_effort_mirror_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/anthony-chaudhary/fak/internal/dispatchtick"
+)
+
+// The reasoning-posture vocabulary is spelled in three places on purpose: the interactive
+// launcher (accounts_launch.go), the guard posture resolver (guard_effort.go), and the pure
+// dispatch leaf (internal/dispatchtick), which mirrors BY VALUE rather than importing cmd/fak so
+// it stays modelroute+stdlib clean. Mirrors drift silently, so these are the drift guards the
+// mirror comments promise. A divergence here is not cosmetic: the dispatch leaf hoists the
+// launcher's inline --settings payload by exact string match, and guard recognizes an
+// operator-pinned posture by exact flag value — a one-character drift turns both into silent
+// no-ops that hand a fleet worker the wrong posture, or strip guard's hook stack.
+func TestUltracodeVocabularyMirrorsDoNotDrift(t *testing.T) {
+	if ultracodeSettingsArg != dispatchtick.UltracodeSettingsArg {
+		t.Fatalf("ultracode --settings payload drifted: launcher %q vs dispatchtick %q",
+			ultracodeSettingsArg, dispatchtick.UltracodeSettingsArg)
+	}
+	if guardEffortModeUltracode != dispatchtick.GuardEffortUltracode {
+		t.Fatalf("guard ultracode posture value drifted: guard %q vs dispatchtick %q",
+			guardEffortModeUltracode, dispatchtick.GuardEffortUltracode)
+	}
+	// dispatchtick relays the posture through guard's OWN flag name, so the flag it emits must
+	// be one `fak guard` actually parses.
+	if got := dispatchtick.GuardEffortFlag; got != "--effort" {
+		t.Fatalf("dispatchtick relays %q, but guard's posture flag is --effort", got)
+	}
+	// xhigh is the agent-session default, and it must stay a level the child CLI admits
+	// (low|medium|high|xhigh|max) — "ultracode" is NOT an --effort level, which is exactly why
+	// it travels as a settings key instead.
+	if guardEffortLevelXHigh != dispatchtick.EffortXHigh {
+		t.Fatalf("xhigh effort level drifted: guard %q vs dispatchtick %q",
+			guardEffortLevelXHigh, dispatchtick.EffortXHigh)
+	}
+}

--- a/cmd/fak/guard_effort_test.go
+++ b/cmd/fak/guard_effort_test.go
@@ -1,0 +1,331 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestGuardEffortPosture pins the attendance table: `auto` is the whole point — an attended
+// interactive child gets ultracode (a human is waiting on the hard answer), a headless `-p`
+// fleet worker gets xhigh (strong reasoning without the orchestration tax nobody is watching).
+// An explicit mode wins over attendance in both directions, and off emits nothing.
+func TestGuardEffortPosture(t *testing.T) {
+	cases := []struct {
+		mode        string
+		interactive bool
+		want        string
+	}{
+		{guardEffortModeAuto, true, guardEffortModeUltracode},
+		{guardEffortModeAuto, false, guardEffortModeXHigh},
+		// An explicit mode ignores attendance.
+		{guardEffortModeUltracode, false, guardEffortModeUltracode},
+		{guardEffortModeUltracode, true, guardEffortModeUltracode},
+		{guardEffortModeXHigh, true, guardEffortModeXHigh},
+		{guardEffortModeXHigh, false, guardEffortModeXHigh},
+		// off leaves the seat's own reasoning default alone.
+		{guardPreCompactModeOff, true, ""},
+		{guardPreCompactModeOff, false, ""},
+	}
+	for _, tc := range cases {
+		if got := guardEffortPosture(tc.mode, tc.interactive); got != tc.want {
+			t.Errorf("guardEffortPosture(%q, interactive=%v) = %q, want %q", tc.mode, tc.interactive, got, tc.want)
+		}
+	}
+}
+
+func TestNormalizeGuardEffortMode(t *testing.T) {
+	for _, tc := range []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"", guardEffortModeAuto, false},
+		{"auto", guardEffortModeAuto, false},
+		{"  AUTO ", guardEffortModeAuto, false},
+		{"ultracode", guardEffortModeUltracode, false},
+		{"XHigh", guardEffortModeXHigh, false},
+		{"off", guardPreCompactModeOff, false},
+		// A typo fails LOUD rather than silently picking a posture — an operator who meant
+		// `xhigh` and typed `x-high` must not get ultracode's bill by accident.
+		{"x-high", "", true},
+		{"max", "", true},
+		{"true", "", true},
+	} {
+		got, err := normalizeGuardEffortMode(tc.in)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("normalizeGuardEffortMode(%q) err = %v, wantErr = %v", tc.in, err, tc.wantErr)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("normalizeGuardEffortMode(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestGuardEffortEffectiveMode: an explicitly-set flag beats the env; otherwise
+// FAK_GUARD_EFFORT speaks; otherwise the flag default stands.
+func TestGuardEffortEffectiveMode(t *testing.T) {
+	env := func(v string) func(string) string {
+		return func(k string) string {
+			if k == guardEffortEnvMode {
+				return v
+			}
+			return ""
+		}
+	}
+	if got := guardEffortEffectiveMode(guardEffortModeXHigh, true, env(guardEffortModeUltracode)); got != guardEffortModeXHigh {
+		t.Errorf("explicit flag must beat env; got %q", got)
+	}
+	if got := guardEffortEffectiveMode(guardEffortModeAuto, false, env(guardEffortModeUltracode)); got != guardEffortModeUltracode {
+		t.Errorf("env must speak when the flag was not set; got %q", got)
+	}
+	if got := guardEffortEffectiveMode(guardEffortModeAuto, false, env("")); got != guardEffortModeAuto {
+		t.Errorf("flag default must stand with no env; got %q", got)
+	}
+}
+
+// TestInstallGuardEffortPostureHeadlessAppendsEffortFlag: a headless `-p` worker — an AGENT
+// session — gets `--effort xhigh` on its own argv. It rides a plain flag, not a settings key,
+// so there is nothing to merge and no --settings to collide with.
+func TestInstallGuardEffortPostureHeadlessAppendsEffortFlag(t *testing.T) {
+	command := []string{"claude", "-p", "--permission-mode", "bypassPermissions", "do the thing"}
+	got, install, err := installGuardEffortPosture(command, guardEffortModeAuto, "")
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if !install.Applied || install.Posture != guardEffortModeXHigh {
+		t.Fatalf("install = %+v, want applied xhigh", install)
+	}
+	want := append(append([]string{}, command...), "--effort", guardEffortLevelXHigh)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("command = %#v, want %#v", got, want)
+	}
+	if install.SettingsPath != "" {
+		t.Fatalf("the xhigh path must not touch a settings file; got %q", install.SettingsPath)
+	}
+}
+
+// TestInstallGuardEffortPostureInteractiveMergesUltracode is the load-bearing one: an attended
+// interactive child gets ultracode MERGED into the hook settings file the installers already
+// wrote and already put on the argv. The argv must gain NO second --settings (Claude's
+// --settings is last-wins, so a second occurrence would silently discard the whole hook stack),
+// and every pre-existing hook key must survive the merge.
+func TestInstallGuardEffortPostureInteractiveMergesUltracode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "claude-guard-settings.json")
+	if err := writeGuardPreCompactSettings(path, "/usr/local/bin/fak"); err != nil {
+		t.Fatalf("seed hook settings: %v", err)
+	}
+	// A second installer has already merged its own event in, as the real chain does.
+	if err := mergeGuardToolprocIntoSettings(path, "/usr/local/bin/fak", filepath.Join(dir, "journal.jsonl")); err != nil {
+		t.Fatalf("seed toolproc hooks: %v", err)
+	}
+
+	command := appendClaudeSettingsArg([]string{"claude", "--dangerously-skip-permissions"}, path)
+	got, install, err := installGuardEffortPosture(command, guardEffortModeAuto, path)
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if !install.Applied || install.Posture != guardEffortModeUltracode {
+		t.Fatalf("install = %+v, want applied ultracode", install)
+	}
+	if !reflect.DeepEqual(got, command) {
+		t.Fatalf("ultracode must not change the argv (it merges into the existing --settings); got %#v want %#v", got, command)
+	}
+	if n := strings.Count(strings.Join(got, " "), "--settings"); n != 1 {
+		t.Fatalf("argv must carry exactly ONE --settings, got %d: %#v", n, got)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read merged settings: %v", err)
+	}
+	var merged map[string]any
+	if err := json.Unmarshal(raw, &merged); err != nil {
+		t.Fatalf("merged settings is not valid JSON: %v\n%s", err, raw)
+	}
+	if merged["ultracode"] != true {
+		t.Fatalf("merged settings missing ultracode:true\n%s", raw)
+	}
+	hooks, ok := merged["hooks"].(map[string]any)
+	if !ok {
+		t.Fatalf("merge dropped the hooks key entirely — this is the regression the merge exists to prevent\n%s", raw)
+	}
+	for _, event := range []string{"PreCompact", "PreToolUse", "PostToolUse", "SessionEnd"} {
+		if _, ok := hooks[event]; !ok {
+			t.Fatalf("merge dropped the %s hook\n%s", event, raw)
+		}
+	}
+}
+
+// TestInstallGuardEffortPostureWritesOwnSettingsWhenNoHookFile: with every hook installer off
+// there is no file to merge into, so the ultracode posture writes its own and injects the one
+// --settings itself.
+func TestInstallGuardEffortPostureWritesOwnSettingsWhenNoHookFile(t *testing.T) {
+	dir := t.TempDir()
+	command := []string{"claude", "--dangerously-skip-permissions"}
+	got, install, err := installGuardEffortPostureAt(command, guardEffortModeAuto, dir)
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if !install.Applied || install.Posture != guardEffortModeUltracode {
+		t.Fatalf("install = %+v, want applied ultracode", install)
+	}
+	want := []string{"claude", "--settings", install.SettingsPath, "--dangerously-skip-permissions"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("command = %#v, want %#v", got, want)
+	}
+	raw, err := os.ReadFile(install.SettingsPath)
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	var settings map[string]any
+	if err := json.Unmarshal(raw, &settings); err != nil {
+		t.Fatalf("settings is not valid JSON: %v\n%s", err, raw)
+	}
+	if settings["ultracode"] != true {
+		t.Fatalf("settings missing ultracode:true\n%s", raw)
+	}
+}
+
+// TestInstallGuardEffortPostureNoOps covers every path that must leave the argv byte-identical:
+// mode=off, a non-Claude child (--effort/--settings are Claude-specific), and a child that
+// already pinned its OWN posture — an explicit per-launch choice outranks a default.
+func TestInstallGuardEffortPostureNoOps(t *testing.T) {
+	cases := []struct {
+		name       string
+		command    []string
+		mode       string
+		wantReason string
+	}{
+		{
+			name:       "mode off",
+			command:    []string{"claude", "--dangerously-skip-permissions"},
+			mode:       guardPreCompactModeOff,
+			wantReason: "disabled",
+		},
+		{
+			name:       "non-claude child",
+			command:    []string{"codex", "--dangerously-bypass-approvals-and-sandbox"},
+			mode:       guardEffortModeAuto,
+			wantReason: "non-claude-child",
+		},
+		{
+			name:       "child already pinned --effort",
+			command:    []string{"claude", "--effort", "max"},
+			mode:       guardEffortModeAuto,
+			wantReason: "child-pinned",
+		},
+		{
+			name:       "child already pinned --effort=max",
+			command:    []string{"claude", "--effort=max"},
+			mode:       guardEffortModeAuto,
+			wantReason: "child-pinned",
+		},
+		{
+			// A pre-guard launcher (or an operator) handing the inline ultracode JSON has
+			// already spoken; guard must not merge a second, possibly different, posture.
+			name:       "child already pinned inline ultracode --settings",
+			command:    []string{"claude", "-p", "--settings", ultracodeSettingsArg, "go"},
+			mode:       guardEffortModeAuto,
+			wantReason: "child-pinned",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, install, err := installGuardEffortPosture(tc.command, tc.mode, "")
+			if err != nil {
+				t.Fatalf("install: %v", err)
+			}
+			if install.Applied {
+				t.Fatalf("install must be a no-op; got %+v", install)
+			}
+			if install.Reason != tc.wantReason {
+				t.Fatalf("reason = %q, want %q", install.Reason, tc.wantReason)
+			}
+			if !reflect.DeepEqual(got, tc.command) {
+				t.Fatalf("command changed: %#v, want %#v", got, tc.command)
+			}
+		})
+	}
+}
+
+// TestInstallGuardEffortPostureRejectsBadMode: a bad posture is an error the caller surfaces,
+// never a silent fallback to some default.
+func TestInstallGuardEffortPostureRejectsBadMode(t *testing.T) {
+	if _, _, err := installGuardEffortPosture([]string{"claude"}, "sometimes", ""); err == nil {
+		t.Fatal("invalid mode must error")
+	}
+}
+
+// TestGuardEffortSettingsFileIsNotAPin: guard writes its OWN --settings as a file path, so the
+// installer must not read that back as a child-supplied pin (which would make a re-entrant or
+// re-installed session silently skip the posture).
+func TestGuardEffortSettingsFileIsNotAPin(t *testing.T) {
+	if guardEffortSettingsNamesUltracode("/tmp/fak-guard/claude-settings.json") {
+		t.Fatal("a settings FILE path must not count as an inline ultracode pin")
+	}
+	if guardEffortSettingsNamesUltracode(`{"hooks":{}}`) {
+		t.Fatal("inline JSON without an ultracode key must not count as a pin")
+	}
+	if !guardEffortSettingsNamesUltracode(ultracodeSettingsArg) {
+		t.Fatal("the inline ultracode JSON must count as a pin")
+	}
+	// An explicit ultracode:false is still a pin: the operator named the key.
+	if !guardEffortSettingsNamesUltracode(`{"ultracode":false}`) {
+		t.Fatal("an explicit ultracode:false must count as a pin")
+	}
+}
+
+// TestGuardHookSettingsRoundTripPreservesPosture is the drift guard for the merge chain: every
+// hook installer round-trips guardPreCompactClaudeSettings, so a posture key merged in earlier
+// must survive a LATER hook merge. Without the field on the struct, json.Unmarshal drops it and
+// the rewrite silently loses the posture.
+func TestGuardHookSettingsRoundTripPreservesPosture(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	if err := writeGuardPreCompactSettings(path, "/usr/local/bin/fak"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := mergeGuardUltracodeIntoSettings(path); err != nil {
+		t.Fatalf("merge posture: %v", err)
+	}
+	// A later installer merges its own hooks into the SAME file.
+	if err := mergeGuardToolprocIntoSettings(path, "/usr/local/bin/fak", filepath.Join(dir, "journal.jsonl")); err != nil {
+		t.Fatalf("later hook merge: %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var settings map[string]any
+	if err := json.Unmarshal(raw, &settings); err != nil {
+		t.Fatalf("bad JSON: %v", err)
+	}
+	if settings["ultracode"] != true {
+		t.Fatalf("a later hook merge dropped the ultracode posture\n%s", raw)
+	}
+}
+
+// TestWriteGuardPreCompactSettingsOmitsUnsetPosture: the new posture fields are omitempty, so a
+// hook-only settings file stays byte-identical to what the installers wrote before — no
+// `"ultracode": false` appears and no seat default is silently overridden.
+func TestWriteGuardPreCompactSettingsOmitsUnsetPosture(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	if err := writeGuardPreCompactSettings(path, "/usr/local/bin/fak"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	for _, key := range []string{"ultracode", "effortLevel"} {
+		if strings.Contains(string(raw), key) {
+			t.Fatalf("hook-only settings must not mention %q:\n%s", key, raw)
+		}
+	}
+}

--- a/cmd/fak/guard_help.go
+++ b/cmd/fak/guard_help.go
@@ -87,7 +87,7 @@ var guardFlagGroups = []guardFlagGroup{
 	{"Session lifecycle hooks (Claude Code)", []string{
 		"precompact-hook", "deny-all-continue", "deny-all-max", "deny-all-warn",
 		"deny-all-final", "same-stop", "toolproc-hooks", "task-handoff", "task-handoff-file",
-		"task-handoff-repo", "task-handoff-live", "operator-directed",
+		"task-handoff-repo", "task-handoff-live", "operator-directed", "effort",
 	}},
 	{"Budgets, resets & session governance", []string{
 		"context-budget-tokens", "max-duration", "budget-envelope",

--- a/cmd/fak/guard_precompact.go
+++ b/cmd/fak/guard_precompact.go
@@ -53,6 +53,19 @@ type guardPreCompactInstall struct {
 
 type guardPreCompactClaudeSettings struct {
 	Hooks map[string][]guardPreCompactClaudeMatcher `json:"hooks"`
+	// Ultracode carries the reasoning posture guard_effort.go merges in (xhigh reasoning
+	// PLUS dynamic multi-agent workflow orchestration). It lives on THIS struct — not in a
+	// second --settings arg — because Claude Code's --settings is last-wins rather than
+	// merged, so a second occurrence would discard the whole hook stack above. A pointer
+	// with omitempty keeps the key absent (not `false`) when no posture was resolved, so a
+	// hook-only settings file stays byte-identical to before. Every installer round-trips
+	// this struct, so the field must live here or a later hook merge would drop the key.
+	Ultracode *bool `json:"ultracode,omitempty"`
+	// EffortLevel is the settings-file spelling of the per-message reasoning knob. Guard
+	// emits xhigh via the child's own `--effort` flag today, so this stays unset; it is
+	// declared for the same round-trip-preservation reason as Ultracode — an operator's
+	// pre-existing effortLevel in a merged-into file must survive a hook install.
+	EffortLevel string `json:"effortLevel,omitempty"`
 }
 
 type guardPreCompactClaudeMatcher struct {

--- a/cmd/fak/guard_sessionstart.go
+++ b/cmd/fak/guard_sessionstart.go
@@ -290,22 +290,13 @@ func writeGuardSessionStartSettings(path, fakBin string, managed bool, traceID s
 // mergeGuardSessionStartIntoSettings adds (or replaces) the SessionStart hook in an existing
 // guard settings file, preserving every other key (PreCompact/Stop/toolproc hooks).
 func mergeGuardSessionStartIntoSettings(path, fakBin string, managed bool, traceID string) error {
-	raw, err := os.ReadFile(path)
+	settings, err := readGuardHookSettings(path)
 	if err != nil {
 		return err
-	}
-	var settings guardPreCompactClaudeSettings
-	if err := json.Unmarshal(raw, &settings); err != nil {
-		return fmt.Errorf("parse existing hook settings %s: %w", path, err)
 	}
 	if settings.Hooks == nil {
 		settings.Hooks = map[string][]guardPreCompactClaudeMatcher{}
 	}
 	settings.Hooks["SessionStart"] = guardSessionStartMatchers(fakBin, managed, traceID)
-	data, err := json.MarshalIndent(settings, "", "  ")
-	if err != nil {
-		return err
-	}
-	data = append(data, '\n')
-	return writeGuardSettingsFileAtomic(path, data)
+	return writeGuardHookSettings(path, settings)
 }

--- a/cmd/fak/guard_stophook.go
+++ b/cmd/fak/guard_stophook.go
@@ -1112,25 +1112,16 @@ func writeGuardStopHookSettings(path, fakBin string) error {
 // mergeGuardStopHookIntoSettings adds (or replaces) the Stop hook in an existing guard settings
 // file, preserving every other key (e.g. the PreCompact hook), so a single --settings carries both.
 func mergeGuardStopHookIntoSettings(path, fakBin string) error {
-	raw, err := os.ReadFile(path)
+	settings, err := readGuardHookSettings(path)
 	if err != nil {
 		return err
-	}
-	var settings guardPreCompactClaudeSettings
-	if err := json.Unmarshal(raw, &settings); err != nil {
-		return fmt.Errorf("parse existing hook settings %s: %w", path, err)
 	}
 	if settings.Hooks == nil {
 		settings.Hooks = map[string][]guardPreCompactClaudeMatcher{}
 	}
 	settings.Hooks["Stop"] = guardStopHookMatchers(fakBin)
 	settings.Hooks["PreToolUse"] = guardCommitGateMatchers(fakBin)
-	data, err := json.MarshalIndent(settings, "", "  ")
-	if err != nil {
-		return err
-	}
-	data = append(data, '\n')
-	return writeGuardSettingsFileAtomic(path, data)
+	return writeGuardHookSettings(path, settings)
 }
 
 type guardStopHookSignals struct {

--- a/cmd/fak/guard_toolproc_hooks.go
+++ b/cmd/fak/guard_toolproc_hooks.go
@@ -188,16 +188,29 @@ func guardToolprocSetHooks(settings *guardPreCompactClaudeSettings, fakBin, jour
 // events in an existing guard settings file, preserving every other key (the
 // PreCompact and Stop hooks), so a single --settings carries all of them.
 func mergeGuardToolprocIntoSettings(path, fakBin, journalPath string) error {
-	raw, err := os.ReadFile(path)
+	settings, err := readGuardHookSettings(path)
 	if err != nil {
 		return err
 	}
-	var settings guardPreCompactClaudeSettings
-	if err := json.Unmarshal(raw, &settings); err != nil {
-		return fmt.Errorf("parse existing hook settings %s: %w", path, err)
-	}
 	guardToolprocSetHooks(&settings, fakBin, journalPath)
 	return writeGuardHookSettings(path, settings)
+}
+
+// readGuardHookSettings parses an existing guard settings file into the shared settings struct.
+// Every merge-into-an-existing-file installer needs exactly this preamble — SessionStart, Stop,
+// toolproc, and the reasoning posture all merge their own key into ONE file so a single
+// --settings carries the whole stack (Claude's --settings is last-wins, not merged) — so the
+// read lives here beside writeGuardHookSettings rather than four times over.
+func readGuardHookSettings(path string) (guardPreCompactClaudeSettings, error) {
+	var settings guardPreCompactClaudeSettings
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return settings, err
+	}
+	if err := json.Unmarshal(raw, &settings); err != nil {
+		return settings, fmt.Errorf("parse existing hook settings %s: %w", path, err)
+	}
+	return settings, nil
 }
 
 func writeGuardHookSettings(path string, settings guardPreCompactClaudeSettings) error {

--- a/cmd/fak/guard_toolproc_hooks_test.go
+++ b/cmd/fak/guard_toolproc_hooks_test.go
@@ -1,21 +1,17 @@
 package main
 
 import (
-	"encoding/json"
-	"os"
 	"path/filepath"
 	"testing"
 )
 
-func readGuardHookSettings(t *testing.T, path string) guardPreCompactClaudeSettings {
+// mustReadGuardHookSettings is the fail-the-test wrapper around the production reader, so the
+// suite exercises the same parse the installers use instead of keeping a second copy of it.
+func mustReadGuardHookSettings(t *testing.T, path string) guardPreCompactClaudeSettings {
 	t.Helper()
-	raw, err := os.ReadFile(path)
+	s, err := readGuardHookSettings(path)
 	if err != nil {
 		t.Fatalf("read settings: %v", err)
-	}
-	var s guardPreCompactClaudeSettings
-	if err := json.Unmarshal(raw, &s); err != nil {
-		t.Fatalf("parse settings: %v", err)
 	}
 	return s
 }
@@ -75,7 +71,7 @@ func TestInstallGuardToolprocHooksFresh(t *testing.T) {
 	if len(env) != 1 || env[0][0] != guardToolprocEnvMode || env[0][1] != guardToolprocModeObserve {
 		t.Fatalf("env = %v", env)
 	}
-	s := readGuardHookSettings(t, install.SettingsPath)
+	s := mustReadGuardHookSettings(t, install.SettingsPath)
 	assertToolprocEvent(t, s, "PreToolUse", "pre", journal)
 	assertToolprocEvent(t, s, "PostToolUse", "post", journal)
 	assertToolprocEvent(t, s, "SessionEnd", "stop", journal)
@@ -104,7 +100,7 @@ func TestInstallGuardToolprocHooksMergesAndPreserves(t *testing.T) {
 	if len(command) != len(commandIn) {
 		t.Fatalf("command = %v, want unchanged (no second --settings)", command)
 	}
-	s := readGuardHookSettings(t, existing)
+	s := mustReadGuardHookSettings(t, existing)
 	if _, ok := s.Hooks["Stop"]; !ok {
 		t.Fatal("merge dropped the pre-existing Stop hook")
 	}
@@ -116,7 +112,7 @@ func TestInstallGuardToolprocHooksMergesAndPreserves(t *testing.T) {
 	if _, _, _, err := installGuardToolprocHooksAt(command, "observe", existing, "fak", "", journal); err != nil {
 		t.Fatalf("re-install: %v", err)
 	}
-	s = readGuardHookSettings(t, existing)
+	s = mustReadGuardHookSettings(t, existing)
 	assertToolprocEvent(t, s, "PreToolUse", "pre", journal)
 }
 

--- a/internal/dispatchtick/dispatchtick.go
+++ b/internal/dispatchtick/dispatchtick.go
@@ -328,11 +328,63 @@ func GuardAuditPath(workspace, lane, backend string) string {
 	return filepath.Join(workspace, RunsDirName, name)
 }
 
+// Guard's reasoning-posture vocabulary, mirrored BY VALUE (not import — this leaf stays pure)
+// the same way UltracodeSettingsArg mirrors the interactive launcher's constant. A drift-guard
+// test keeps the two equal.
+const (
+	// GuardEffortFlag is the `fak guard` flag that carries the child's default reasoning
+	// posture. Guard owns the single --settings file, so ultracode must be relayed through
+	// this flag rather than handed to the child as a second --settings.
+	GuardEffortFlag = "--effort"
+	// GuardEffortUltracode is the posture value naming ultracode.
+	GuardEffortUltracode = "ultracode"
+)
+
+// hoistUltracodeSettings moves an inline `--settings {"ultracode":true}` OFF the child argv and
+// reports that the guard segment must carry `--effort ultracode` instead.
+//
+// This is a correctness fix, not a style preference. Claude Code's --settings is LAST-WINS, not
+// merged: with two --settings occurrences the keys of the earlier one are dropped wholesale.
+// `fak guard` puts its own hook-settings FILE on the child argv (the deny-all auto-continue Stop
+// hook, the task-handoff gate, the toolproc journal, the SessionStart affordance, the PreCompact
+// coherence gate), and it inserts that file right after the child's argv[0] — i.e. BEFORE this
+// inline payload. So an ultracode worker's inline `--settings` silently discarded guard's ENTIRE
+// hook stack, on exactly the highest-tier fleet workers. Relaying the posture as a guard flag
+// keeps one --settings on the argv; guard merges the ultracode key into that same file.
+//
+// It returns a copy; the input is never mutated. Both spellings are handled
+// (`--settings <json>` and `--settings=<json>`), and only a payload naming ultracode is hoisted —
+// any other inline settings JSON is left exactly where the caller put it.
+func hoistUltracodeSettings(command []string) (child []string, ultracode bool) {
+	out := make([]string, 0, len(command))
+	for i := 0; i < len(command); i++ {
+		arg := command[i]
+		if arg == "--settings" && i+1 < len(command) && command[i+1] == UltracodeSettingsArg {
+			ultracode = true
+			i++ // skip the payload too
+			continue
+		}
+		if arg == "--settings="+UltracodeSettingsArg {
+			ultracode = true
+			continue
+		}
+		out = append(out, arg)
+	}
+	return out, ultracode
+}
+
 // GuardedLaunchCommand returns command fronted by `fak guard` when a fak binary is available.
+//
+// An ultracode child has its inline --settings hoisted to the guard segment as
+// `--effort ultracode` (see hoistUltracodeSettings) so the worker keeps guard's hook stack. A
+// worker with no ultracode profile is left alone and picks up guard's own attendance default,
+// which for a headless `-p` child is xhigh — strong per-message reasoning without the
+// multi-agent orchestration tax no one is watching.
 func GuardedLaunchCommand(command []string, fakBin, lane, backend, workspace, baseURL string) ([]string, bool) {
 	if len(command) == 0 || strings.TrimSpace(fakBin) == "" {
 		return append([]string(nil), command...), false
 	}
+	command, ultracode := hoistUltracodeSettings(command)
 	args := []string{fakBin, "guard", "--provider", GuardProvider(backend)}
 	if backend != "claude" {
 		if strings.TrimSpace(baseURL) == "" {
@@ -344,7 +396,13 @@ func GuardedLaunchCommand(command []string, fakBin, lane, backend, workspace, ba
 	// ~9.9k-token full-registry schema floor to the allowlist a single-issue worker uses; the
 	// rest page in via the still-exposed fak_tools_search. The guard honors FAK_GUARD_EXPOSE_PROFILE
 	// as the fleet opt-out (=full/off restores the whole registry).
-	args = append(args, "--audit", GuardAuditPath(workspace, lane, backend), "--expose-profile", "headless", "--")
+	args = append(args, "--audit", GuardAuditPath(workspace, lane, backend), "--expose-profile", "headless")
+	if ultracode {
+		// The tier profile asked for ultracode explicitly (tier/T0 or tier/ultra), so pin it
+		// rather than leaving guard's headless default (xhigh) to decide.
+		args = append(args, GuardEffortFlag, GuardEffortUltracode)
+	}
+	args = append(args, "--")
 	args = append(args, command...)
 	return args, true
 }

--- a/internal/dispatchtick/dispatchtick_test.go
+++ b/internal/dispatchtick/dispatchtick_test.go
@@ -213,6 +213,53 @@ func TestGuardedLaunchCommand(t *testing.T) {
 	}
 }
 
+// TestGuardedLaunchCommandHoistsUltracodeSettings pins the clobber fix: Claude Code's --settings
+// is LAST-WINS, not merged, and guard inserts its own hook-settings FILE right after the child's
+// argv[0]. So an ultracode worker carrying an inline `--settings {"ultracode":true}` LATER on the
+// same argv silently discarded guard's whole hook stack. The posture must instead ride the guard
+// segment as `--effort ultracode`, leaving exactly ONE --settings on the child.
+func TestGuardedLaunchCommandHoistsUltracodeSettings(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		raw  []string
+	}{
+		{"space-separated", []string{"claude", "-p", "--model", WorkerModelOpus, "--settings", UltracodeSettingsArg}},
+		{"equals form", []string{"claude", "-p", "--model", WorkerModelOpus, "--settings=" + UltracodeSettingsArg}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, guarded := GuardedLaunchCommand(tc.raw, "fak", "docs", "claude", "/repo", "")
+			if !guarded {
+				t.Fatalf("claude command must be guarded: %#v", got)
+			}
+			joined := strings.Join(got, " ")
+			if strings.Contains(joined, UltracodeSettingsArg) {
+				t.Fatalf("inline ultracode --settings must not survive on the child argv (it clobbers guard's hook settings): %#v", got)
+			}
+			if !strings.Contains(joined, GuardEffortFlag+" "+GuardEffortUltracode+" --") {
+				t.Fatalf("posture must ride the guard segment as `%s %s` before `--`: %#v", GuardEffortFlag, GuardEffortUltracode, got)
+			}
+			// The rest of the child argv is untouched.
+			if !strings.HasSuffix(joined, "-- claude -p --model "+WorkerModelOpus) {
+				t.Fatalf("child argv beyond the hoisted posture must be unchanged: %#v", got)
+			}
+		})
+	}
+
+	// A worker with no ultracode profile gains no posture flag: it picks up guard's own headless
+	// default (xhigh), which is what an unattended agent session should run at.
+	got, _ := GuardedLaunchCommand([]string{"claude", "-p", "--effort", EffortXHigh}, "fak", "docs", "claude", "/repo", "")
+	if strings.Contains(strings.Join(got, " "), GuardEffortFlag+" "+GuardEffortUltracode) {
+		t.Fatalf("a non-ultracode worker must not be handed the ultracode posture: %#v", got)
+	}
+
+	// A DIFFERENT inline settings payload is not ours to move.
+	other := `{"theme":"dark"}`
+	got, _ = GuardedLaunchCommand([]string{"claude", "-p", "--settings", other}, "fak", "docs", "claude", "/repo", "")
+	if !strings.Contains(strings.Join(got, " "), "--settings "+other) {
+		t.Fatalf("a non-ultracode inline --settings must be left exactly where the caller put it: %#v", got)
+	}
+}
+
 func TestLaunchCommandShapeRedactsSensitiveFields(t *testing.T) {
 	raw := []string{
 		`C:\private\fak\fak.exe`, "guard",


### PR DESCRIPTION
Claude Code's --settings is LAST-WINS, not merged: with two occurrences the keys of the
earlier one are dropped wholesale. `fak guard` puts its own hook-settings FILE on the
child argv right after argv[0], so an ultracode launch that appended an inline
`--settings '{"ultracode":true}'` LATER on that argv silently discarded guard's ENTIRE
hook stack -- the deny-all auto-continue Stop hook, the task-handoff gate, the
PreToolUse commit-boundary lint gate, the toolproc journal, the SessionStart affordance
and the PreCompact coherence gate all vanished. It hit exactly the highest-tier work:
the interactive `--ultracode=on` launcher and the tier/T0 + tier/ultra fleet workers.
The tool-call policy floor is NOT affected -- those denials are adjudicated in-process
and were never installed as hooks by this file, so what was lost is observability,
session-lifecycle behaviour and a shadow-mode commit lint.

The fix keeps exactly ONE --settings on the argv and merges the posture key into it:

- guard_effort.go resolves the child's DEFAULT reasoning posture from ATTENDANCE
  (`--effort auto|ultracode|xhigh|off`, or FAK_GUARD_EFFORT). An attended interactive
  child gets ultracode -- a human is waiting on the hard question and the orchestration
  tax is wall-clock they already accepted by asking. A headless `-p` fleet worker gets
  xhigh: strong per-message reasoning without the fan-out wall-clock and spend nobody is
  watching. A child that already pinned its own --effort, or handed an inline --settings
  naming ultracode, is left untouched.
- ultracode is MERGED into the file the hook installers already wrote, because it is a
  settings KEY with no --effort level of its own; xhigh rides the child's own --effort
  flag. This is why the posture runs LAST of the settings writers.
- readGuardHookSettings is lifted out beside writeGuardHookSettings so all four
  merge-into-one-file installers (SessionStart, Stop, toolproc, posture) share one
  read-modify-write instead of four copies of the same preamble.
- The interactive launcher relays its resolved posture as `--effort` instead of an inline
  --settings, and its auto/unknown row flips ON: a bare `fak accounts launch` IS
  user-initiated, which is exactly the row that should pay the orchestration tax. The
  conservative-OFF that row used to hold was reasoning about UNATTENDED work, and
  unattended work arrives through the headless dispatch path instead.
- dispatchtick hoists an inline ultracode --settings off a worker argv into
  `--effort ultracode` on the guard segment, so a tier-profile worker keeps the stack.

Why this cannot be a settings.json value: ~/.claude/settings.json is ONE file shared by
every session on the host, so `"ultracode": true` there leaks the orchestration tax into
every fleet worker and `false` denies it to the human. Guard is the only seam that knows
which kind of session it is about to launch.

This change is code-only on purpose: the concept-glossary entry and the regenerated
concept-disambiguation scorecard artifacts are left to a follow-up `make` regen so the
diff a reviewer reads is the behaviour change and nothing derived from it.

Verified: go build ./... clean, gofmt clean, and the full ./cmd/fak suite A/B'd against a
pristine HEAD tree shows an identical 40 pre-existing env failures with zero regressions.


Fixes #5510
