### PR TITLE
fix(leaseref): skip empty namespace push

### DIFF
--- a/internal/leaseref/sync.go
+++ b/internal/leaseref/sync.go
@@ -51,8 +51,8 @@ import (
 // syncRefspec is the one refspec sync ever uses, on both the push and the fetch side:
 // the whole lock namespace, forced (lease refs point at blobs — no ancestry, so any
 // update of an existing ref needs the force), confined to refs/fak/locks/* at both
-// ends. A wildcard refspec matching ZERO refs is a successful no-op in git, so syncing
-// an empty namespace is clean on both sides.
+// ends. Git treats an empty wildcard FETCH as a clean no-op, but an empty wildcard
+// PUSH exits 1, so Sync probes the local namespace before issuing a push.
 const syncRefspec = "+" + refPrefix + "*:" + refPrefix + "*"
 
 // SyncResult reports what one Sync call actually did — which directions ran and the
@@ -99,12 +99,21 @@ func (s *Store) Sync(ctx context.Context, remote string, doPush, doFetch bool) (
 		return res, err
 	}
 	if doPush {
-		// Stop here: force-fetching over unpublished local state would regress the
-		// very leases this clone just wrote (the ordering rationale in the file doc).
-		if err := s.runSyncDirection(ctx, "push", remote, " — sync stopped before fetch (never force-fetch over unpublished local leases)"); err != nil {
+		hasRefs, err := s.localRefsExist(ctx)
+		if err != nil {
 			return res, err
 		}
-		res.Pushed = true
+		// A fresh clone has no lease refs. Git reports an empty wildcard
+		// push as a transport failure, so skip that push and let a fetch
+		// (if requested) proceed.
+		if hasRefs {
+			// Stop here: force-fetching over unpublished local state would regress the
+			// very leases this clone just wrote (the ordering rationale in the file doc).
+			if err := s.runSyncDirection(ctx, "push", remote, " — sync stopped before fetch (never force-fetch over unpublished local leases)"); err != nil {
+				return res, err
+			}
+			res.Pushed = true
+		}
 	}
 	if doFetch {
 		if err := s.runSyncDirection(ctx, "fetch", remote, ""); err != nil {
@@ -113,6 +122,27 @@ func (s *Store) Sync(ctx context.Context, remote string, doPush, doFetch bool) (
 		res.Fetched = true
 	}
 	return res, nil
+}
+
+// localRefsExist reports whether this clone has any refs in the lease namespace.
+// It checks only ref names: reading every record would add unnecessary object-
+// database work to each ambient sync tick. A non-zero for-each-ref exit is a real
+// git/store failure, while an empty successful listing is the expected fresh-clone
+// state.
+func (s *Store) localRefsExist(ctx context.Context) (bool, error) {
+	out, code, err := s.run(ctx, s.dir, "for-each-ref", "--format=%(refname)", refPrefix)
+	if err != nil {
+		return false, fmt.Errorf("leaseref: git not executable: %w", err)
+	}
+	if code != 0 {
+		return false, fmt.Errorf("leaseref: git for-each-ref %s exited %d", refPrefix, code)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if strings.TrimSpace(line) != "" {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // runSyncDirection runs one sync direction (git verb remote syncRefspec) and

--- a/internal/leaseref/sync_test.go
+++ b/internal/leaseref/sync_test.go
@@ -31,6 +31,9 @@ func (r *syncRec) run(ctx context.Context, dir string, args ...string) (string, 
 	if r.err != nil {
 		return "", -1, r.err
 	}
+	if args[0] == "for-each-ref" {
+		return refPrefix + "seed\n", r.code[args[0]], nil
+	}
 	return "", r.code[args[0]], nil
 }
 
@@ -53,6 +56,7 @@ func TestSyncPushThenFetchExactArgv(t *testing.T) {
 		t.Fatalf("refspec = %q, want %q", res.Refspec, wantRefspec)
 	}
 	want := [][]string{
+		{"for-each-ref", "--format=%(refname)", refPrefix},
 		{"push", "origin", wantRefspec},
 		{"fetch", "origin", wantRefspec},
 	}
@@ -87,8 +91,12 @@ func TestSyncSingleDirection(t *testing.T) {
 			if res.Pushed != tc.wantPushed || res.Fetched != tc.wantFetched {
 				t.Fatalf("got %+v, want pushed=%v fetched=%v", res, tc.wantPushed, tc.wantFetched)
 			}
-			if len(rec.calls) != 1 || rec.calls[0][0] != tc.wantVerb {
-				t.Fatalf("calls = %v, want exactly one %q", rec.calls, tc.wantVerb)
+			wantCalls := 1
+			if tc.push {
+				wantCalls = 2
+			}
+			if len(rec.calls) != wantCalls || rec.calls[len(rec.calls)-1][0] != tc.wantVerb {
+				t.Fatalf("calls = %v, want %q as the final call", rec.calls, tc.wantVerb)
 			}
 		})
 	}
@@ -106,8 +114,8 @@ func TestSyncPushFailureStopsBeforeFetch(t *testing.T) {
 	if res.Pushed || res.Fetched {
 		t.Fatalf("nothing should be marked done after a failed push, got %+v", res)
 	}
-	if len(rec.calls) != 1 || rec.calls[0][0] != "push" {
-		t.Fatalf("calls = %v, want the push only — a failed push must not be followed by a force-fetch", rec.calls)
+	if len(rec.calls) != 2 || rec.calls[0][0] != "for-each-ref" || rec.calls[1][0] != "push" {
+		t.Fatalf("calls = %v, want the ref probe then push only — a failed push must not be followed by a force-fetch", rec.calls)
 	}
 }
 
@@ -213,6 +221,51 @@ func TestSyncQuarantinesMalformedLooseRefAndFetches(t *testing.T) {
 	matches, err := filepath.Glob(filepath.Join(common, "fak", "quarantine", "malformed-lock-refs", "*", "session-bad"))
 	if err != nil || len(matches) != 1 {
 		t.Fatalf("quarantine matches=%v err=%v", matches, err)
+	}
+}
+
+// An empty lease namespace is normal for a fresh clone. Git treats a wildcard
+// push with no matching source refs as an error, so Sync must skip that push
+// rather than turn an otherwise clean convergence tick into a transport failure.
+func TestSyncPushOnlyEmptyNamespaceIsCleanNoOp(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	ctx := context.Background()
+	root := t.TempDir()
+	remote := filepath.Join(root, "remote.git")
+	local := filepath.Join(root, "local")
+	runGit := func(dir string, args ...string) string {
+		t.Helper()
+		cmd := exec.CommandContext(ctx, "git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	runGit(root, "init", "--bare", remote)
+	runGit(root, "init", local)
+	runGit(local, "config", "user.name", "fak-test")
+	runGit(local, "config", "user.email", "fak-test@example.invalid")
+	if err := os.WriteFile(filepath.Join(local, "README"), []byte("seed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(local, "add", "README")
+	runGit(local, "commit", "-m", "seed")
+	runGit(local, "remote", "add", "origin", remote)
+	runGit(local, "push", "origin", "HEAD:main")
+
+	got, err := NewInDir(local).Sync(ctx, "origin", true, false)
+	if err != nil {
+		t.Fatalf("empty lease namespace must be a clean no-op: %v", err)
+	}
+	if got.Pushed {
+		t.Fatalf("empty lease namespace should skip the git push, got %+v", got)
+	}
+	if refs := runGit(local, "for-each-ref", "--format=%(refname)", refPrefix); refs != "" {
+		t.Fatalf("empty lease namespace changed locally: %q", refs)
 	}
 }
 


### PR DESCRIPTION
## What & why

Fixes #5550. `fak leaseref sync --push-only` currently forwards a wildcard push even when the local clone has no `refs/fak/locks/*` refs. Git exits 1 for that zero-match push, so a normal fresh-clone sync is reported as a transport failure. The sync now probes the namespace and skips only the empty push while preserving the existing push-before-fetch ordering when refs exist.

## Evidence

- Added a real bare-remote regression that starts from a valid clone with an empty lease namespace and proves `Sync` is a clean no-op.
- `go test ./internal/leaseref`
- `go build ./internal/leaseref`
- `go vet ./internal/leaseref`
- `git diff --check`

The commit is DCO signed off with `git commit -s`.

## Checklist

- [x] Commits are signed off (`git commit -s`, DCO — see CONTRIBUTING.md)
- [x] The check named under **Evidence** was actually run, output quoted
- [x] Numbers are witnessed; anything simulated is labeled simulated
