### PR TITLE
fix(guard): handle Tailscale SSH remote boundaries

### DIFF
--- a/internal/adjudicator/command_writes.go
+++ b/internal/adjudicator/command_writes.go
@@ -471,10 +471,22 @@ type shellWord struct {
 // negative result means the command is not a structurally understood ssh
 // invocation, so callers conservatively inspect every nested program string.
 func remoteExecPayloadStart(words []shellWord, start int) int {
-	if start < 0 || start >= len(words) || !isSSHExecutable(words[start].text) {
+	if start < 0 || start >= len(words) {
 		return -1
 	}
-	for i := start + 1; i < len(words); i++ {
+	ssh := start
+	if isTailscaleExecutable(words[start].text) {
+		// `tailscale ssh` has the same destination + remote-command boundary as
+		// OpenSSH. Treat only the explicit ssh subcommand this way: other
+		// tailscale operations remain ordinary local commands.
+		if start+1 >= len(words) || !strings.EqualFold(words[start+1].text, "ssh") {
+			return -1
+		}
+		ssh++
+	} else if !isSSHExecutable(words[start].text) {
+		return -1
+	}
+	for i := ssh + 1; i < len(words); i++ {
 		word := words[i].text
 		if word == "--" {
 			if i+1 < len(words) {
@@ -514,6 +526,14 @@ func isSSHExecutable(head string) bool {
 		head = head[slash+1:]
 	}
 	return head == "ssh" || head == "ssh.exe"
+}
+
+func isTailscaleExecutable(head string) bool {
+	head = strings.TrimPrefix(strings.ToLower(head), "./")
+	if slash := strings.LastIndexAny(head, "/\\"); slash >= 0 {
+		head = head[slash+1:]
+	}
+	return head == "tailscale" || head == "tailscale.exe"
 }
 
 func sshOptionTakesValue(option byte) bool {

--- a/internal/adjudicator/command_writes_remote_test.go
+++ b/internal/adjudicator/command_writes_remote_test.go
@@ -25,6 +25,9 @@ func TestSSHRemotePayloadDoesNotNameLocalWriteTargets(t *testing.T) {
 		{"env wrapper", "env ssh node 'cp x internal/abi/x.go'", guarded},
 		{"absolute executable", "/usr/bin/ssh node 'mv x dos.toml'", guarded},
 		{"windows executable", "ssh.exe node 'echo x > .env'", credential},
+		{"tailscale hostname", "tailscale ssh anthony@100.68.66.42 'hostname; test -f ~/.profile'", credential},
+		{"tailscale utc date", "tailscale.exe ssh anthony@100.68.66.42 'hostname; date -u; test -e /etc/hosts'", credential},
+		{"absolute tailscale executable", "/usr/bin/tailscale ssh node 'test -e .git/config'", credential},
 		{"powershell probe", "Test-NetConnection node -Port 22", guarded},
 		{"socket probe", "nc -z node 22", guarded},
 		{"http head mention", "curl --head https://example.invalid/.git/", credential},
@@ -53,6 +56,8 @@ func TestSSHLocalExecutionSurfacesRemainGuarded(t *testing.T) {
 		{"local nested shell", "sh -c 'cp x internal/abi/x.go'", "internal/abi/"},
 		{"plain local copy", "cp x internal/abi/x.go", "internal/abi/"},
 		{"preceding local mutation", "sed -i s/a/b/ internal/abi/x.go && ssh host echo done", "internal/abi/"},
+		{"tailscale outer redirect", "tailscale ssh node 'hostname' > dos.toml", "dos.toml"},
+		{"tailscale preceding local mutation", "cp x internal/abi/x.go && tailscale ssh node hostname", "internal/abi/"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -69,6 +74,8 @@ func TestSSHRemotePayloadBoundaryParsing(t *testing.T) {
 		"ssh -oProxyCommand=none node 'cp x internal/abi/x.go'",
 		"ssh -p22 node 'mv x dos.toml'",
 		"ssh -vv node 'echo x > internal/abi/x.go'",
+		"tailscale ssh node 'test -e .git/config'",
+		"tailscale.exe ssh node 'test -e /etc/hosts'",
 	}
 	for _, cmd := range allowed {
 		if got := commandSelfModify(map[string]any{"command": cmd}, DefaultPolicy().SelfModifyGlobs); got != "" {


### PR DESCRIPTION
## Summary

- recognize `tailscale ssh` and `tailscale.exe ssh` as remote-execution boundaries
- prevent read-only remote path mentions from being classified as local `SELF_MODIFY`
- retain denials for local redirects and mutations surrounding the remote invocation

Fixes anthony-chaudhary/job#251
Fixes anthony-chaudhary/job#252

## Verification

- `go test ./internal/adjudicator -count=1`
- focused SSH classifier regression suite
- `go build ./cmd/fak`
