### PR TITLE
feat(modelreg): add first-class Qwen3.8-27B identities

### DIFF
--- a/docs/supported/qwen38-27b.md
+++ b/docs/supported/qwen38-27b.md
@@ -1,0 +1,72 @@
+# Qwen3.8-27B
+
+Tracking epic: [#8011](https://github.com/anthony-chaudhary/fak/issues/8011)
+
+Qwen3.8-27B is represented by exact built-in model aliases. The aliases are
+launch identities, not a claim that a particular machine has passed acceptance:
+
+| Alias | Exact target | Intended path |
+|---|---|---|
+| `qwen38`, `qwen38:27b` | `hf://unsloth/Qwen3.8-27B-GGUF/Qwen3.8-27B-Q4_K_M.gguf` | portable GGUF on Apple Metal or NVIDIA CUDA |
+| `qwen38:27b-fp8` | `hf://Qwen/Qwen3.8-27B-FP8` | A100-class upstream engine (for example vLLM) |
+
+The upstream model advertises `Qwen3_5ForConditionalGeneration` / `qwen3_5`:
+64 decoder layers, hidden size 5120, 24 attention heads, 4 KV heads, a 3:1
+GDN/full-attention cadence, and a 262144-token configured context. It also has a
+vision tower. Existing Qwen3.5 architecture compatibility is therefore relevant,
+but does **not** replace exact Qwen3.8 acceptance.
+
+## Resolve and inspect
+
+```console
+fak model ls
+fak model load qwen38:27b
+```
+
+`model load` downloads the exact GGUF and verifies its Hugging Face LFS digest.
+The Q4_K_M file is large; check free disk and memory before pulling it.
+
+## MacBook Metal candidate
+
+On an Apple-Silicon MacBook with enough unified memory:
+
+```console
+fak model pull qwen38:27b
+fak serve --gguf qwen38:27b --model qwen38:27b --metal
+```
+
+`--metal` is required for the prove-out so an unavailable Metal path fails
+closed rather than producing a misleading CPU result. Record the exact fak
+commit, macOS/SoC/RAM, resolved file SHA-256, load time, peak memory, TTFT,
+prefill/decode throughput, and the raw exact-model acceptance report.
+
+## A100 CUDA candidates
+
+Portable GGUF parity:
+
+```console
+fak model pull qwen38:27b
+fak serve --gguf qwen38:27b --model qwen38:27b --backend cuda
+```
+
+Official FP8 through an upstream engine:
+
+```console
+# Start the supported upstream engine with Qwen/Qwen3.8-27B-FP8, preserving
+# that exact served model ID, then point fak at its OpenAI-compatible endpoint.
+fak serve --base-url http://127.0.0.1:8000/v1 --model qwen38:27b-fp8
+```
+
+Record A100 SKU (40/80 GB), count/topology, driver/CUDA versions, tensor
+parallelism, per-rank peak memory, and evidence that CUDA—not CPU fallback—ran
+the campaign.
+
+## Promotion rule
+
+An alias appearing in `fak model ls` means it is discoverable and exact. It is
+not proof of hardware readiness. Promotion requires immutable reports for the
+exact resolved revision/hash covering deterministic text, structured JSON, a
+correlated tool call, and performance/resource telemetry. Fold those reports
+with `fak model acceptance-gate` and join them using
+`fak model readiness-inventory`. Missing MacBook or A100 evidence is `HOLD`, not
+an inferred pass.

--- a/internal/modelreg/modelreg.go
+++ b/internal/modelreg/modelreg.go
@@ -95,6 +95,12 @@ var Catalog = map[string]string{
 	"qwen2.5-coder:1.5b": "hf://bartowski/Qwen2.5-Coder-1.5B-Instruct-GGUF/Qwen2.5-Coder-1.5B-Instruct-Q4_K_M.gguf",
 	"qwen2.5-coder:3b":   "hf://bartowski/Qwen2.5-Coder-3B-Instruct-GGUF/Qwen2.5-Coder-3B-Instruct-Q4_K_M.gguf",
 	"qwen2.5-coder:7b":   "hf://bartowski/Qwen2.5-Coder-7B-Instruct-GGUF/Qwen2.5-Coder-7B-Instruct-Q4_K_M.gguf",
+	// Qwen3.8-27B is a dense multimodal hybrid (GDN + full attention).
+	// Q4_K_M is the portable default for Metal and CUDA prove-outs; the
+	// official FP8 checkpoint is exposed separately for A100-class engines.
+	"qwen38":         "hf://unsloth/Qwen3.8-27B-GGUF/Qwen3.8-27B-Q4_K_M.gguf",
+	"qwen38:27b":     "hf://unsloth/Qwen3.8-27B-GGUF/Qwen3.8-27B-Q4_K_M.gguf",
+	"qwen38:27b-fp8": "hf://Qwen/Qwen3.8-27B-FP8",
 	// Ornith 1.0 — DeepReinforce's MIT-licensed Qwen3.5-family agentic-coding models
 	// (released 2026-06-25, HF org deepreinforce-ai; the collection is exactly 7 public
 	// repos — 9B/35B/397B + GGUF/FP8 siblings, NO 31B). Bare "ornith" and "ornith:9b-gguf"
@@ -126,6 +132,9 @@ var codingAliases = map[string]bool{
 	"qwen2.5-coder:1.5b": true,
 	"qwen2.5-coder:3b":   true,
 	"qwen2.5-coder:7b":   true,
+	"qwen38":             true,
+	"qwen38:27b":         true,
+	"qwen38:27b-fp8":     true,
 }
 
 // DefaultLocalCodingAlias is the model `fak guard --local`/`--gguf` picks when the user

--- a/internal/modelreg/modelreg_test.go
+++ b/internal/modelreg/modelreg_test.go
@@ -282,3 +282,21 @@ func writeRegistry(t *testing.T, dir string, m map[string]string) {
 		t.Fatal(err)
 	}
 }
+
+func TestEmbeddedQwen38Aliases(t *testing.T) {
+	want := map[string]string{
+		"qwen38":         "hf://unsloth/Qwen3.8-27B-GGUF/Qwen3.8-27B-Q4_K_M.gguf",
+		"qwen38:27b":     "hf://unsloth/Qwen3.8-27B-GGUF/Qwen3.8-27B-Q4_K_M.gguf",
+		"qwen38:27b-fp8": "hf://Qwen/Qwen3.8-27B-FP8",
+	}
+	for alias, target := range want {
+		t.Run(alias, func(t *testing.T) {
+			if got := Catalog[alias]; got != target {
+				t.Fatalf("Catalog[%q] = %q, want %q", alias, got, target)
+			}
+			if !IsCoding(alias) {
+				t.Fatalf("Qwen3.8 alias %q must be marked coding-capable", alias)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- adds exact built-in `qwen38`, `qwen38:27b`, and `qwen38:27b-fp8` model identities
- marks them coding/tool capable in model inventory
- documents fail-closed Metal GGUF, A100 CUDA GGUF, and A100 FP8 prove-out recipes
- explicitly separates discoverability from hardware acceptance

Tracks #8011.

## Evidence

- `go test ./internal/modelreg ./internal/ggufload ./internal/compute`
- `go test ./cmd/fak -run 'Test.*(Model|Comput|Backend|Serve)' -count=1`
- built CLI reports all three aliases with exact targets and coding capability

## Hardware status

No MacBook/A100 pass is claimed by this PR. #8011 defines the immutable exact-ID reports and cross-hardware promotion gate. Until those reports exist, readiness remains HOLD.