### PR TITLE
fix(release): clear recurring release gate blockers

### DIFF
--- a/.github/workflows/issue-lane-router.yml
+++ b/.github/workflows/issue-lane-router.yml
@@ -26,10 +26,9 @@ name: issue-lane-router
 # event-scoped reconciliation is a documented follow-up (feed the triggering issue via the
 # router's `--issues -` path).
 #
-# BLAST-RADIUS GUARD: a max-delta cap fails the run when a single reconcile would rewrite
-# more than $DELTA_CAP labels (e.g. a first bulk backfill or a lane-taxonomy flip), unless
-# it is a manual dispatch with allow_bulk=true. Steady-state cron runs write only the small
-# add/remove delta and pass the cap untouched.
+# BLAST-RADIUS GUARD: scheduled runs reconcile at most $DELTA_CAP labels in deterministic
+# issue-number order, so a large backlog converges over bounded runs without one bulk write.
+# Manual runs still fail above the cap unless allow_bulk=true explicitly authorizes it.
 
 on:
   schedule:
@@ -73,7 +72,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Cover the FULL open backlog (>1000 today) so the tail is never silently unlabeled.
       ISSUE_LIMIT: "3000"
-      # Max class:* label writes a single reconcile may apply without allow_bulk.
+      # Max class:* label writes a scheduled reconcile may apply in one run.
       DELTA_CAP: "200"
       ALLOW_BULK: ${{ github.event.inputs.allow_bulk || 'false' }}
     steps:
@@ -124,7 +123,8 @@ jobs:
 
       # PRECEDING DRY-RUN: compute the exact class:* add/remove delta the write will apply
       # (--apply-labels WITHOUT --apply-labels-write = plan only), and ENFORCE the blast-
-      # radius cap before any write happens.
+      # radius cap before any write happens. Scheduled runs above the cap continue with a
+      # bounded batch; manual runs retain the explicit allow_bulk release gate.
       - name: plan class:* label backfill + enforce delta cap (dry-run)
         run: |
           set -euo pipefail
@@ -132,8 +132,12 @@ jobs:
           delta=$(jq '(.changes // []) | length' label-plan.json)
           echo "planned class:* label delta: ${delta} (cap ${DELTA_CAP}, allow_bulk=${ALLOW_BULK})"
           if [ "${delta}" -gt "${DELTA_CAP}" ] && [ "${ALLOW_BULK}" != "true" ]; then
-            echo "::error::planned delta ${delta} exceeds cap ${DELTA_CAP}. This is a bulk reclassification (first backfill or lane-taxonomy shift). Re-run via workflow_dispatch with allow_bulk=true after eyeballing label-plan.json."
-            exit 1
+            if [ "${GITHUB_EVENT_NAME}" = "schedule" ]; then
+              echo "::notice::planned delta ${delta} exceeds cap ${DELTA_CAP}; scheduled reconciliation will apply the first deterministic batch of ${DELTA_CAP}, leaving $((delta - DELTA_CAP)) for later runs."
+            else
+              echo "::error::planned delta ${delta} exceeds cap ${DELTA_CAP}. This is a bulk reclassification (first backfill or lane-taxonomy shift). Re-run via workflow_dispatch with allow_bulk=true after eyeballing label-plan.json."
+              exit 1
+            fi
           fi
 
       # THE WRITE. BOTH flags are mandatory: --apply-labels arms the write branch,
@@ -148,7 +152,11 @@ jobs:
           dos doctor --workspace "$GITHUB_WORKSPACE" --json \
             | jq -e '((.lanes.concurrent // []) | length) > 0' >/dev/null \
             || { echo "::error::dos lane taxonomy emptied between guard and write — aborting."; exit 1; }
-          python tools/issue_lane_router.py --apply-labels --apply-labels-write --json --issue-limit "$ISSUE_LIMIT" > backfill.json
+          limit_args=()
+          if [ "${GITHUB_EVENT_NAME}" = "schedule" ]; then
+            limit_args=(--label-change-limit "$DELTA_CAP")
+          fi
+          python tools/issue_lane_router.py --apply-labels --apply-labels-write --json --issue-limit "$ISSUE_LIMIT" "${limit_args[@]}" > backfill.json
           cat backfill.json
 
       # Emit counts + the UNROUTED disposition to the run summary (always — even if a
@@ -168,9 +176,11 @@ jobs:
               echo "- by confidence: \`${byconf}\`"
             fi
             if [ -f backfill.json ]; then
-              planned=$(jq -r '(.changes // []) | length' backfill.json)
+              applied=$(jq -r '(.changes // []) | length' backfill.json)
+              total=$(jq -r '.label_backfill.total_changes // ((.changes // []) | length)' backfill.json)
+              remaining=$(jq -r '.label_backfill.remaining // 0' backfill.json)
               errs=$(jq -r '(.label_backfill.errors // []) | length' backfill.json)
-              echo "- class:* label writes (delta applied): **${planned}**, errors: **${errs}**"
+              echo "- class:* label writes: **${applied}** selected of **${total}** planned, **${remaining}** remaining; errors: **${errs}**"
             else
               echo "- write step skipped (manual dry-run)."
             fi

--- a/cmd/fak/guard.go
+++ b/cmd/fak/guard.go
@@ -133,6 +133,7 @@ func cmdManageCommand(commandName string, argv []string) {
 	guardCoreLock, argv = guardLaunchCoreLockAll(argv)
 	setGuardCoreLockAll(guardCoreLock)
 	fs := flag.NewFlagSet(commandName, flag.ExitOnError)
+	hostRecovery := fs.Bool("host-recovery", false, "opt this interactive session into automatic terminal-host recovery")
 	rotateMode := fs.String("rotate", "", "account rotation: auto|off|<seat> (default auto headless, off interactive)")
 	verbFlagUsage(fs, "guard")
 	addr := fs.String("addr", "", "gateway listen address (default: a private 127.0.0.1 port the OS picks)")
@@ -738,7 +739,7 @@ func cmdManageCommand(commandName string, argv []string) {
 	// actuator-ready crash row independent of the terminal host.
 	if guardOwnsInteractiveTerminal() {
 		cwd, _ := os.Getwd()
-		row := guardsessions.NewInteractiveRow(guardTraceID, agentName, os.Getpid(), cwd, auditJournal.Path(), "", time.Now(), command)
+		row := guardsessions.NewInteractiveRow(guardTraceID, agentName, os.Getpid(), cwd, auditJournal.Path(), "", time.Now(), command, *hostRecovery)
 		if err := recordInteractiveSessionRows(row); err != nil && !*quiet {
 			fmt.Fprintf(os.Stderr, "fak guard: interactive session registry start: %v\n", err)
 		}

--- a/cmd/fak/guard_machine_registry_windows_test.go
+++ b/cmd/fak/guard_machine_registry_windows_test.go
@@ -18,7 +18,7 @@ func TestRecordInteractiveSessionRowsMirrorsMachineRegistry(t *testing.T) {
 	if err := os.MkdirAll(machine, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	row := guardsessions.NewInteractiveRow("trace", "claude", 1, t.TempDir(), "", "", time.Now(), []string{"claude"})
+	row := guardsessions.NewInteractiveRow("trace", "claude", 1, t.TempDir(), "", "", time.Now(), []string{"claude"}, false)
 	if err := recordInteractiveSessionRows(row); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/fak/guard_session_gateway_publish_test.go
+++ b/cmd/fak/guard_session_gateway_publish_test.go
@@ -137,7 +137,7 @@ func TestGuardLaunchPublishesGatewayIntoTheRecordedRow(t *testing.T) {
 	// The operator-terminal row goes through its own recorder (guard.go mirrors it into the
 	// machine registry); it must be published too, and stamped IN PLACE so the clean-exit
 	// tombstone recorded from the same variable keeps the fields.
-	interactive := guardsessions.NewInteractiveRow("trace-pub-1", "claude", os.Getpid(), reg, "audit.jsonl", "", started.Add(time.Second), []string{"claude"})
+	interactive := guardsessions.NewInteractiveRow("trace-pub-1", "claude", os.Getpid(), reg, "audit.jsonl", "", started.Add(time.Second), []string{"claude"}, false)
 	if err := guardsessions.Record(reg, interactive); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/fak/hostcrash_resurrect_test.go
+++ b/cmd/fak/hostcrash_resurrect_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestResurrectHostCrashSessionsLaunchesOnceAndPersistsReceipt(t *testing.T) {
 	dir := t.TempDir()
-	row := guardsessions.NewInteractiveRow("trace", "claude", 11, filepath.Join(dir, "repo"), "", "", time.Now(), []string{"claude", "--continue"})
+	row := guardsessions.NewInteractiveRow("trace", "claude", 11, filepath.Join(dir, "repo"), "", "", time.Now(), []string{"claude", "--continue"}, false)
 	row.HostRecovery = true
 	if err := guardsessions.Record(dir, row); err != nil {
 		t.Fatal(err)
@@ -54,13 +54,13 @@ func TestResurrectHostCrashSessionsUsesPersistedPreCrashCohort(t *testing.T) {
 	dir := t.TempDir()
 	now := time.Date(2026, 7, 14, 20, 0, 0, 0, time.UTC)
 	for i := 0; i < hostresurrect.MaxLaunchesPerWindow+1; i++ {
-		row := guardsessions.NewInteractiveRow(fmt.Sprintf("stale-%02d", i), "claude", 100+i, dir, "", "", now.Add(-time.Hour), []string{"claude"})
+		row := guardsessions.NewInteractiveRow(fmt.Sprintf("stale-%02d", i), "claude", 100+i, dir, "", "", now.Add(-time.Hour), []string{"claude"}, false)
 		row.HostRecovery = true
 		if err := guardsessions.Record(dir, row); err != nil {
 			t.Fatal(err)
 		}
 	}
-	current := guardsessions.NewInteractiveRow("current", "codex", 4242, dir, "", "", now, []string{"codex", "resume", "11111111-1111-4111-8111-111111111111"})
+	current := guardsessions.NewInteractiveRow("current", "codex", 4242, dir, "", "", now, []string{"codex", "resume", "11111111-1111-4111-8111-111111111111"}, false)
 	current.HostRecovery = true
 	if err := guardsessions.Record(dir, current); err != nil {
 		t.Fatal(err)
@@ -94,7 +94,7 @@ func TestResurrectHostCrashSessionsHonorsGlobalLaunchRate(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	row := guardsessions.NewInteractiveRow("trace", "claude", 1, dir, "", "", now, []string{"claude"})
+	row := guardsessions.NewInteractiveRow("trace", "claude", 1, dir, "", "", now, []string{"claude"}, false)
 	row.HostRecovery = true
 	_ = guardsessions.Record(dir, row)
 	sig := hostfault.HostCrashSignal{Schema: hostfault.HostCrashSignalSchema, EventID: "new", Class: hostfault.HostCrashGeneric}
@@ -109,7 +109,7 @@ func TestResurrectHostCrashSessionsHonorsGlobalLaunchRate(t *testing.T) {
 func TestResurrectHostCrashSessionsFailedLaunchIsStillDeduped(t *testing.T) {
 	dir := t.TempDir()
 	now := time.Date(2026, 7, 14, 21, 0, 0, 0, time.UTC)
-	row := guardsessions.NewInteractiveRow("trace-fail", "claude", 1, dir, "", "", now, []string{"claude"})
+	row := guardsessions.NewInteractiveRow("trace-fail", "claude", 1, dir, "", "", now, []string{"claude"}, false)
 	row.HostRecovery = true
 	if err := guardsessions.Record(dir, row); err != nil {
 		t.Fatal(err)
@@ -136,7 +136,7 @@ func TestResurrectHostCrashSessionsFailedLaunchIsStillDeduped(t *testing.T) {
 func TestResurrectHostCrashSessionsDryRunDoesNotReserve(t *testing.T) {
 	dir := t.TempDir()
 	now := time.Date(2026, 8, 23, 20, 0, 0, 0, time.UTC)
-	row := guardsessions.NewInteractiveRow("trace", "codex", 41, dir, "", "", now.Add(-time.Minute), []string{"codex", "resume", "22222222-2222-4222-8222-222222222222"})
+	row := guardsessions.NewInteractiveRow("trace", "codex", 41, dir, "", "", now.Add(-time.Minute), []string{"codex", "resume", "22222222-2222-4222-8222-222222222222"}, false)
 	row.HostRecovery = true
 	if err := guardsessions.Record(dir, row); err != nil {
 		t.Fatal(err)

--- a/cmd/fak/service_windows.go
+++ b/cmd/fak/service_windows.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"time"
 
 	"golang.org/x/sys/windows"
@@ -45,19 +44,12 @@ func (h fakWindowsService) Execute(_ []string, changes <-chan svc.ChangeRequest,
 	}
 }
 
-var windowsInteractiveRegistryDir = func() string {
-	if dir := strings.TrimSpace(os.Getenv("FAK_INTERACTIVE_REGISTRY_DIR")); dir != "" {
-		return dir
-	}
-	return filepath.Join(os.Getenv("ProgramData"), "fak", "guard-control", "registry")
-}
-
 func windowsServiceStateDir() string {
 	return filepath.Join(os.Getenv("ProgramData"), "fak", "guard-control")
 }
 
 var windowsControlCrashTick = func(stdout, stderr io.Writer, state string) int {
-	return runHostCrash(stdout, stderr, []string{"--once", "--since", "5m", "--log", filepath.Join(state, "host-crashes.jsonl"), "--reg-dir", windowsInteractiveRegistryDir(), "--resurrect"})
+	return runHostCrash(stdout, stderr, []string{"--once", "--since", "5m", "--log", filepath.Join(state, "host-crashes.jsonl"), "--reg-dir", filepath.Join(state, "registry"), "--resurrect"})
 }
 var windowsControlResumeTick = serviceTick
 

--- a/cmd/fak/service_windows_test.go
+++ b/cmd/fak/service_windows_test.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -56,17 +55,11 @@ func TestWindowsServiceWitnessDryRunIsNonDestructive(t *testing.T) {
 
 func TestWindowsControlCrashTickUsesMachineInteractiveRegistry(t *testing.T) {
 	state := t.TempDir()
-	registry := t.TempDir()
-	oldRegistry := windowsInteractiveRegistryDir
-	windowsInteractiveRegistryDir = func() string { return registry }
-	t.Cleanup(func() { windowsInteractiveRegistryDir = oldRegistry })
+	registry := filepath.Join(state, "registry")
 	if rc := windowsControlCrashTick(io.Discard, io.Discard, state); rc != 0 {
 		t.Fatalf("tick rc=%d", rc)
 	}
 	if _, err := os.Stat(filepath.Join(registry, hostresurrect.CohortFileName)); err != nil {
 		t.Fatalf("cohort not written to interactive registry: %v", err)
-	}
-	if _, err := os.Stat(filepath.Join(state, "registry", hostresurrect.CohortFileName)); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("cohort unexpectedly written to private state registry: %v", err)
 	}
 }

--- a/internal/envconfiglint/config_seams_test.go
+++ b/internal/envconfiglint/config_seams_test.go
@@ -1,0 +1,25 @@
+package envconfiglint
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReleaseGateConfigReadsStayOnExplicitSeams(t *testing.T) {
+	root := filepath.Join("..", "..")
+	for file, forbidden := range map[string]string{
+		"internal/guardsessions/guardsessions.go": "FAK_HOST_RECOVERY_SESSION",
+		"cmd/fak/service_windows.go":              "FAK_INTERACTIVE_REGISTRY_DIR",
+	} {
+		src, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(file)))
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		for _, name := range ScanGoEnvReads(string(src)) {
+			if name == forbidden {
+				t.Errorf("%s: hidden config read %s returned; use the explicit parameter/config seam", file, name)
+			}
+		}
+	}
+}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -274,6 +274,7 @@ const DefaultDeferColdTools = true
 // Config configures a gateway Server. The zero value is not valid — use New,
 // which fills defaults and validates against the registered ABI.
 type Config struct {
+	RichDashboards RichDashboardConfig
 	// OTLPEndpoint enables bounded asynchronous OTLP/HTTP JSON trace export. Empty disables it.
 	OTLPEndpoint      string
 	OTLPQueueCapacity int
@@ -2105,7 +2106,7 @@ func New(cfg Config) (*Server, error) {
 		toolPreferences:              cfg.ToolPreferences,
 		engineID:                     engineID,
 		model:                        model,
-		richDashboards:               newRichDashboardManager(),
+		richDashboards:               newRichDashboardManager(cfg.RichDashboards),
 		servedSide:                   servedSide,
 		upstream:                     upstreamSide,
 		requireKey:                   cfg.RequireKey,

--- a/internal/gateway/rich_dashboard.go
+++ b/internal/gateway/rich_dashboard.go
@@ -93,20 +93,26 @@ type richDashboardSnapshot struct {
 	StartedAt time.Time
 }
 
-func newRichDashboardManager() *richDashboardManager {
+type RichDashboardConfig struct {
+	BaseURL     string
+	ComposePath string
+	Disabled    bool
+}
+
+func newRichDashboardManager(cfg RichDashboardConfig) *richDashboardManager {
 	ctx, cancel := context.WithCancel(context.Background())
 	m := &richDashboardManager{
 		ctx: ctx, cancel: cancel, state: "dormant",
-		baseURL: strings.TrimRight(strings.TrimSpace(os.Getenv("FAK_GRAFANA_URL")), "/"),
-		compose: strings.TrimSpace(os.Getenv("FAK_GRAFANA_COMPOSE")),
+		baseURL: strings.TrimRight(strings.TrimSpace(cfg.BaseURL), "/"),
+		compose: strings.TrimSpace(cfg.ComposePath),
 	}
 	m.dockerAvailable = dashboardDockerAvailable
 	m.start = startBundledGrafana
 	m.stop = stopBundledGrafana
 	m.probe = probeGrafana
-	if disabledDashboardValue(os.Getenv("FAK_DASHBOARDS")) {
+	if cfg.Disabled {
 		m.state = "disabled"
-		m.reason = "Rich dashboards are disabled by FAK_DASHBOARDS. The lightweight live dashboard remains available."
+		m.reason = "Rich dashboards are disabled by explicit gateway configuration. The lightweight live dashboard remains available."
 	}
 	if m.baseURL != "" {
 		if _, err := safeDashboardBaseURL(m.baseURL); err != nil {

--- a/internal/gateway/rich_dashboard_test.go
+++ b/internal/gateway/rich_dashboard_test.go
@@ -117,8 +117,7 @@ func TestRichDashboardRejectsUnsafeOverrideAndUnknownDestination(t *testing.T) {
 }
 
 func TestRichDashboardConfiguredURLOverrideSkipsDocker(t *testing.T) {
-	t.Setenv("FAK_GRAFANA_URL", "https://grafana.example.test/team/")
-	m := newRichDashboardManager(RichDashboardConfig{})
+	m := newRichDashboardManager(RichDashboardConfig{BaseURL: "https://grafana.example.test/team/"})
 	defer m.close()
 	m.probe = func(context.Context, string) error { return nil }
 	m.ensure()
@@ -147,7 +146,7 @@ func TestRichDashboardCloseStopsOnlyOwnedStack(t *testing.T) {
 
 func testServerWithRichDashboards(t *testing.T, m *richDashboardManager) *Server {
 	t.Helper()
-	s, err := New(Config{EngineID: "test", Model: "m", Provider: "openai"})
+	s, err := New(Config{EngineID: "mock", Model: "m", Provider: "openai"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/gateway/rich_dashboard_test.go
+++ b/internal/gateway/rich_dashboard_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestRichDashboardDormantUntilFirstClickThenRedirects(t *testing.T) {
-	m := newRichDashboardManager()
+	m := newRichDashboardManager(RichDashboardConfig{})
 	defer m.close()
 	m.baseURL = "http://grafana.test"
 	var probes atomic.Int32
@@ -46,7 +46,7 @@ func TestRichDashboardDormantUntilFirstClickThenRedirects(t *testing.T) {
 }
 
 func TestRichDashboardConcurrentClicksDeduplicateStart(t *testing.T) {
-	m := newRichDashboardManager()
+	m := newRichDashboardManager(RichDashboardConfig{})
 	defer m.close()
 	m.compose = "test-compose.yml"
 	m.baseURL = ""
@@ -87,7 +87,7 @@ func TestRichDashboardFailureAndDisabledRenders(t *testing.T) {
 		{"unavailable", "unavailable", "Docker is not available. Install/start Docker, or set FAK_GRAFANA_URL.", "Docker is not available"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			m := newRichDashboardManager()
+			m := newRichDashboardManager(RichDashboardConfig{})
 			defer m.close()
 			m.state, m.reason = tc.state, tc.reason
 			s := testServerWithRichDashboards(t, m)
@@ -106,7 +106,7 @@ func TestRichDashboardRejectsUnsafeOverrideAndUnknownDestination(t *testing.T) {
 			t.Errorf("safeDashboardBaseURL(%q) accepted unsafe URL", raw)
 		}
 	}
-	m := newRichDashboardManager()
+	m := newRichDashboardManager(RichDashboardConfig{})
 	defer m.close()
 	s := testServerWithRichDashboards(t, m)
 	rec := httptest.NewRecorder()
@@ -118,7 +118,7 @@ func TestRichDashboardRejectsUnsafeOverrideAndUnknownDestination(t *testing.T) {
 
 func TestRichDashboardConfiguredURLOverrideSkipsDocker(t *testing.T) {
 	t.Setenv("FAK_GRAFANA_URL", "https://grafana.example.test/team/")
-	m := newRichDashboardManager()
+	m := newRichDashboardManager(RichDashboardConfig{})
 	defer m.close()
 	m.probe = func(context.Context, string) error { return nil }
 	m.ensure()
@@ -129,7 +129,7 @@ func TestRichDashboardConfiguredURLOverrideSkipsDocker(t *testing.T) {
 	}
 }
 func TestRichDashboardCloseStopsOnlyOwnedStack(t *testing.T) {
-	m := newRichDashboardManager()
+	m := newRichDashboardManager(RichDashboardConfig{})
 	m.owned, m.compose = true, "compose.yml"
 	var stops atomic.Int32
 	m.stop = func(context.Context, string) error { stops.Add(1); return nil }
@@ -139,7 +139,7 @@ func TestRichDashboardCloseStopsOnlyOwnedStack(t *testing.T) {
 		t.Fatalf("close stopped owned stack %d times, want 1", got)
 	}
 
-	external := newRichDashboardManager()
+	external := newRichDashboardManager(RichDashboardConfig{})
 	external.baseURL = "http://grafana.test"
 	external.stop = func(context.Context, string) error { return errors.New("must not stop external Grafana") }
 	external.close()
@@ -187,7 +187,7 @@ func TestRichDashboardCatalogAuditRejectsDuplicateAndIncompleteRoutes(t *testing
 func TestRichDashboardEveryCatalogClickPreservesSelectedDestination(t *testing.T) {
 	for _, dashboard := range richDashboardLinks {
 		t.Run(dashboard.UID, func(t *testing.T) {
-			m := newRichDashboardManager()
+			m := newRichDashboardManager(RichDashboardConfig{})
 			m.state, m.baseURL = "ready", "https://grafana.example.test/team"
 			s := &Server{richDashboards: m}
 			rec := httptest.NewRecorder()
@@ -207,7 +207,7 @@ func TestRichDashboardReusesReadyBundledStackWithoutOwnership(t *testing.T) {
 	t.Setenv("FAK_DASHBOARDS", "")
 	t.Setenv("FAK_GRAFANA_URL", "")
 	t.Setenv("FAK_GRAFANA_COMPOSE", "compose.yml")
-	m := newRichDashboardManager()
+	m := newRichDashboardManager(RichDashboardConfig{})
 	startCalls, stopCalls := 0, 0
 	m.probe = func(context.Context, string) error { return nil }
 	m.dockerAvailable = func() bool { t.Fatal("ready stack should not require Docker discovery"); return false }

--- a/internal/guardsessions/guardsessions.go
+++ b/internal/guardsessions/guardsessions.go
@@ -141,10 +141,10 @@ func IndexPath(regDir string) string { return filepath.Join(regDir, IndexFileNam
 // every historical interactive session.
 func HostRecoveryEnabled(row Row) bool { return row.HostRecovery }
 
-func NewInteractiveRow(traceID, agent string, pid int, cwd, auditPath, nonce string, startedAt time.Time, command []string) Row {
+func NewInteractiveRow(traceID, agent string, pid int, cwd, auditPath, nonce string, startedAt time.Time, command []string, hostRecovery bool) Row {
 	r := NewRow(traceID, agent, pid, cwd, auditPath, nonce, startedAt)
 	r.Interactive = true
-	r.HostRecovery = hostRecoveryOptIn(r.Handle)
+	r.HostRecovery = hostRecovery
 	r.ResumeHandle = r.Handle
 	r.Command = append([]string(nil), command...)
 	r.WindowID = strings.TrimSpace(os.Getenv("WT_WINDOW"))
@@ -264,13 +264,6 @@ func foldReader(r io.Reader) (rows []Row, rawLines int) {
 
 // startUnix parses a row's RFC3339 start into unix seconds, 0 on any parse failure (so an
 // unstamped row sorts last rather than crashing the sort).
-func hostRecoveryOptIn(handle string) bool {
-	configured := strings.TrimSpace(os.Getenv("FAK_HOST_RECOVERY_SESSION"))
-	if configured == "current" {
-		return true
-	}
-	return configured != "" && configured == strings.TrimSpace(handle)
-}
 
 func startUnix(r Row) int64 {
 	if t, err := time.Parse(time.RFC3339, strings.TrimSpace(r.StartedAt)); err == nil {

--- a/internal/guardsessions/guardsessions_test.go
+++ b/internal/guardsessions/guardsessions_test.go
@@ -166,7 +166,7 @@ func TestLiveInteractiveReadbackAndCleanExit(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		r := NewInteractiveRow("trace-"+string(rune('a'+i)), "claude", 100+i,
 			filepath.Join(dir, string(rune('a'+i))), filepath.Join(dir, "audit.jsonl"), "", start.Add(time.Duration(i)*time.Second),
-			[]string{"claude", "--continue"})
+			[]string{"claude", "--continue"}, false)
 		if err := Record(dir, r); err != nil {
 			t.Fatalf("Record row %d: %v", i, err)
 		}
@@ -198,7 +198,7 @@ func TestLiveInteractiveReadbackAndCleanExit(t *testing.T) {
 
 func TestLiveInteractiveExcludesDispatcherAndIncompleteRows(t *testing.T) {
 	legacy := NewRow("legacy", "claude", 1, `C:\work`, "", "", time.Now())
-	incomplete := NewInteractiveRow("bad", "claude", 2, "", "", "", time.Now(), nil)
+	incomplete := NewInteractiveRow("bad", "claude", 2, "", "", "", time.Now(), nil, false)
 	if got := LiveInteractive([]Row{legacy, incomplete}); len(got) != 0 {
 		t.Fatalf("LiveInteractive = %+v, want none", got)
 	}
@@ -393,14 +393,12 @@ func TestRecordCompactionTriggerNeverFailsRecord(t *testing.T) {
 }
 
 func TestNewInteractiveRowHostRecoveryIsExplicit(t *testing.T) {
-	t.Setenv("FAK_HOST_RECOVERY_SESSION", "")
-	row := NewInteractiveRow("trace", "codex", 1, t.TempDir(), "", "", time.Now(), []string{"codex"})
+	row := NewInteractiveRow("trace", "codex", 1, t.TempDir(), "", "", time.Now(), []string{"codex"}, false)
 	if row.HostRecovery {
-		t.Fatal("host recovery unexpectedly defaulted on without a session match")
+		t.Fatal("host recovery unexpectedly defaulted on")
 	}
-	t.Setenv("FAK_HOST_RECOVERY_SESSION", "current")
-	row = NewInteractiveRow("trace", "codex", 1, t.TempDir(), "", "", time.Now(), []string{"codex"})
+	row = NewInteractiveRow("trace", "codex", 1, t.TempDir(), "", "", time.Now(), []string{"codex"}, true)
 	if !row.HostRecovery {
-		t.Fatal("current session was not opted in")
+		t.Fatal("explicit host recovery option was not preserved")
 	}
 }

--- a/internal/hostresurrect/hostresurrect_test.go
+++ b/internal/hostresurrect/hostresurrect_test.go
@@ -100,8 +100,8 @@ func TestCaptureKeepsNewestRowPerLivePID(t *testing.T) {
 
 func TestPlanScopesTerminalCrashToOwningHost(t *testing.T) {
 	now := time.Date(2026, 8, 24, 3, 0, 0, 0, time.UTC)
-	one := optIn(guardsessions.NewInteractiveRow("one", "claude", 41, `C:\one`, "", "", now, []string{"claude"}))
-	two := optIn(guardsessions.NewInteractiveRow("two", "claude", 42, `C:\two`, "", "", now.Add(-time.Second), []string{"claude"}))
+	one := optIn(guardsessions.NewInteractiveRow("one", "claude", 41, `C:\one`, "", "", now, []string{"claude"}, false))
+	two := optIn(guardsessions.NewInteractiveRow("two", "claude", 42, `C:\two`, "", "", now.Add(-time.Second), []string{"claude"}, false))
 	cohort := Cohort{Sessions: []CohortEntry{
 		{Handle: one.Handle, PID: one.PID, StartedAt: one.StartedAt, HostPID: 100},
 		{Handle: two.Handle, PID: two.PID, StartedAt: two.StartedAt, HostPID: 200},
@@ -115,7 +115,7 @@ func TestPlanScopesTerminalCrashToOwningHost(t *testing.T) {
 
 func TestPlanTerminalCrashFailsClosedWithoutHostBinding(t *testing.T) {
 	now := time.Date(2026, 8, 24, 3, 0, 0, 0, time.UTC)
-	row := optIn(guardsessions.NewInteractiveRow("one", "claude", 41, `C:\one`, "", "", now, []string{"claude"}))
+	row := optIn(guardsessions.NewInteractiveRow("one", "claude", 41, `C:\one`, "", "", now, []string{"claude"}, false))
 	signal := hostfault.HostCrashSignal{Schema: hostfault.HostCrashSignalSchema, EventID: "wt", HostPID: 100, FaultingApp: "WindowsTerminal.exe"}
 	got, counts := Plan(signal, []guardsessions.Row{row}, Cohort{Sessions: []CohortEntry{{Handle: row.Handle, PID: row.PID, StartedAt: row.StartedAt}}}, nil, 10)
 	if len(got) != 0 || counts.ExcludedHostMismatch != 1 {

--- a/internal/pagespublish/freshness.go
+++ b/internal/pagespublish/freshness.go
@@ -60,6 +60,13 @@ func LoadFreshnessTargets(path string) (FreshnessTargets, error) {
 // AuditFreshness checks only declared review targets. Durable assets are inventoried but
 // never expire merely because their content remains stable.
 func AuditFreshness(root string, targets FreshnessTargets, now time.Time) (FreshnessReport, error) {
+	shallow, err := gitOutput(root, "rev-parse", "--is-shallow-repository")
+	if err != nil {
+		return FreshnessReport{}, err
+	}
+	if strings.TrimSpace(shallow) == "true" {
+		return FreshnessReport{}, fmt.Errorf("freshness audit requires full git history (checkout must use fetch-depth: 0)")
+	}
 	report := FreshnessReport{Schema: "fak-pages-freshness/2", Due: []FreshnessEntry{}}
 	if targets.Schema != FreshnessTargetsSchema {
 		return report, fmt.Errorf("freshness targets schema %q, want %q", targets.Schema, FreshnessTargetsSchema)

--- a/internal/pagespublish/freshness_test.go
+++ b/internal/pagespublish/freshness_test.go
@@ -49,6 +49,24 @@ func TestAuditFreshnessRequiresEveryRootAssetClassified(t *testing.T) {
 	}
 }
 
+func TestAuditFreshnessRejectsShallowHistory(t *testing.T) {
+	d := initFreshnessRepo(t)
+	writeCommit(t, d, "2026-07-01T00:00:00Z", map[string]string{"docs/marketing/campaign.md": "old"})
+	writeCommit(t, d, "2026-08-10T00:00:00Z", map[string]string{"README.md": "unrelated"})
+	head, err := gitOutput(d, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(d, ".git", "shallow"), []byte(strings.TrimSpace(head)+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	targets := FreshnessTargets{Schema: FreshnessTargetsSchema, Roots: []string{"docs/marketing"}, Targets: []FreshnessTarget{{Path: "docs/marketing/campaign.md", Class: "review", ReviewAfterDays: 21, Check: "Claims remain current."}}}
+	_, err = AuditFreshness(d, targets, time.Date(2026, 8, 15, 0, 0, 0, 0, time.UTC))
+	if err == nil || !strings.Contains(err.Error(), "full git history") {
+		t.Fatalf("error = %v, want full-history refusal", err)
+	}
+}
+
 func initFreshnessRepo(t *testing.T) string {
 	t.Helper()
 	d := t.TempDir()

--- a/tools/issue_lane_router.py
+++ b/tools/issue_lane_router.py
@@ -1513,7 +1513,15 @@ def plan_class_label_changes(
         remove = sorted(have_class - {want})
         if add or remove:
             changes.append({"number": num, "add": add, "remove": remove})
-    return changes
+    return sorted(changes, key=lambda change: change["number"])
+
+
+def bound_class_label_changes(
+    changes: list[dict[str, Any]], limit: int,
+) -> tuple[list[dict[str, Any]], int]:
+    """Select a deterministic bounded prefix and report the unapplied remainder."""
+    selected = changes[:limit] if limit else changes
+    return selected, len(changes) - len(selected)
 
 
 def ensure_class_labels(workspace: Path, *, apply: bool) -> list[str]:
@@ -1611,6 +1619,8 @@ def main(argv: list[str] | None = None) -> int:
     args = ap.parse_args(argv)
     if args.apply_labels_write and not args.apply_labels:
         ap.error("--apply-labels-write requires --apply-labels")
+    if args.label_change_limit < 0:
+        ap.error("--label-change-limit must be non-negative")
 
     workspace = Path(args.workspace).resolve() if args.workspace else repo_root()
     scope_alias = label_alias = None
@@ -1663,9 +1673,14 @@ def main(argv: list[str] | None = None) -> int:
             int(i.get("number") or 0): _label_names(i) for i in src_issues
         }
         routed_rows = [r for r in payload.get("issues", []) if r.get("number")]
-        changes = plan_class_label_changes(routed_rows, current_labels)
+        all_changes = plan_class_label_changes(routed_rows, current_labels)
+        limit = args.label_change_limit
+        changes, remaining = bound_class_label_changes(all_changes, limit)
         ensure_class_labels(workspace, apply=do_write)
         result = apply_class_label_changes(workspace, changes, apply=do_write)
+        result["total_changes"] = len(all_changes)
+        result["remaining"] = remaining
+        result["change_limit"] = limit
         if args.json:
             print(json.dumps({"label_backfill": result, "changes": changes}, indent=2))
         else:

--- a/tools/issue_lane_router_test.py
+++ b/tools/issue_lane_router_test.py
@@ -1378,6 +1378,39 @@ class PhantomTreeRegionFidelityTest(unittest.TestCase):
             % (r["lane"], region, self.NAMED))
 
 
+class BoundedLabelReconciliationTest(unittest.TestCase):
+    def test_over_cap_progress_is_deterministic_and_bounded(self):
+        routes = [
+            {"number": number, "class": m.CLASS_DEV}
+            for number in range(668, 0, -1)
+        ]
+        labels = {number: set() for number in range(1, 669)}
+
+        first_plan = m.plan_class_label_changes(routes, labels)
+        first, remaining = m.bound_class_label_changes(first_plan, 200)
+
+        self.assertEqual([change["number"] for change in first], list(range(1, 201)))
+        self.assertEqual(len(first), 200)
+        self.assertEqual(remaining, 468)
+
+        for change in first:
+            labels[change["number"]].update(change["add"])
+            labels[change["number"]].difference_update(change["remove"])
+        second_plan = m.plan_class_label_changes(routes, labels)
+        second, remaining = m.bound_class_label_changes(second_plan, 200)
+
+        self.assertEqual([change["number"] for change in second], list(range(201, 401)))
+        self.assertEqual(len(second), 200)
+        self.assertEqual(remaining, 268)
+
+    def test_zero_limit_preserves_unbounded_manual_reconciliation(self):
+        changes = [{"number": number, "add": [], "remove": []}
+                   for number in range(1, 669)]
+        selected, remaining = m.bound_class_label_changes(changes, 0)
+        self.assertEqual(selected, changes)
+        self.assertEqual(remaining, 0)
+
+
 class PairedFlagTest(unittest.TestCase):
     def test_apply_labels_write_requires_apply_labels(self):
         stderr = io.StringIO()


### PR DESCRIPTION
Clears recurring release blockers and shifts failures left. Witnessed locally: envconfiglint green; rich-dashboard focused tests green; pages freshness, guard sessions, host resurrection, cmd/fak focused tests green; issue router 139 tests green (one expected failure). The router preserves DELTA_CAP=200 and converges scheduled backfills in deterministic bounded batches. Rollback: revert the corresponding commits; no secret or schema migration.