### PR TITLE
fix(router): bound manual reconciliation batches

### DIFF
--- a/.github/workflows/issue-lane-router.yml
+++ b/.github/workflows/issue-lane-router.yml
@@ -153,7 +153,7 @@ jobs:
             | jq -e '((.lanes.concurrent // []) | length) > 0' >/dev/null \
             || { echo "::error::dos lane taxonomy emptied between guard and write — aborting."; exit 1; }
           limit_args=()
-          if [ "${GITHUB_EVENT_NAME}" = "schedule" ]; then
+          if [ "${ALLOW_BULK}" != "true" ]; then
             limit_args=(--label-change-limit "$DELTA_CAP")
           fi
           python tools/issue_lane_router.py --apply-labels --apply-labels-write --json --issue-limit "$ISSUE_LIMIT" "${limit_args[@]}" > backfill.json


### PR DESCRIPTION
## Result
Manual and scheduled non-bulk reconciliation now both apply at most DELTA_CAP changes; only explicit allow_bulk=true bypasses the cap.

## Live repro
- workflow run 32754172546 planned 676 changes during workflow_dispatch, then failed before writes because the write path only passed --label-change-limit for schedule events.

## Proof
- python tools/issue_lane_router_test.py (139 tests, 1 expected failure)
- git diff --check

Signed-off-by: Codex <codex@openai.com>