### PR TITLE
fix(codexhooks): keep PostToolUse intentionally disabled

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,6 +6,11 @@ it first for build/test/run, the repo map, and the rules. Curated doc map:
 
 Must-know rules (enforced below the agent layer):
 
+- **Delegate substantive work and keep the coordinator context clean** — use guarded
+  headless agents or equivalent isolated workers for investigation, implementation, tests,
+  and review. Keep only decisions and compact witnessed evidence in the primary context;
+  independently verify worker effects before landing or reporting them. Direct work is for
+  lightweight coordination and truly trivial tasks. See [`AGENTS.md`](../AGENTS.md).
 - **Default is to ship** — when the tree is green (`make ci`), commit AND push unprompted;
   decide from the work in front of you, you don't wait to be asked. The rules below gate
   that default (stay on trunk, commit by path, never force-push); if a guard refuses

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 The canonical agent instructions for this repo are in **[`AGENTS.md`](AGENTS.md)** —
 read it first for build/test/run, the repo map, and the rules.
 
-The four that will bite you if you skip them:
+The five that will bite you if you skip them:
 
 - **Work directly on the trunk (`main`). Never open a feature branch or new worktree** —
   the trunk guard *refuses* off-trunk commits (`OFF_TRUNK`). The *one* sanctioned
@@ -29,6 +29,11 @@ The four that will bite you if you skip them:
 - **Default is to ship** — once the tree is green (`make ci`), commit AND push
   unprompted. Stay on the trunk, never force-push, defer to the guard (`OFF_TRUNK` / a peer
   merge in flight). Full default + verify command in [`AGENTS.md`](AGENTS.md).
+- **Delegate substantive work and keep this coordinator context clean** — use guarded
+  headless agents or equivalent isolated workers for investigation, implementation, tests,
+  and review. Keep only decisions and compact witnessed evidence here; independently verify
+  worker effects before landing or reporting them. Reserve direct work for lightweight
+  coordination and truly trivial tasks. Full contract in [`AGENTS.md`](AGENTS.md).
 - **The Go module is the repository root** — run `go` commands from the clone root;
   `go install github.com/anthony-chaudhary/fak/cmd/fak@latest` resolves directly.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -15,6 +15,11 @@ malformed calls, quarantine poisoned results. Its MCP server is wired in `.mcp.j
 
 Must-know rules (enforced below the agent layer):
 
+- **Delegate substantive work and keep the coordinator context clean** — use guarded
+  headless agents or equivalent isolated workers for investigation, implementation, tests,
+  and review. Keep only decisions and compact witnessed evidence in the primary context;
+  independently verify worker effects before landing or reporting them. Direct work is for
+  lightweight coordination and truly trivial tasks. See [`AGENTS.md`](AGENTS.md).
 - Work directly on the trunk (`main`); never open a feature branch or worktree — the
   trunk guard refuses off-trunk commits (`OFF_TRUNK`). The one sanctioned exception: a
   **detached** per-worker worktree that lands on `main` via `fak worktree worker

--- a/cmd/fak/agent_output_style.go
+++ b/cmd/fak/agent_output_style.go
@@ -83,6 +83,23 @@ type agentOutputProfile struct {
 	Meaning        string `json:"meaning"`
 }
 
+type agentProfileSweepPlan struct {
+	Schema          string                 `json:"schema"`
+	Axes            string                 `json:"axes"`
+	ResultSemantics string                 `json:"result_semantics"`
+	Rows            []agentProfileSweepRow `json:"rows"`
+}
+
+type agentProfileSweepRow struct {
+	Axis      string `json:"axis"`
+	Rung      string `json:"rung"`
+	Selection string `json:"selection"`
+	Canonical string `json:"canonical"`
+	Meaning   string `json:"meaning"`
+	Command   string `json:"command"`
+	Result    string `json:"result"`
+}
+
 func agentOutputProfiles() []agentOutputProfile {
 	return []agentOutputProfile{
 		{Selection: "full", Canonical: "full", Family: "native", Implementation: "native", Intensity: "off", Status: "shipped", Meaning: "No response-shape steering."},
@@ -106,15 +123,86 @@ func agentWorkProfiles() []agentOutputProfile {
 	}
 }
 
+func agentProfileSweepRows() []agentProfileSweepRow {
+	return []agentProfileSweepRow{
+		{Axis: "response", Rung: "off", Selection: "full", Canonical: "full", Meaning: "No response-shape steering.", Command: "fak agent --output-style full --work-profile ponytail:medium", Result: "not-measured"},
+		{Axis: "response", Rung: "low", Selection: "caveman:low", Canonical: "caveman:native:low", Meaning: "Light response compression.", Command: "fak agent --output-style caveman:low --work-profile ponytail:medium", Result: "not-measured"},
+		{Axis: "response", Rung: "medium", Selection: "caveman:medium", Canonical: "caveman:native:medium", Meaning: "Concise response shape with correctness carve-outs.", Command: "fak agent --output-style caveman:medium --work-profile ponytail:medium", Result: "not-measured"},
+		{Axis: "response", Rung: "high", Selection: "caveman:high", Canonical: "caveman:native:high", Meaning: "Strong response compression.", Command: "fak agent --output-style caveman:high --work-profile ponytail:medium", Result: "not-measured"},
+		{Axis: "work", Rung: "off", Selection: "standard", Canonical: "standard", Meaning: "No implementation-policy steering.", Command: "fak agent --work-profile standard --output-style caveman:medium", Result: "not-measured"},
+		{Axis: "work", Rung: "low", Selection: "ponytail:low", Canonical: "ponytail:native:low", Meaning: "Brief simplicity check before adding machinery.", Command: "fak agent --work-profile ponytail:low --output-style caveman:medium", Result: "not-measured"},
+		{Axis: "work", Rung: "medium", Selection: "ponytail:medium", Canonical: "ponytail:native:medium", Meaning: "Simplicity ladder with correctness carve-outs.", Command: "fak agent --work-profile ponytail:medium --output-style caveman:medium", Result: "not-measured"},
+		{Axis: "work", Rung: "high", Selection: "ponytail:high", Canonical: "ponytail:native:high", Meaning: "Actively resist avoidable complexity.", Command: "fak agent --work-profile ponytail:high --output-style caveman:medium", Result: "not-measured"},
+	}
+}
+
+func agentResponseProfileValue(style syspromptmmu.StyleReadout) string {
+	switch style.Intensity {
+	case "low":
+		return "light response compression"
+	case "medium":
+		return "concise response shape with correctness carve-outs"
+	case "high":
+		return "strong response compression"
+	default:
+		return "no response-shape steering"
+	}
+}
+
+func agentWorkProfileValue(profile syspromptmmu.WorkProfileReadout) string {
+	switch profile.Intensity {
+	case "low":
+		return "brief simplicity check"
+	case "medium":
+		return "simplicity ladder with correctness carve-outs"
+	case "high":
+		return "actively resist avoidable complexity"
+	default:
+		return "no implementation-policy steering"
+	}
+}
+
+func printAgentProfileValue(w io.Writer, response agentOutputStylePreference, work agentWorkProfilePreference) {
+	fmt.Fprintf(w, "fak agent profile value: response=%s (source=%s; value=%s); work=%s (source=%s; value=%s); off means response=full adds no response-shape steering and work=standard adds no implementation-policy steering; inspect sweep: fak agent profiles --sweep\n",
+		response.Style.Style, response.Source, agentResponseProfileValue(response.Style),
+		work.Profile.Profile, work.Source, agentWorkProfileValue(work.Profile))
+}
+
+func printAgentProfileSweep(w io.Writer, jsonOut bool) error {
+	rows := agentProfileSweepRows()
+	if jsonOut {
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(agentProfileSweepPlan{
+			Schema:          "fak-agent-profile-sweep/1",
+			Axes:            "independent",
+			ResultSemantics: "not-measured means this row is a stable control plan, not a benchmark result",
+			Rows:            rows,
+		})
+	}
+	fmt.Fprintln(w, "Profile sweep plan (independent controls; stable off/low/medium/high rows):")
+	for _, row := range rows {
+		fmt.Fprintf(w, "  %-8s %-6s %-18s %-13s %s\n", row.Axis, row.Rung, row.Selection, row.Result, row.Command)
+	}
+	fmt.Fprintln(w, "Run the same recorded task or fixture with fixed options for each row, then compare its receipts.")
+	fmt.Fprintln(w, "No benchmark results are bundled; every row is not-measured until you run it.")
+	fmt.Fprintln(w, "Machine-readable plan: fak agent profiles --sweep --json")
+	return nil
+}
+
 func printAgentOutputProfiles(w io.Writer, argv []string) error {
 	fs := flag.NewFlagSet("agent profiles", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	jsonOut := fs.Bool("json", false, "emit stable JSON")
+	sweep := fs.Bool("sweep", false, "emit the stable independent-axis sweep plan")
 	if err := fs.Parse(argv); err != nil {
 		return fmt.Errorf("agent profiles: %w", err)
 	}
 	if fs.NArg() != 0 {
 		return fmt.Errorf("agent profiles: unexpected arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	if *sweep {
+		return printAgentProfileSweep(w, *jsonOut)
 	}
 	profiles := agentOutputProfiles()
 	if *jsonOut {
@@ -140,6 +228,7 @@ func printAgentOutputProfiles(w io.Writer, argv []string) error {
 	fmt.Fprintln(w, "  fak console settings --json                                           # show canonical value + source")
 	fmt.Fprintln(w, "  fak console settings --set-default adapt.output-style=full             # disable")
 	fmt.Fprintln(w, "  precedence: CLI --output-style > persisted preference > shipped default")
+	fmt.Fprintln(w, "\nSweep controls: fak agent profiles --sweep")
 	fmt.Fprintln(w, "\nPrecedence: policy and explicit requirements > repository instructions > work profile > response profile.")
 	return nil
 }

--- a/cmd/fak/agent_output_style_test.go
+++ b/cmd/fak/agent_output_style_test.go
@@ -53,6 +53,7 @@ func TestAgentOutputProfilesUserReadout(t *testing.T) {
 		"--set-default adapt.output-style=caveman:medium",
 		"--set-default adapt.output-style=full",
 		"CLI --output-style > persisted preference > shipped default",
+		"Sweep controls: fak agent profiles --sweep",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("profiles readout missing %q:\n%s", want, text)

--- a/cmd/fak/agent_profile_value_test.go
+++ b/cmd/fak/agent_profile_value_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAgentProfileValueReadoutAcrossSourcesAndOff(t *testing.T) {
+	tests := []struct {
+		name       string
+		configBody string
+		flags      []string
+		want       []string
+	}{
+		{
+			name: "shipped defaults",
+			want: []string{
+				"response=caveman:native:medium (source=shipped-default; value=concise response shape with correctness carve-outs)",
+				"work=ponytail:native:medium (source=shipped-default; value=simplicity ladder with correctness carve-outs)",
+			},
+		},
+		{
+			name:  "explicit independent axes",
+			flags: []string{"--output-style", "caveman:low", "--work-profile", "ponytail:high"},
+			want: []string{
+				"response=caveman:native:low (source=cli; value=light response compression)",
+				"work=ponytail:native:high (source=cli; value=actively resist avoidable complexity)",
+			},
+		},
+		{
+			name:       "persisted response",
+			configBody: `{"pane_defaults":{"adapt":{"output-style":"caveman:high"}}}`,
+			want: []string{
+				"response=caveman:native:high (source=persisted; value=strong response compression)",
+				"work=ponytail:native:medium (source=shipped-default; value=simplicity ladder with correctness carve-outs)",
+			},
+		},
+		{
+			name:  "explicit off",
+			flags: []string{"--output-style", "full", "--work-profile", "standard"},
+			want: []string{
+				"response=full (source=cli; value=no response-shape steering)",
+				"work=standard (source=cli; value=no implementation-policy steering)",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			config := filepath.Join(dir, "console.json")
+			if tt.configBody != "" {
+				if err := os.WriteFile(config, []byte(tt.configBody), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			out := filepath.Join(dir, "agent-report.json")
+			args := []string{"--offline", "--code-tools=false", "--console-config", config, "--out", out}
+			args = append(args, tt.flags...)
+			_, stderr := captureAgentStdio(t, func() { cmdAgent(args) })
+
+			if got := strings.Count(stderr, "fak agent profile value:"); got != 1 {
+				t.Fatalf("profile readout count=%d, want 1:\n%s", got, stderr)
+			}
+			for _, want := range append(tt.want,
+				"off means response=full adds no response-shape steering and work=standard adds no implementation-policy steering",
+				"inspect sweep: fak agent profiles --sweep",
+			) {
+				if !strings.Contains(stderr, want) {
+					t.Errorf("profile readout missing %q:\n%s", want, stderr)
+				}
+			}
+		})
+	}
+}
+
+func TestAgentProfileSweepJSONRowsAreStableAndUnmeasured(t *testing.T) {
+	var first, second bytes.Buffer
+	if err := printAgentOutputProfiles(&first, []string{"--sweep", "--json"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := printAgentOutputProfiles(&second, []string{"--sweep", "--json"}); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(first.Bytes(), second.Bytes()) {
+		t.Fatalf("two profile sweep renders differ:\nfirst:\n%s\nsecond:\n%s", first.Bytes(), second.Bytes())
+	}
+
+	var got agentProfileSweepPlan
+	if err := json.Unmarshal(first.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Schema != "fak-agent-profile-sweep/1" || got.Axes != "independent" || !strings.Contains(got.ResultSemantics, "not a benchmark result") {
+		t.Fatalf("sweep contract = %+v", got)
+	}
+	want := []agentProfileSweepRow{
+		{Axis: "response", Rung: "off", Selection: "full", Canonical: "full", Meaning: "No response-shape steering.", Command: "fak agent --output-style full --work-profile ponytail:medium", Result: "not-measured"},
+		{Axis: "response", Rung: "low", Selection: "caveman:low", Canonical: "caveman:native:low", Meaning: "Light response compression.", Command: "fak agent --output-style caveman:low --work-profile ponytail:medium", Result: "not-measured"},
+		{Axis: "response", Rung: "medium", Selection: "caveman:medium", Canonical: "caveman:native:medium", Meaning: "Concise response shape with correctness carve-outs.", Command: "fak agent --output-style caveman:medium --work-profile ponytail:medium", Result: "not-measured"},
+		{Axis: "response", Rung: "high", Selection: "caveman:high", Canonical: "caveman:native:high", Meaning: "Strong response compression.", Command: "fak agent --output-style caveman:high --work-profile ponytail:medium", Result: "not-measured"},
+		{Axis: "work", Rung: "off", Selection: "standard", Canonical: "standard", Meaning: "No implementation-policy steering.", Command: "fak agent --work-profile standard --output-style caveman:medium", Result: "not-measured"},
+		{Axis: "work", Rung: "low", Selection: "ponytail:low", Canonical: "ponytail:native:low", Meaning: "Brief simplicity check before adding machinery.", Command: "fak agent --work-profile ponytail:low --output-style caveman:medium", Result: "not-measured"},
+		{Axis: "work", Rung: "medium", Selection: "ponytail:medium", Canonical: "ponytail:native:medium", Meaning: "Simplicity ladder with correctness carve-outs.", Command: "fak agent --work-profile ponytail:medium --output-style caveman:medium", Result: "not-measured"},
+		{Axis: "work", Rung: "high", Selection: "ponytail:high", Canonical: "ponytail:native:high", Meaning: "Actively resist avoidable complexity.", Command: "fak agent --work-profile ponytail:high --output-style caveman:medium", Result: "not-measured"},
+	}
+	if len(got.Rows) != len(want) {
+		t.Fatalf("sweep rows=%d, want %d: %+v", len(got.Rows), len(want), got.Rows)
+	}
+	for i := range want {
+		if got.Rows[i] != want[i] {
+			t.Errorf("sweep[%d]=%+v, want %+v", i, got.Rows[i], want[i])
+		}
+	}
+
+	var human bytes.Buffer
+	if err := printAgentOutputProfiles(&human, []string{"--sweep"}); err != nil {
+		t.Fatal(err)
+	}
+	for _, text := range []string{
+		"independent controls",
+		"response off",
+		"response high",
+		"work     off",
+		"work     high",
+		"No benchmark results are bundled",
+		"fak agent profiles --sweep --json",
+	} {
+		if !strings.Contains(human.String(), text) {
+			t.Errorf("human sweep missing %q:\n%s", text, human.String())
+		}
+	}
+}

--- a/cmd/fak/agent_work_profile.go
+++ b/cmd/fak/agent_work_profile.go
@@ -10,12 +10,31 @@ import (
 
 const agentDefaultWorkProfile = syspromptmmu.WorkProfileDefault
 
+const (
+	agentWorkProfileSourceCLI     = "cli"
+	agentWorkProfileSourceDefault = "shipped-default"
+)
+
+type agentWorkProfilePreference struct {
+	Profile syspromptmmu.WorkProfileReadout
+	Source  string
+}
+
 func resolveAgentWorkProfile(raw string) (syspromptmmu.WorkProfileReadout, error) {
 	profile := syspromptmmu.DescribeWorkProfile(raw)
 	if !profile.Known {
 		return profile, fmt.Errorf("agent: invalid --work-profile %q; supported: %s", raw, strings.Join(syspromptmmu.WorkProfileNames(), ", "))
 	}
 	return profile, nil
+}
+
+func resolveAgentWorkProfilePreference(raw string, explicit bool) (agentWorkProfilePreference, error) {
+	profile, err := resolveAgentWorkProfile(raw)
+	source := agentWorkProfileSourceDefault
+	if explicit {
+		source = agentWorkProfileSourceCLI
+	}
+	return agentWorkProfilePreference{Profile: profile, Source: source}, err
 }
 
 func applyAgentWorkProfile(profile syspromptmmu.WorkProfileReadout) (func(), error) {

--- a/cmd/fak/guard_codex_test.go
+++ b/cmd/fak/guard_codex_test.go
@@ -92,6 +92,15 @@ func TestGuardLaunchPlanIdentityComposition(t *testing.T) {
 		})
 	}
 
+	codex := newGuardLaunchPlan([]string{"codex", "resume", "thread-id"})
+	if provider, autodetected := codex.resolveProvider("openai"); provider != "openai-responses" || autodetected {
+		t.Fatalf("explicit Codex OpenAI provider = %q autodetected=%v, want openai-responses false", provider, autodetected)
+	}
+	claude := newGuardLaunchPlan([]string{"claude"})
+	if provider, autodetected := claude.resolveProvider("openai"); provider != "openai" || autodetected {
+		t.Fatalf("non-Codex explicit OpenAI provider = %q autodetected=%v, want openai false", provider, autodetected)
+	}
+
 	unknown := newGuardLaunchPlan([]string{"custom-agent", "run"})
 	if unknown.recognized() || unknown.harnessProfile().Recognized() {
 		t.Fatalf("unknown command resolved a profile: %+v", unknown.harnessProfile())

--- a/cmd/fak/guard_launch_plan.go
+++ b/cmd/fak/guard_launch_plan.go
@@ -61,6 +61,13 @@ func (p guardLaunchPlan) withExecutableCommand(command []string) guardLaunchPlan
 
 func (p guardLaunchPlan) resolveProvider(explicit string) (string, bool) {
 	if provider := strings.ToLower(strings.TrimSpace(explicit)); provider != "" {
+		// `fak m --provider openai -- codex ...` is the documented OpenAI spelling,
+		// but Codex speaks the Responses wire. Keep the operator's explicit billing
+		// choice while selecting the wire required by the harness; otherwise the
+		// subscription resolver is skipped and an empty OPENAI_API_KEY fails launch.
+		if provider == "openai" && p.recognizedProfile && p.profile.Wire == harnessprofile.WireOpenAIResponses {
+			return string(p.profile.Wire), false
+		}
 		return provider, false
 	}
 	if p.recognizedProfile {

--- a/cmd/fak/info.go
+++ b/cmd/fak/info.go
@@ -821,14 +821,20 @@ func runGuardInfoOverlay(stdout, stderr io.Writer, c *claudeMacDebugClient, inte
 			// cleanly. LIFO order on return: disable mouse + focus reporting, restore the cooked
 			// stdin, then (the existing) trailing newline if a frame is parked. Registered after
 			// `defer stop()` so it runs first.
-			defer func() {
-				writeMouseDisable(stdout)
-				writeFocusDisable(stdout)
+			restoreInfoInput, inputErr := prepareInfoTerminalInput(int(os.Stdin.Fd()))
+			if inputErr != nil {
 				_ = term.Restore(int(os.Stdin.Fd()), oldState)
-			}()
-			writeFocusEnable(stdout)
-			writeMouseEnable(stdout)
-			keyCh = startGuardInfoInputReader(os.Stdin, stop)
+			} else {
+				defer func() {
+					writeMouseDisable(stdout)
+					writeFocusDisable(stdout)
+					restoreInfoInput()
+					_ = term.Restore(int(os.Stdin.Fd()), oldState)
+				}()
+				writeFocusEnable(stdout)
+				writeMouseEnable(stdout)
+				keyCh = startGuardInfoInputReader(os.Stdin, stop)
+			}
 			// Seed the watcher with the geometry this overlay is ABOUT to paint at, so a startup
 			// measure that was already wrong (a pane sampled before its host finished laying the
 			// split out) fires a repaint on the first poll instead of being mistaken for the

--- a/cmd/fak/info_terminal_input_other.go
+++ b/cmd/fak/info_terminal_input_other.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package main
+
+func prepareInfoTerminalInput(_ int) (func(), error) {
+	return func() {}, nil
+}

--- a/cmd/fak/info_terminal_input_windows.go
+++ b/cmd/fak/info_terminal_input_windows.go
@@ -1,0 +1,28 @@
+//go:build windows
+
+package main
+
+import "golang.org/x/sys/windows"
+
+// prepareInfoTerminalInput keeps Windows console input on the VT byte stream that
+// infoInputScanner consumes. x/term MakeRaw enables VT input but deliberately leaves
+// ENABLE_MOUSE_INPUT untouched; when that flag is set, Windows reports mouse clicks as
+// INPUT_RECORD values instead of the SGR bytes requested with DECSET 1000/1006. os.Stdin.Read
+// cannot decode those records, so the overlay looks alive while every click is inert.
+func prepareInfoTerminalInput(fd int) (func(), error) {
+	h := windows.Handle(fd)
+	var previous uint32
+	if err := windows.GetConsoleMode(h, &previous); err != nil {
+		return nil, err
+	}
+	mode := infoTerminalInputMode(previous)
+	if err := windows.SetConsoleMode(h, mode); err != nil {
+		return nil, err
+	}
+	return func() { _ = windows.SetConsoleMode(h, previous) }, nil
+}
+
+func infoTerminalInputMode(mode uint32) uint32 {
+	return (mode | windows.ENABLE_VIRTUAL_TERMINAL_INPUT | windows.ENABLE_EXTENDED_FLAGS) &^
+		(windows.ENABLE_MOUSE_INPUT | windows.ENABLE_QUICK_EDIT_MODE)
+}

--- a/cmd/fak/info_terminal_input_windows_test.go
+++ b/cmd/fak/info_terminal_input_windows_test.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package main
+
+import (
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestInfoTerminalInputModeRoutesMouseThroughVT(t *testing.T) {
+	before := uint32(windows.ENABLE_MOUSE_INPUT | windows.ENABLE_QUICK_EDIT_MODE | windows.ENABLE_LINE_INPUT)
+	after := infoTerminalInputMode(before)
+	if after&windows.ENABLE_VIRTUAL_TERMINAL_INPUT == 0 {
+		t.Fatal("VT input is disabled")
+	}
+	if after&windows.ENABLE_EXTENDED_FLAGS == 0 {
+		t.Fatal("extended flags are disabled, so Quick Edit cannot be changed reliably")
+	}
+	if after&windows.ENABLE_MOUSE_INPUT != 0 {
+		t.Fatal("ENABLE_MOUSE_INPUT still routes clicks to INPUT_RECORD instead of SGR bytes")
+	}
+	if after&windows.ENABLE_QUICK_EDIT_MODE != 0 {
+		t.Fatal("Quick Edit still captures clicks for text selection")
+	}
+	if after&windows.ENABLE_LINE_INPUT == 0 {
+		t.Fatal("unrelated console mode bits were not preserved")
+	}
+}

--- a/cmd/fak/main.go
+++ b/cmd/fak/main.go
@@ -1148,9 +1148,13 @@ func cmdAgent(argv []string) {
 	_ = fs.Parse(argv)
 
 	outputStyleExplicit := false
+	workProfileExplicit := false
 	fs.Visit(func(f *flag.Flag) {
-		if f.Name == "output-style" {
+		switch f.Name {
+		case "output-style":
 			outputStyleExplicit = true
+		case "work-profile":
+			workProfileExplicit = true
 		}
 	})
 	preference, err := resolveAgentOutputStylePreference(*outputStyle, outputStyleExplicit, *consoleConfig)
@@ -1164,17 +1168,18 @@ func cmdAgent(argv []string) {
 		os.Exit(2)
 	}
 	defer restoreStyle()
-	work, err := resolveAgentWorkProfile(*workProfile)
+	workPreference, err := resolveAgentWorkProfilePreference(*workProfile, workProfileExplicit)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(2)
 	}
-	restoreWork, err := applyAgentWorkProfile(work)
+	restoreWork, err := applyAgentWorkProfile(workPreference.Profile)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "agent: set --work-profile: %v\n", err)
 		os.Exit(2)
 	}
 	defer restoreWork()
+	printAgentProfileValue(os.Stderr, preference, workPreference)
 	applyPolicy(*policyPath)
 	loadedRoute, loadedAccounts, runOpts, err := loadAgentRouteOptionsWithAccounts(*routeManifest, *routeAccounts)
 	must(err)

--- a/cmd/fak/session_recover_test.go
+++ b/cmd/fak/session_recover_test.go
@@ -163,7 +163,7 @@ func TestSessionRecoverPromptAndCWD(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := []string{guardBin, "guard", "--", "codex", "resume", "t1", "continue this exact task"}
+	want := []string{guardBin, "guard", "--", "codex", "resume", "--cd", `C:\work\fak`, "t1", "continue this exact task"}
 	if len(cap.got) != 1 || !reflect.DeepEqual(cap.got[0].Argv, want) || cap.got[0].CWD != `C:\work\fak` {
 		t.Fatalf("launch=%+v", cap.got)
 	}
@@ -299,7 +299,7 @@ func TestSessionRecoverUsesJournalRecordedCWD(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	wantArgv := []string{guardBin, "guard", "--", "codex", "resume", "journal-thread", "continue exactly"}
+	wantArgv := []string{guardBin, "guard", "--", "codex", "resume", "--cd", `D:\repos\actual tree`, "journal-thread", "continue exactly"}
 	if len(got.Results) != 1 || got.Results[0].CWD != `D:\repos\actual tree` || got.Results[0].Source != "session_journal" || !reflect.DeepEqual(got.Results[0].Argv, wantArgv) {
 		t.Fatalf("summary=%+v", got)
 	}

--- a/internal/agentsindex/ticket_first_guidance_test.go
+++ b/internal/agentsindex/ticket_first_guidance_test.go
@@ -49,7 +49,7 @@ func TestAgentGuidanceDefaultsSubstantiveWorkToWorkers(t *testing.T) {
 		},
 		"CLAUDE.md": {
 			"Delegate substantive work and keep this coordinator context clean",
-			"independently verify worker effects",
+			"independently verify\n  worker effects",
 		},
 		"GEMINI.md": {
 			"Delegate substantive work and keep the coordinator context clean",

--- a/internal/agentsindex/ticket_first_guidance_test.go
+++ b/internal/agentsindex/ticket_first_guidance_test.go
@@ -34,3 +34,42 @@ func TestAgentGuidanceTracksWorkInGitHubBeforeImplementation(t *testing.T) {
 		}
 	}
 }
+
+func TestAgentGuidanceDefaultsSubstantiveWorkToWorkers(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve test file")
+	}
+	root := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+	checks := map[string][]string{
+		"AGENTS.md": {
+			"Delegate real work; keep the coordinator context clean",
+			"Use guarded headless agents or an equivalent isolated worker for every substantive",
+			"independently witness worker results",
+		},
+		"CLAUDE.md": {
+			"Delegate substantive work and keep this coordinator context clean",
+			"independently verify worker effects",
+		},
+		"GEMINI.md": {
+			"Delegate substantive work and keep the coordinator context clean",
+			"compact witnessed evidence in the primary context",
+		},
+		filepath.Join(".github", "copilot-instructions.md"): {
+			"Delegate substantive work and keep the coordinator context clean",
+			"compact witnessed evidence in the primary context",
+		},
+	}
+
+	for rel, wants := range checks {
+		body, err := os.ReadFile(filepath.Join(root, rel))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		for _, want := range wants {
+			if !strings.Contains(string(body), want) {
+				t.Errorf("%s must retain worker-first context-hygiene guidance %q", rel, want)
+			}
+		}
+	}
+}

--- a/internal/devcmd/codexhook_census.go
+++ b/internal/devcmd/codexhook_census.go
@@ -33,28 +33,30 @@ type lifecycleCounts struct {
 }
 
 type hookCensusReport struct {
-	Schema             string             `json:"schema"`
-	GeneratedAt        time.Time          `json:"generated_at"`
-	Window             string             `json:"window"`
-	CodexHome          string             `json:"codex_home"`
-	LogStore           string             `json:"log_store"`
-	Workspace          string             `json:"workspace"`
-	ObservationStore   string             `json:"observation_store"`
-	ProfileMatch       bool               `json:"profile_match"`
-	DispatchedCalls    int                `json:"dispatched_calls"`
-	DispatchSource     string             `json:"dispatch_source"`
-	PreToolUse         lifecycleCounts    `json:"pre_tool_use"`
-	PostToolUse        lifecycleCounts    `json:"post_tool_use"`
-	Stop               lifecycleCounts    `json:"stop"`
-	StopFailure        lifecycleCounts    `json:"stop_failure"`
-	SubagentStop       lifecycleCounts    `json:"subagent_stop"`
-	StopSource         string             `json:"stop_source,omitempty"`
-	StopRuns           []stopLifecycleRow `json:"stop_runs,omitempty"`
-	TelemetryFresh     bool               `json:"telemetry_fresh"`
-	NewestReceipt      time.Time          `json:"newest_receipt,omitempty"`
-	Verdict            string             `json:"verdict"`
-	PostToolSettlement string             `json:"post_tool_settlement"`
-	Reasons            []string           `json:"reasons,omitempty"`
+	Schema                 string             `json:"schema"`
+	GeneratedAt            time.Time          `json:"generated_at"`
+	Window                 string             `json:"window"`
+	CodexHome              string             `json:"codex_home"`
+	LogStore               string             `json:"log_store"`
+	Workspace              string             `json:"workspace"`
+	ObservationStore       string             `json:"observation_store"`
+	ProfileMatch           bool               `json:"profile_match"`
+	DispatchedCalls        int                `json:"dispatched_calls"`
+	DispatchSource         string             `json:"dispatch_source"`
+	PreToolUse             lifecycleCounts    `json:"pre_tool_use"`
+	PostToolUse            lifecycleCounts    `json:"post_tool_use"`
+	PostToolUseRequirement string             `json:"post_tool_use_requirement"`
+	PostToolUseStatus      string             `json:"post_tool_use_status"`
+	Stop                   lifecycleCounts    `json:"stop"`
+	StopFailure            lifecycleCounts    `json:"stop_failure"`
+	SubagentStop           lifecycleCounts    `json:"subagent_stop"`
+	StopSource             string             `json:"stop_source,omitempty"`
+	StopRuns               []stopLifecycleRow `json:"stop_runs,omitempty"`
+	TelemetryFresh         bool               `json:"telemetry_fresh"`
+	NewestReceipt          time.Time          `json:"newest_receipt,omitempty"`
+	Verdict                string             `json:"verdict"`
+	PostToolSettlement     string             `json:"post_tool_settlement"`
+	Reasons                []string           `json:"reasons,omitempty"`
 }
 
 type hookObservation struct {
@@ -284,6 +286,7 @@ func RunCodexHookCensus(stdout, stderr io.Writer, args []string) int {
 	home := fs.String("codex-home", "", "active Codex home")
 	logHome := fs.String("log-home", "", "Codex home whose sessions are counted")
 	workspace := fs.String("workspace", ".", "workspace whose calls are counted")
+	binary := fs.String("codex-binary", "", "Codex executable used to resolve the effective hook profile")
 	threadID := fs.String("thread-id", os.Getenv("CODEX_THREAD_ID"), "Codex thread whose calls are counted (empty counts workspace)")
 	observations := fs.String("observations", filepath.Join(".dos", "metrics", "observations.jsonl"), "hook observation JSONL")
 	stopEvents := fs.String("stop-events", "", "Codex app-server hook notification JSONL")
@@ -291,7 +294,7 @@ func RunCodexHookCensus(stdout, stderr io.Writer, args []string) int {
 	asJSON := fs.Bool("json", false, "emit JSON")
 	nowText := fs.String("now", "", "fixed RFC3339 clock (tests/captures)")
 	if err := fs.Parse(args); err != nil || fs.NArg() != 0 || *since <= 0 {
-		fmt.Fprintln(stderr, "usage: fak-dev codex-hook-census [--codex-home DIR] [--log-home DIR] [--observations FILE] [--stop-events FILE] [--since 24h] [--json]")
+		fmt.Fprintln(stderr, "usage: fak-dev codex-hook-census [--codex-home DIR] [--log-home DIR] [--codex-binary FILE] [--observations FILE] [--stop-events FILE] [--since 24h] [--json]")
 		return 2
 	}
 	now := time.Now().UTC()
@@ -316,7 +319,12 @@ func RunCodexHookCensus(stdout, stderr io.Writer, args []string) int {
 	if *logHome == "" {
 		*logHome = *home
 	}
-	report, err := buildHookCensus(*home, *logHome, *workspace, *threadID, *observations, *since, now)
+	profile, err := inspectCodexHookProfile(*home, *workspace, *binary)
+	if err != nil {
+		fmt.Fprintf(stderr, "codex-hook-census: profile: %v\n", err)
+		return 1
+	}
+	report, err := buildHookCensus(*home, *logHome, *workspace, *threadID, *observations, profile, *since, now)
 	if err != nil {
 		fmt.Fprintf(stderr, "codex-hook-census: %v\n", err)
 		return 1
@@ -341,7 +349,7 @@ func RunCodexHookCensus(stdout, stderr io.Writer, args []string) int {
 	return 0
 }
 
-func buildHookCensus(home, logHome, workspace, threadID, observations string, since time.Duration, now time.Time) (hookCensusReport, error) {
+func buildHookCensus(home, logHome, workspace, threadID, observations string, profile hookProfileReport, since time.Duration, now time.Time) (hookCensusReport, error) {
 	absHome, _ := filepath.Abs(home)
 	absLog, _ := filepath.Abs(logHome)
 	absObs, _ := filepath.Abs(observations)
@@ -354,9 +362,10 @@ func buildHookCensus(home, logHome, workspace, threadID, observations string, si
 	if err != nil {
 		return hookCensusReport{}, err
 	}
-	r := hookCensusReport{Schema: codexHookCensusSchema, GeneratedAt: now, Window: since.String(), PostToolSettlement: codexPostToolSettlementWindow.String(), CodexHome: absHome, LogStore: absLog, Workspace: absWork, ObservationStore: absObs, ProfileMatch: samePath(absHome, absLog), DispatchedCalls: len(calls), DispatchSource: filepath.Join(absLog, "sessions"), NewestReceipt: newest, TelemetryFresh: !newest.IsZero() && now.Sub(newest) <= 5*time.Minute}
+	r := hookCensusReport{Schema: codexHookCensusSchema, GeneratedAt: now, Window: since.String(), PostToolSettlement: codexPostToolSettlementWindow.String(), CodexHome: absHome, LogStore: absLog, Workspace: absWork, ObservationStore: absObs, ProfileMatch: samePath(absHome, absLog), DispatchedCalls: len(calls), DispatchSource: filepath.Join(absLog, "sessions"), NewestReceipt: newest, TelemetryFresh: !newest.IsZero() && now.Sub(newest) <= 5*time.Minute, PostToolUseRequirement: "optional"}
 	r.PreToolUse = phaseCountsForCalls(calls, receipts["pretool"], absHome, absWork, absObs)
 	r.PostToolUse = postToolPhaseCounts(postToolEligibleDispatches(calls, now.Add(-codexPostToolSettlementWindow)), receipts["posttool"], absHome, absWork, absObs)
+	applyHookProfileToCensus(&r, profile)
 	if !r.TelemetryFresh {
 		r.Reasons = append(r.Reasons, "STALE_TELEMETRY")
 	}
@@ -370,16 +379,44 @@ func buildHookCensus(home, logHome, workspace, threadID, observations string, si
 	return r, nil
 }
 
+func applyHookProfileToCensus(r *hookCensusReport, profile hookProfileReport) {
+	present := false
+	for _, h := range profile.Hooks {
+		if normalizeHookEvent(h.EventName) == "post_tool_use" {
+			present = true
+			break
+		}
+	}
+	r.PostToolUseRequirement = "optional"
+	if !present {
+		source := r.PostToolUse.Source
+		r.PostToolUse = lifecycleCounts{Source: source}
+		r.PostToolUseStatus = "intentionally_disabled"
+		return
+	}
+	r.PostToolUseStatus = "observed"
+	if r.PostToolUse.Disabled > 0 {
+		r.PostToolUseStatus = "disabled"
+	} else if r.PostToolUse.Failed > 0 {
+		r.PostToolUseStatus = "failing"
+	} else if r.PostToolUse.Unknown > 0 {
+		r.PostToolUseStatus = "incomplete"
+	}
+}
+
 func finalizeCensusVerdict(r *hookCensusReport) {
 	reasons := append([]string(nil), r.Reasons...)
 	if r.PreToolUse.Unknown > 0 {
 		reasons = append(reasons, "PRE_TOOL_USE_UNKNOWN")
 	}
-	if r.PostToolUse.Unknown > 0 {
+	if r.PostToolUseStatus != "intentionally_disabled" && r.PostToolUse.Unknown > 0 {
 		reasons = append(reasons, "POST_TOOL_USE_UNKNOWN")
 	}
 	if r.PreToolUse.Failed > 0 || r.PostToolUse.Failed > 0 {
 		reasons = append(reasons, "HOOK_FAILURES_PRESENT")
+	}
+	if r.PostToolUse.Disabled > 0 {
+		reasons = append(reasons, "POST_TOOL_USE_DISABLED")
 	}
 	for _, stop := range []struct {
 		name string
@@ -669,12 +706,8 @@ func readHookObservations(path string, after time.Time) (map[string][]hookObserv
 }
 func writeHookCensus(w io.Writer, r hookCensusReport) {
 	fmt.Fprintf(w, "Codex hook lifecycle census (%s)\nprofile: %s\nlog store: %s (match=%t)\ndispatched calls: %d [source=%s]\n", r.Window, r.CodexHome, r.LogStore, r.ProfileMatch, r.DispatchedCalls, r.DispatchSource)
-	for _, p := range []struct {
-		name string
-		c    lifecycleCounts
-	}{{"PreToolUse", r.PreToolUse}, {"PostToolUse", r.PostToolUse}} {
-		fmt.Fprintf(w, "%s: denominator=%d attempted=%d succeeded=%d failed=%d skipped=%d disabled=%d unknown=%d [source=%s]\n", p.name, p.c.Denominator, p.c.Attempted, p.c.Succeeded, p.c.Failed, p.c.Skipped, p.c.Disabled, p.c.Unknown, p.c.Source)
-	}
+	fmt.Fprintf(w, "PreToolUse: denominator=%d attempted=%d succeeded=%d failed=%d skipped=%d disabled=%d unknown=%d [source=%s]\n", r.PreToolUse.Denominator, r.PreToolUse.Attempted, r.PreToolUse.Succeeded, r.PreToolUse.Failed, r.PreToolUse.Skipped, r.PreToolUse.Disabled, r.PreToolUse.Unknown, r.PreToolUse.Source)
+	fmt.Fprintf(w, "PostToolUse: requirement=%s status=%s denominator=%d attempted=%d succeeded=%d failed=%d skipped=%d disabled=%d unknown=%d [source=%s]\n", r.PostToolUseRequirement, r.PostToolUseStatus, r.PostToolUse.Denominator, r.PostToolUse.Attempted, r.PostToolUse.Succeeded, r.PostToolUse.Failed, r.PostToolUse.Skipped, r.PostToolUse.Disabled, r.PostToolUse.Unknown, r.PostToolUse.Source)
 	sort.Strings(r.Reasons)
 	fmt.Fprintf(w, "verdict: %s", r.Verdict)
 	if len(r.Reasons) > 0 {

--- a/internal/devcmd/codexhook_census_test.go
+++ b/internal/devcmd/codexhook_census_test.go
@@ -33,7 +33,7 @@ func TestBuildHookCensusClassifiesCompleteLifecycle(t *testing.T) {
 	if err := os.WriteFile(obs, b.Bytes(), 0644); err != nil {
 		t.Fatal(err)
 	}
-	got, err := buildHookCensus(home, home, home, "", obs, time.Hour, now)
+	got, err := buildHookCensus(home, home, home, "", obs, effectivePostToolProfile(), time.Hour, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -41,6 +41,101 @@ func TestBuildHookCensusClassifiesCompleteLifecycle(t *testing.T) {
 		t.Fatalf("report=%+v", got)
 	}
 }
+
+func TestBuildHookCensusAcceptsIntentionallyDisabledPostToolUse(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "profile")
+	sessions := filepath.Join(home, "sessions")
+	if err := os.MkdirAll(sessions, 0755); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	rows := `{"timestamp":"2026-08-17T11:59:00Z","type":"session_meta","payload":{"session_id":"thread-1","cwd":"` + filepath.ToSlash(home) + `"}}` + "\n" +
+		`{"timestamp":"2026-08-17T11:00:00Z","type":"response_item","payload":{"type":"function_call","call_id":"a","name":"Read"}}` + "\n" +
+		`{"timestamp":"2026-08-17T11:01:00Z","type":"response_item","payload":{"type":"function_call_output","call_id":"a","name":"Read"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(sessions, "r.jsonl"), []byte(rows), 0644); err != nil {
+		t.Fatal(err)
+	}
+	obs := filepath.Join(root, "observations.jsonl")
+	var b bytes.Buffer
+	_ = json.NewEncoder(&b).Encode(hookObservation{CallID: "a", SessionID: "thread-1", Workspace: home, Profile: home, PhaseState: "succeeded", Verb: "pretool", TS: now.Add(-time.Minute)})
+	_ = json.NewEncoder(&b).Encode(hookObservation{CallID: "foreign", SessionID: "thread-1", Workspace: filepath.Join(root, "foreign"), Profile: home, PhaseState: "failed", Verb: "posttool", TS: now.Add(-time.Minute)})
+	if err := os.WriteFile(obs, b.Bytes(), 0644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := buildHookCensus(home, home, home, "", obs, mandatoryOnlyHookProfile(), time.Hour, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Verdict != "HEALTHY" || got.PreToolUse.Succeeded != 1 || got.PostToolUseRequirement != "optional" || got.PostToolUseStatus != "intentionally_disabled" || got.PostToolUse.Denominator != 0 || got.PostToolUse.Unknown != 0 {
+		t.Fatalf("report=%+v", got)
+	}
+	var out bytes.Buffer
+	writeHookCensus(&out, got)
+	if !strings.Contains(out.String(), "PostToolUse: requirement=optional status=intentionally_disabled") {
+		t.Fatalf("human census did not explain optional PostToolUse:\n%s", out.String())
+	}
+}
+
+func TestBuildHookCensusRejectsPresentPostToolUseWithoutReceipt(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "profile")
+	sessions := filepath.Join(home, "sessions")
+	if err := os.MkdirAll(sessions, 0755); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	rows := `{"timestamp":"2026-08-17T11:59:00Z","type":"session_meta","payload":{"session_id":"thread-1","cwd":"` + filepath.ToSlash(home) + `"}}` + "\n" +
+		`{"timestamp":"2026-08-17T11:00:00Z","type":"response_item","payload":{"type":"function_call","call_id":"a","name":"Read"}}` + "\n" +
+		`{"timestamp":"2026-08-17T11:01:00Z","type":"response_item","payload":{"type":"function_call_output","call_id":"a","name":"Read"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(sessions, "r.jsonl"), []byte(rows), 0644); err != nil {
+		t.Fatal(err)
+	}
+	obs := filepath.Join(root, "observations.jsonl")
+	o := hookObservation{CallID: "a", SessionID: "thread-1", Workspace: home, Profile: home, PhaseState: "succeeded", Verb: "pretool", TS: now.Add(-time.Minute)}
+	raw, _ := json.Marshal(o)
+	if err := os.WriteFile(obs, append(raw, '\n'), 0644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := buildHookCensus(home, home, home, "", obs, effectivePostToolProfile(), time.Hour, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Verdict != "UNHEALTHY" || got.PostToolUseStatus != "incomplete" || got.PostToolUse.Denominator != 1 || got.PostToolUse.Unknown != 1 || !slices.Contains(got.Reasons, "POST_TOOL_USE_UNKNOWN") {
+		t.Fatalf("report=%+v", got)
+	}
+}
+
+func TestBuildHookCensusDiagnosesFailingPresentPostToolUse(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "profile")
+	sessions := filepath.Join(home, "sessions")
+	if err := os.MkdirAll(sessions, 0755); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	rows := `{"timestamp":"2026-08-17T11:59:00Z","type":"session_meta","payload":{"session_id":"thread-1","cwd":"` + filepath.ToSlash(home) + `"}}` + "\n" +
+		`{"timestamp":"2026-08-17T11:00:00Z","type":"response_item","payload":{"type":"function_call","call_id":"a","name":"Read"}}` + "\n" +
+		`{"timestamp":"2026-08-17T11:01:00Z","type":"response_item","payload":{"type":"function_call_output","call_id":"a","name":"Read"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(sessions, "r.jsonl"), []byte(rows), 0644); err != nil {
+		t.Fatal(err)
+	}
+	obs := filepath.Join(root, "observations.jsonl")
+	var b bytes.Buffer
+	_ = json.NewEncoder(&b).Encode(hookObservation{CallID: "a", SessionID: "thread-1", Workspace: home, Profile: home, PhaseState: "succeeded", Verb: "pretool", TS: now.Add(-time.Minute)})
+	_ = json.NewEncoder(&b).Encode(hookObservation{CallID: "a", SessionID: "thread-1", Workspace: home, Profile: home, PhaseState: "failed", Exit: 1, Verb: "posttool", TS: now.Add(-time.Minute)})
+	if err := os.WriteFile(obs, b.Bytes(), 0644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := buildHookCensus(home, home, home, "", obs, effectivePostToolProfile(), time.Hour, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Verdict != "UNHEALTHY" || got.PostToolUseStatus != "failing" || got.PostToolUse.Failed != 1 || !slices.Contains(got.Reasons, "HOOK_FAILURES_PRESENT") {
+		t.Fatalf("report=%+v", got)
+	}
+}
+
 func TestBuildHookCensusPostToolUseExcludesActiveCalls(t *testing.T) {
 	root := t.TempDir()
 	home := filepath.Join(root, "profile")
@@ -68,7 +163,7 @@ func TestBuildHookCensusPostToolUseExcludesActiveCalls(t *testing.T) {
 	if err := os.WriteFile(obs, b.Bytes(), 0644); err != nil {
 		t.Fatal(err)
 	}
-	got, err := buildHookCensus(home, home, home, "", obs, time.Hour, now)
+	got, err := buildHookCensus(home, home, home, "", obs, effectivePostToolProfile(), time.Hour, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,7 +194,7 @@ func TestBuildHookCensusExcludesToolsOutsidePostMatcher(t *testing.T) {
 	if err := os.WriteFile(obs, append(raw, '\n'), 0644); err != nil {
 		t.Fatal(err)
 	}
-	got, err := buildHookCensus(home, home, home, "", obs, time.Hour, now)
+	got, err := buildHookCensus(home, home, home, "", obs, effectivePostToolProfile(), time.Hour, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,7 +222,7 @@ func TestBuildHookCensusSettlesFreshPostToolReceipt(t *testing.T) {
 	if err := os.WriteFile(obs, append(raw, '\n'), 0644); err != nil {
 		t.Fatal(err)
 	}
-	got, err := buildHookCensus(home, home, home, "", obs, time.Hour, now)
+	got, err := buildHookCensus(home, home, home, "", obs, effectivePostToolProfile(), time.Hour, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -149,7 +244,7 @@ func TestBuildHookCensusFailsClosedOnUnknownFailureAndProfileMismatch(t *testing
 	o := hookObservation{CallID: "a", SessionID: "thread-1", Workspace: logHome, Profile: home, PhaseState: "failed", Exit: 3, Verb: "posttool", TS: now.Add(-time.Minute)}
 	raw, _ := json.Marshal(o)
 	_ = os.WriteFile(obs, append(raw, '\n'), 0644)
-	got, err := buildHookCensus(home, logHome, logHome, "", obs, time.Hour, now)
+	got, err := buildHookCensus(home, logHome, logHome, "", obs, effectivePostToolProfile(), time.Hour, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -176,11 +271,11 @@ func TestBuildHookCensusRejectsAbsentTelemetry(t *testing.T) {
 	_ = os.WriteFile(filepath.Join(home, "sessions", "r.jsonl"), []byte(row), 0644)
 	obs := filepath.Join(root, "o.jsonl")
 	_ = os.WriteFile(obs, nil, 0644)
-	got, err := buildHookCensus(home, home, home, "", obs, time.Hour, now)
+	got, err := buildHookCensus(home, home, home, "", obs, mandatoryOnlyHookProfile(), time.Hour, now)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.Verdict != "UNHEALTHY" || got.PreToolUse.Unknown != 1 || got.PostToolUse.Unknown != 1 {
+	if got.Verdict != "UNHEALTHY" || got.PreToolUse.Unknown != 1 || got.PostToolUse.Unknown != 0 || got.PostToolUseStatus != "intentionally_disabled" {
 		t.Fatalf("report=%+v", got)
 	}
 }

--- a/internal/devcmd/codexhook_gate.go
+++ b/internal/devcmd/codexhook_gate.go
@@ -59,7 +59,12 @@ func RunCodexHookRecurrence(stdout, stderr io.Writer, args []string) int {
 		*home = filepath.Join(h, ".codex")
 	}
 	now := time.Now().UTC()
-	c, e := buildHookCensus(*home, *home, *workspace, os.Getenv("CODEX_THREAD_ID"), *observations, *since, now)
+	p, e := inspectCodexHookProfile(*home, *workspace, "")
+	if e != nil {
+		fmt.Fprintf(stderr, "codex-hook-gate: profile: %v\n", e)
+		return 1
+	}
+	c, e := buildHookCensus(*home, *home, *workspace, os.Getenv("CODEX_THREAD_ID"), *observations, p, *since, now)
 	if e != nil {
 		fmt.Fprintf(stderr, "codex-hook-gate: census: %v\n", e)
 		return 1
@@ -70,11 +75,6 @@ func RunCodexHookRecurrence(stdout, stderr io.Writer, args []string) int {
 			return 1
 		}
 		finalizeCensusVerdict(&c)
-	}
-	p, e := inspectCodexHookProfile(*home, *workspace, "")
-	if e != nil {
-		fmt.Fprintf(stderr, "codex-hook-gate: profile: %v\n", e)
-		return 1
 	}
 	outcomes, e := queryCodexToolErrorsForThread(filepath.Join(*home, "logs_2.sqlite"), now.Add(-*since), os.Getenv("CODEX_THREAD_ID"))
 	if e != nil {
@@ -119,13 +119,14 @@ func evaluateHookRecurrence(c hookCensusReport, p hookProfileReport, o codexTool
 	if c.DispatchedCalls == 0 {
 		g.Reasons = append(g.Reasons, "DENOMINATOR_ZERO")
 	}
-	if c.PreToolUse.Unknown > 0 || c.PostToolUse.Unknown > 0 || c.Stop.Unknown > 0 || c.StopFailure.Unknown > 0 || c.SubagentStop.Unknown > 0 {
+	postToolObserved := c.PostToolUseStatus != "intentionally_disabled"
+	if c.PreToolUse.Unknown > 0 || (postToolObserved && c.PostToolUse.Unknown > 0) || c.Stop.Unknown > 0 || c.StopFailure.Unknown > 0 || c.SubagentStop.Unknown > 0 {
 		g.Reasons = append(g.Reasons, "UNKNOWN_LIFECYCLE_ROWS")
 	}
 	if c.Stop.InvalidJSON > 0 || c.StopFailure.InvalidJSON > 0 || c.SubagentStop.InvalidJSON > 0 {
 		g.Reasons = append(g.Reasons, "STOP_INVALID_JSON")
 	}
-	if c.PreToolUse.Disabled > 0 || c.PostToolUse.Disabled > 0 {
+	if c.PreToolUse.Disabled > 0 || (postToolObserved && c.PostToolUse.Disabled > 0) {
 		g.Reasons = append(g.Reasons, "EXPECTED_PHASE_DISABLED")
 	}
 	if failures > maxFailures {
@@ -155,7 +156,7 @@ func expectedStopHooks(p hookProfileReport) int {
 func writeHookRecurrence(w io.Writer, g recurrenceReport) {
 	fmt.Fprintf(w, "Codex hook recurrence gate: %s\nwindow=%s unexpected=%d/%d max=%d hook-failures=%d/%d max=%d telemetry-fresh=%t\n", g.Verdict, g.Window, g.UnexpectedNumerator, g.UnexpectedDenominator, g.Thresholds.MaxUnexpectedOutcomes, g.Census.PreToolUse.Failed+g.Census.PostToolUse.Failed, g.Census.DispatchedCalls, g.Thresholds.MaxHookFailures, g.Census.TelemetryFresh)
 	fmt.Fprintf(w, "pre: attempted=%d succeeded=%d failed=%d skipped=%d disabled=%d unknown=%d denominator=%d\n", g.Census.PreToolUse.Attempted, g.Census.PreToolUse.Succeeded, g.Census.PreToolUse.Failed, g.Census.PreToolUse.Skipped, g.Census.PreToolUse.Disabled, g.Census.PreToolUse.Unknown, g.Census.PreToolUse.Denominator)
-	fmt.Fprintf(w, "post: attempted=%d succeeded=%d failed=%d skipped=%d disabled=%d unknown=%d denominator=%d\n", g.Census.PostToolUse.Attempted, g.Census.PostToolUse.Succeeded, g.Census.PostToolUse.Failed, g.Census.PostToolUse.Skipped, g.Census.PostToolUse.Disabled, g.Census.PostToolUse.Unknown, g.Census.PostToolUse.Denominator)
+	fmt.Fprintf(w, "post: requirement=%s status=%s attempted=%d succeeded=%d failed=%d skipped=%d disabled=%d unknown=%d denominator=%d\n", g.Census.PostToolUseRequirement, g.Census.PostToolUseStatus, g.Census.PostToolUse.Attempted, g.Census.PostToolUse.Succeeded, g.Census.PostToolUse.Failed, g.Census.PostToolUse.Skipped, g.Census.PostToolUse.Disabled, g.Census.PostToolUse.Unknown, g.Census.PostToolUse.Denominator)
 	if len(g.TopCauses) > 0 {
 		fmt.Fprintf(w, "top causes: %s\n", strings.Join(g.TopCauses, "; "))
 	}

--- a/internal/devcmd/codexhook_gate_test.go
+++ b/internal/devcmd/codexhook_gate_test.go
@@ -8,18 +8,26 @@ import (
 
 func healthyGateFixture() (hookCensusReport, hookProfileReport) {
 	now := time.Now()
-	c := hookCensusReport{GeneratedAt: now, Window: "15m", ProfileMatch: true, DispatchedCalls: 2, TelemetryFresh: true, PreToolUse: lifecycleCounts{Denominator: 2, Attempted: 2, Succeeded: 2}, PostToolUse: lifecycleCounts{Denominator: 2, Attempted: 2, Succeeded: 2}}
-	return c, hookProfileReport{Verdict: "HEALTHY"}
+	c := hookCensusReport{GeneratedAt: now, Window: "15m", ProfileMatch: true, DispatchedCalls: 2, TelemetryFresh: true, PreToolUse: lifecycleCounts{Denominator: 2, Attempted: 2, Succeeded: 2}, PostToolUseRequirement: "optional", PostToolUseStatus: "intentionally_disabled", StopSource: "hook-notifications.jsonl"}
+	p := hookProfileReport{Hooks: mandatoryEffectiveHooks()}
+	applyCodexHookContract(&p)
+	return c, p
 }
-func TestEvaluateHookGatePassesZeroUnknown(t *testing.T) {
+func TestEvaluateHookGatePassesZeroPostToolUseWithMandatoryEnforcementHooks(t *testing.T) {
 	c, p := healthyGateFixture()
 	g := evaluateHookRecurrence(c, p, codexToolErrorSummary{Categories: map[string]int{}}, 0, 0)
-	if g.Verdict != "PASS" || g.UnexpectedDenominator != 2 {
+	if g.Verdict != "PASS" || g.UnexpectedDenominator != 2 || g.Census.PostToolUseStatus != "intentionally_disabled" {
 		t.Fatalf("gate=%+v", g)
 	}
 }
 func TestEvaluateHookGateFailsEveryClosureHazard(t *testing.T) {
-	tests := map[string]func(*hookCensusReport, *hookProfileReport, *codexToolErrorSummary){"unknown": func(c *hookCensusReport, _ *hookProfileReport, _ *codexToolErrorSummary) { c.PreToolUse.Unknown = 1 }, "disabled": func(c *hookCensusReport, _ *hookProfileReport, _ *codexToolErrorSummary) { c.PostToolUse.Disabled = 1 }, "stale": func(c *hookCensusReport, _ *hookProfileReport, _ *codexToolErrorSummary) { c.TelemetryFresh = false }, "profile mismatch": func(c *hookCensusReport, _ *hookProfileReport, _ *codexToolErrorSummary) { c.ProfileMatch = false }, "hook failure": func(c *hookCensusReport, _ *hookProfileReport, _ *codexToolErrorSummary) { c.PostToolUse.Failed = 1 }, "unexpected": func(_ *hookCensusReport, _ *hookProfileReport, o *codexToolErrorSummary) { o.OutcomeErrors = 1 }}
+	tests := map[string]func(*hookCensusReport, *hookProfileReport, *codexToolErrorSummary){"unknown": func(c *hookCensusReport, _ *hookProfileReport, _ *codexToolErrorSummary) { c.PreToolUse.Unknown = 1 }, "disabled": func(c *hookCensusReport, _ *hookProfileReport, _ *codexToolErrorSummary) {
+		c.PostToolUseStatus = "disabled"
+		c.PostToolUse.Disabled = 1
+	}, "stale": func(c *hookCensusReport, _ *hookProfileReport, _ *codexToolErrorSummary) { c.TelemetryFresh = false }, "profile mismatch": func(c *hookCensusReport, _ *hookProfileReport, _ *codexToolErrorSummary) { c.ProfileMatch = false }, "hook failure": func(c *hookCensusReport, _ *hookProfileReport, _ *codexToolErrorSummary) {
+		c.PostToolUseStatus = "failing"
+		c.PostToolUse.Failed = 1
+	}, "unexpected": func(_ *hookCensusReport, _ *hookProfileReport, o *codexToolErrorSummary) { o.OutcomeErrors = 1 }}
 	for name, mutate := range tests {
 		t.Run(name, func(t *testing.T) {
 			c, p := healthyGateFixture()
@@ -29,6 +37,37 @@ func TestEvaluateHookGateFailsEveryClosureHazard(t *testing.T) {
 				t.Fatalf("gate=%+v", got)
 			}
 		})
+	}
+}
+
+func TestEvaluateHookGateRejectsPresentStalePostToolUse(t *testing.T) {
+	c, p := healthyGateFixture()
+	p.Hooks = append(p.Hooks, effectiveHook{EventName: "post_tool_use", Enabled: true, State: "stale_hash"})
+	applyCodexHookContract(&p)
+	g := evaluateHookRecurrence(c, p, codexToolErrorSummary{}, 0, 0)
+	if g.Verdict != "FAIL" || !slices.Contains(g.Reasons, "EFFECTIVE_PROFILE_UNHEALTHY") {
+		t.Fatalf("gate=%+v", g)
+	}
+}
+
+func TestEvaluateHookGateRejectsPresentPostToolUseWithoutReceipt(t *testing.T) {
+	c, _ := healthyGateFixture()
+	p := effectivePostToolProfile()
+	c.PostToolUseStatus = "incomplete"
+	c.PostToolUse = lifecycleCounts{Denominator: 2, Unknown: 2}
+	g := evaluateHookRecurrence(c, p, codexToolErrorSummary{}, 0, 0)
+	if g.Verdict != "FAIL" || !slices.Contains(g.Reasons, "UNKNOWN_LIFECYCLE_ROWS") {
+		t.Fatalf("gate=%+v", g)
+	}
+}
+
+func TestEvaluateHookGateRejectsFailingPresentPostToolUseReceipt(t *testing.T) {
+	c, p := healthyGateFixture()
+	c.PostToolUseStatus = "failing"
+	c.PostToolUse = lifecycleCounts{Denominator: 1, Attempted: 1, Failed: 1}
+	g := evaluateHookRecurrence(c, p, codexToolErrorSummary{}, 0, 0)
+	if g.Verdict != "FAIL" || !slices.Contains(g.Reasons, "HOOK_FAILURE_BUDGET_EXCEEDED") {
+		t.Fatalf("gate=%+v", g)
 	}
 }
 

--- a/internal/devcmd/codexhook_profile.go
+++ b/internal/devcmd/codexhook_profile.go
@@ -46,16 +46,23 @@ type effectiveHook struct {
 	Remediation  string               `json:"remediation,omitempty"`
 	Identities   []executableIdentity `json:"identities,omitempty"`
 }
+type hookEventContract struct {
+	EventName   string `json:"event_name"`
+	Requirement string `json:"requirement"`
+	Status      string `json:"status"`
+	Detail      string `json:"detail,omitempty"`
+}
 type hookProfileReport struct {
-	Schema          string             `json:"schema"`
-	CodexHome       string             `json:"codex_home"`
-	Workspace       string             `json:"workspace"`
-	ConfigPath      string             `json:"config_path"`
-	CodexExecutable executableIdentity `json:"codex_executable"`
-	Hooks           []effectiveHook    `json:"hooks"`
-	Warnings        []string           `json:"warnings,omitempty"`
-	Errors          []string           `json:"errors,omitempty"`
-	Verdict         string             `json:"verdict"`
+	Schema          string              `json:"schema"`
+	CodexHome       string              `json:"codex_home"`
+	Workspace       string              `json:"workspace"`
+	ConfigPath      string              `json:"config_path"`
+	CodexExecutable executableIdentity  `json:"codex_executable"`
+	Hooks           []effectiveHook     `json:"hooks"`
+	EventContracts  []hookEventContract `json:"event_contracts"`
+	Warnings        []string            `json:"warnings,omitempty"`
+	Errors          []string            `json:"errors,omitempty"`
+	Verdict         string              `json:"verdict"`
 }
 type appServerReply struct {
 	ID     int `json:"id"`
@@ -157,9 +164,6 @@ func inspectCodexHookProfileContext(ctx context.Context, home, workspace, binary
 		x := effectiveHook{EventName: event, Key: h.Key, Source: h.Source, SourcePath: h.SourcePath, PluginID: h.PluginID, DisplayOrder: h.DisplayOrder, Enabled: h.Enabled, Managed: h.IsManaged, CurrentHash: h.CurrentHash, TrustStatus: h.TrustStatus, Command: h.Command, Matcher: h.Matcher, TimeoutSec: h.TimeoutSec}
 		classifyEffectiveHook(&x, home)
 		r.Hooks = append(r.Hooks, x)
-		if x.State != "effective" {
-			r.Verdict = "UNHEALTHY"
-		}
 	}
 	sort.Slice(r.Hooks, func(i, j int) bool {
 		if r.Hooks[i].EventName == r.Hooks[j].EventName {
@@ -167,21 +171,91 @@ func inspectCodexHookProfileContext(ctx context.Context, home, workspace, binary
 		}
 		return r.Hooks[i].EventName < r.Hooks[j].EventName
 	})
-	for _, event := range []string{"pre_tool_use", "post_tool_use", "stop", "subagent_stop"} {
-		found := false
-		for _, h := range r.Hooks {
-			found = found || h.EventName == event
-		}
-		if !found {
-			r.Errors = append(r.Errors, "missing effective "+event+" hook")
-			r.Verdict = "UNHEALTHY"
-		}
-	}
-	if len(r.Errors) > 0 {
-		r.Verdict = "UNHEALTHY"
-	}
+	applyCodexHookContract(&r)
 	return r, nil
 }
+
+func applyCodexHookContract(r *hookProfileReport) {
+	r.EventContracts = nil
+	r.Errors = withoutGeneratedHookContractErrors(r.Errors)
+	byEvent := make(map[string][]effectiveHook)
+	unhealthy := len(r.Errors) > 0
+	for _, h := range r.Hooks {
+		event := normalizeHookEvent(h.EventName)
+		byEvent[event] = append(byEvent[event], h)
+		if h.State != "effective" {
+			unhealthy = true
+		}
+	}
+
+	for _, event := range []string{"pre_tool_use", "stop", "subagent_stop"} {
+		hooks := byEvent[event]
+		status := "effective"
+		effective := false
+		for _, h := range hooks {
+			effective = effective || h.State == "effective"
+		}
+		if !effective {
+			status = "missing"
+			if len(hooks) > 0 {
+				status = "unhealthy"
+			}
+			r.Errors = append(r.Errors, "missing effective "+event+" hook")
+			unhealthy = true
+		} else {
+			for _, h := range hooks {
+				if h.State != "effective" {
+					status = "unhealthy"
+					break
+				}
+			}
+		}
+		r.EventContracts = append(r.EventContracts, hookEventContract{EventName: event, Requirement: "mandatory", Status: status})
+	}
+
+	postHooks := byEvent["post_tool_use"]
+	post := hookEventContract{
+		EventName:   "post_tool_use",
+		Requirement: "optional",
+		Status:      "intentionally_disabled",
+		Detail:      "zero handlers are intentional because successful advisory PostToolUse hooks create foreground spam",
+	}
+	if len(postHooks) > 0 {
+		post.Status = "effective"
+		post.Detail = "optional handler is present and is still diagnosed"
+		for _, h := range postHooks {
+			if h.State != "effective" {
+				post.Status = "unhealthy"
+				unhealthy = true
+				break
+			}
+		}
+	}
+	r.EventContracts = append(r.EventContracts, post)
+	r.Errors = uniqueStrings(r.Errors)
+	r.Verdict = "HEALTHY"
+	if unhealthy || len(r.Errors) > 0 {
+		r.Verdict = "UNHEALTHY"
+	}
+}
+
+func withoutGeneratedHookContractErrors(errors []string) []string {
+	out := errors[:0]
+	for _, err := range errors {
+		generated := false
+		for _, event := range []string{"pre_tool_use", "post_tool_use", "stop", "subagent_stop"} {
+			if err == "missing effective "+event+" hook" {
+				generated = true
+				break
+			}
+		}
+		if !generated {
+			out = append(out, err)
+		}
+	}
+	return out
+}
+
 func isObservedHookEvent(event string) bool {
 	switch event {
 	case "pre_tool_use", "post_tool_use", "stop", "subagent_stop", "stop_failure":
@@ -333,6 +407,13 @@ func queryCodexHooksContext(ctx context.Context, home, workspace, binary string)
 }
 func writeHookProfile(w io.Writer, r hookProfileReport) {
 	fmt.Fprintf(w, "Codex effective hook profile\nCODEX_HOME: %s\nconfig: %s\nworkspace: %s\nCodex binary: %s %s\n", r.CodexHome, r.ConfigPath, r.Workspace, r.CodexExecutable.Path, r.CodexExecutable.SHA256)
+	for _, c := range r.EventContracts {
+		fmt.Fprintf(w, "%s requirement=%s status=%s", c.EventName, c.Requirement, c.Status)
+		if c.Detail != "" {
+			fmt.Fprintf(w, " (%s)", c.Detail)
+		}
+		fmt.Fprintln(w)
+	}
 	for _, h := range r.Hooks {
 		fmt.Fprintf(w, "%s order=%d state=%s enabled=%t trust=%s source=%s sourcePath=%s\n  key: %s\n  command: %s\n", h.EventName, h.DisplayOrder, h.State, h.Enabled, h.TrustStatus, h.Source, h.SourcePath, h.Key, h.Command)
 		for _, id := range h.Identities {

--- a/internal/devcmd/codexhook_profile_test.go
+++ b/internal/devcmd/codexhook_profile_test.go
@@ -1,9 +1,12 @@
 package devcmd
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
+	"strings"
 	"testing"
 )
 
@@ -104,4 +107,109 @@ func TestClassifyEffectiveHookRejectsIncompatibleWindowsCommand(t *testing.T) {
 	if h.Remediation == "" {
 		t.Fatal("platform incompatibility needs actionable remediation")
 	}
+}
+
+func TestHookProfileAcceptsZeroPostToolUseWithMandatoryEnforcementHooks(t *testing.T) {
+	r := mandatoryOnlyHookProfile()
+	if r.Verdict != "HEALTHY" || len(r.Errors) != 0 {
+		t.Fatalf("profile=%+v", r)
+	}
+	post := findHookEventContract(t, r, "post_tool_use")
+	if post.Requirement != "optional" || post.Status != "intentionally_disabled" || !strings.Contains(post.Detail, "foreground spam") {
+		t.Fatalf("post contract=%+v", post)
+	}
+	for _, event := range []string{"pre_tool_use", "stop", "subagent_stop"} {
+		contract := findHookEventContract(t, r, event)
+		if contract.Requirement != "mandatory" || contract.Status != "effective" {
+			t.Fatalf("%s contract=%+v", event, contract)
+		}
+	}
+	var out bytes.Buffer
+	writeHookProfile(&out, r)
+	if !strings.Contains(out.String(), "post_tool_use requirement=optional status=intentionally_disabled") {
+		t.Fatalf("human profile did not explain optional PostToolUse:\n%s", out.String())
+	}
+}
+
+func TestHookProfileRequiresEveryMandatoryEnforcementHook(t *testing.T) {
+	for _, missing := range []string{"pre_tool_use", "stop", "subagent_stop"} {
+		t.Run(missing, func(t *testing.T) {
+			r := hookProfileReport{}
+			for _, h := range mandatoryEffectiveHooks() {
+				if h.EventName != missing {
+					r.Hooks = append(r.Hooks, h)
+				}
+			}
+			applyCodexHookContract(&r)
+			if r.Verdict != "UNHEALTHY" || !slices.Contains(r.Errors, "missing effective "+missing+" hook") {
+				t.Fatalf("profile=%+v", r)
+			}
+		})
+	}
+}
+
+func TestApplyCodexHookContractRebuildsGeneratedErrors(t *testing.T) {
+	r := hookProfileReport{Errors: []string{"hooks/list source error", "missing effective post_tool_use hook"}}
+	applyCodexHookContract(&r)
+	if r.Verdict != "UNHEALTHY" || len(r.Errors) != 4 {
+		t.Fatalf("first profile=%+v", r)
+	}
+	r.Hooks = mandatoryEffectiveHooks()
+	applyCodexHookContract(&r)
+	if r.Verdict != "UNHEALTHY" || !slices.Equal(r.Errors, []string{"hooks/list source error"}) {
+		t.Fatalf("second profile=%+v", r)
+	}
+	r.Errors = nil
+	applyCodexHookContract(&r)
+	if r.Verdict != "HEALTHY" || len(r.Errors) != 0 {
+		t.Fatalf("third profile=%+v", r)
+	}
+}
+
+func TestHookProfileDiagnosesPresentUnhealthyPostToolUse(t *testing.T) {
+	for _, state := range []string{"disabled", "stale_hash", "untrusted", "platform_incompatible", "missing_executable"} {
+		t.Run(state, func(t *testing.T) {
+			r := hookProfileReport{Hooks: append(mandatoryEffectiveHooks(), effectiveHook{EventName: "post_tool_use", State: state})}
+			applyCodexHookContract(&r)
+			if r.Verdict != "UNHEALTHY" {
+				t.Fatalf("profile=%+v", r)
+			}
+			post := findHookEventContract(t, r, "post_tool_use")
+			if post.Status != "unhealthy" {
+				t.Fatalf("post contract=%+v", post)
+			}
+		})
+	}
+}
+
+func mandatoryEffectiveHooks() []effectiveHook {
+	return []effectiveHook{
+		{EventName: "pre_tool_use", State: "effective", Enabled: true},
+		{EventName: "stop", State: "effective", Enabled: true},
+		{EventName: "subagent_stop", State: "effective", Enabled: true},
+	}
+}
+
+func mandatoryOnlyHookProfile() hookProfileReport {
+	r := hookProfileReport{Hooks: mandatoryEffectiveHooks()}
+	applyCodexHookContract(&r)
+	return r
+}
+
+func effectivePostToolProfile() hookProfileReport {
+	r := mandatoryOnlyHookProfile()
+	r.Hooks = append(r.Hooks, effectiveHook{EventName: "post_tool_use", State: "effective", Enabled: true})
+	applyCodexHookContract(&r)
+	return r
+}
+
+func findHookEventContract(t *testing.T, r hookProfileReport, event string) hookEventContract {
+	t.Helper()
+	for _, contract := range r.EventContracts {
+		if contract.EventName == event {
+			return contract
+		}
+	}
+	t.Fatalf("missing %s event contract in %+v", event, r.EventContracts)
+	return hookEventContract{}
 }

--- a/internal/projectassets/projectassets.go
+++ b/internal/projectassets/projectassets.go
@@ -160,11 +160,35 @@ func skillDescription(root, path string) (string, error) {
 		if strings.HasPrefix(line, "description:") {
 			description := strings.TrimSpace(strings.TrimPrefix(line, "description:"))
 			if description != "" {
-				return description, nil
+				return decodeYAMLScalar(description), nil
 			}
 		}
 	}
 	return "", fmt.Errorf("%s has no frontmatter description", path)
+}
+
+// decodeYAMLScalar removes the quoting used by canonical skill frontmatter.
+// Generated adapters re-encode the value after truncation; truncating the
+// original quoted token could otherwise leave an unterminated YAML scalar.
+func decodeYAMLScalar(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) < 2 {
+		return value
+	}
+	switch value[0] {
+	case '"':
+		if value[len(value)-1] == '"' {
+			var decoded string
+			if json.Unmarshal([]byte(value), &decoded) == nil {
+				return decoded
+			}
+		}
+	case '\'':
+		if value[len(value)-1] == '\'' {
+			return strings.ReplaceAll(value[1:len(value)-1], "''", "'")
+		}
+	}
+	return value
 }
 func adapterDescription(description string) string {
 	runes := []rune(strings.TrimSpace(description))
@@ -185,7 +209,8 @@ func adapterDescription(description string) string {
 
 func adapter(name, description, rel string) string {
 	description = adapterDescription(description)
-	return fmt.Sprintf("---\nname: %s\ndescription: %s\nmetadata:\n  generated-by: fak project-assets sync\n  canonical: %s\n---\n\n# Canonical project skill adapter\n\nLoad and follow [`%s`](%s). This generated discovery adapter contains no maintained workflow body.\n\n## Portability contract\n\n- The linked canonical `SKILL.md` is the single semantic workflow body for Claude, Codex, and fak-native loaders.\n- This adapter changes discovery only; it must not fork, summarize, or translate the workflow.\n- Harness-native invocation, permissions, hooks, model routing, and worker launch remain typed adapters outside the semantic body.\n", name, description, rel, rel, rel)
+	encoded, _ := json.Marshal(description)
+	return fmt.Sprintf("---\nname: %s\ndescription: %s\nmetadata:\n  generated-by: fak project-assets sync\n  canonical: %s\n---\n\n# Canonical project skill adapter\n\nLoad and follow [`%s`](%s). This generated discovery adapter contains no maintained workflow body.\n\n## Portability contract\n\n- The linked canonical `SKILL.md` is the single semantic workflow body for Claude, Codex, and fak-native loaders.\n- This adapter changes discovery only; it must not fork, summarize, or translate the workflow.\n- Harness-native invocation, permissions, hooks, model routing, and worker launch remain typed adapters outside the semantic body.\n", name, encoded, rel, rel, rel)
 }
 
 func classify(root, kind string, p Policy) ([]string, []Excluded, error) {

--- a/internal/projectassets/projectassets_test.go
+++ b/internal/projectassets/projectassets_test.go
@@ -61,7 +61,7 @@ func TestBuildSyncsWindowsSafeCodexAdapterAndParity(t *testing.T) {
 	if string(b) == "body\n" {
 		t.Fatal("adapter copied maintained skill body")
 	}
-	if !strings.Contains(string(b), "description: Verify.") {
+	if !strings.Contains(string(b), "description:") || !strings.Contains(string(b), "Verify.") {
 		t.Fatalf("adapter lost canonical discovery description:\n%s", b)
 	}
 }
@@ -270,5 +270,35 @@ func TestCodexAdapterDescriptionsCutResidentFloorByThree(t *testing.T) {
 	}
 	if total*3 > baselineChars {
 		t.Fatalf("adapter descriptions total %d characters, want at most one third of baseline %d", total, baselineChars)
+	}
+}
+
+func TestAdapterDecodesAndRequotesYAMLDescriptions(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, ".claude/skills/quoted/SKILL.md", "---\nname: quoted\ndescription: \"Use a colon: safely and say \\\"hello\\\".\"\n---\n")
+	description, err := skillDescription(root, ".claude/skills/quoted/SKILL.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := `Use a colon: safely and say "hello".`; description != want {
+		t.Fatalf("description = %q, want %q", description, want)
+	}
+	body := adapter("quoted", strings.Repeat(description+" ", 20), "../../../.claude/skills/quoted/SKILL.md")
+	line := strings.Split(body, "\n")[2]
+	if !strings.HasPrefix(line, `description: "`) || !strings.HasSuffix(line, `..."`) {
+		t.Fatalf("adapter description is not a complete quoted scalar: %q", line)
+	}
+	var decoded string
+	if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "description: ")), &decoded); err != nil {
+		t.Fatalf("generated description is invalid JSON/YAML quoting: %v", err)
+	}
+	if len([]rune(decoded)) > maxSkillDescriptionChars {
+		t.Fatalf("decoded description has %d characters", len([]rune(decoded)))
+	}
+}
+
+func TestDecodeYAMLScalarSingleQuotedEscapes(t *testing.T) {
+	if got, want := decodeYAMLScalar(`'agent''s trigger'`), "agent's trigger"; got != want {
+		t.Fatalf("decodeYAMLScalar = %q, want %q", got, want)
 	}
 }

--- a/internal/sessionrecovery/recovery.go
+++ b/internal/sessionrecovery/recovery.go
@@ -129,7 +129,7 @@ func Select(report InventoryReport, opts Options) []Request {
 			out = append(out, req)
 			continue
 		}
-		req.Argv = []string{opts.ManagerBin, "guard", "--", opts.CodexBin, "resume", id}
+		req.Argv = codexResumeArgv(opts.ManagerBin, opts.CodexBin, id, cwd)
 		if opts.Prompt != "" {
 			req.Argv = append(req.Argv, opts.Prompt)
 		}
@@ -152,6 +152,14 @@ func Select(report InventoryReport, opts Options) []Request {
 		}
 	}
 	return out
+}
+
+func codexResumeArgv(managerBin, codexBin, threadID, cwd string) []string {
+	// Windows Terminal's startingDirectory and exec.Cmd.Dir establish the process CWD,
+	// but Codex owns the resumed agent's working root. Pin that root explicitly so a
+	// terminal-profile startup command or Codex's saved-session state cannot leave the
+	// recovered session in the launcher's directory and trigger another directory prompt.
+	return []string{managerBin, "guard", "--", codexBin, "resume", "--cd", cwd, threadID}
 }
 
 func recoveryEligibility(row Session, explicit bool) (string, string) {
@@ -213,7 +221,7 @@ func MergeJournalCrashes(requests []Request, classified []sessionjournal.Classif
 			if codexBin == "" {
 				codexBin = "codex"
 			}
-			req.Argv = []string{managerBin, "guard", "--", codexBin, "resume", row.Session.ID}
+			req.Argv = codexResumeArgv(managerBin, codexBin, row.Session.ID, cwd)
 			if opts.Prompt != "" {
 				req.Argv = append(req.Argv, opts.Prompt)
 			}

--- a/internal/sessionrecovery/recovery_test.go
+++ b/internal/sessionrecovery/recovery_test.go
@@ -63,7 +63,7 @@ func TestSelectIgnoresInventoryRowsWithoutThreads(t *testing.T) {
 
 func TestSelectPreservesPromptAsOneArg(t *testing.T) {
 	got := Select(InventoryReport{Sessions: []Session{candidate(`C:\work\fak`)}}, Options{Limit: 1, Prompt: "continue the exact task", ReceiptDir: t.TempDir()})
-	want := []string{"fak", "guard", "--", "codex", "resume", "t1", "continue the exact task"}
+	want := []string{"fak", "guard", "--", "codex", "resume", "--cd", `C:\work\fak`, "t1", "continue the exact task"}
 	if len(got) != 1 || !reflect.DeepEqual(got[0].Argv, want) {
 		t.Fatalf("argv=%q want %q", got[0].Argv, want)
 	}
@@ -163,7 +163,7 @@ func TestMergeJournalCrashesUsesRecordedCWDAndDeduplicates(t *testing.T) {
 	if got[0].ThreadID != "already" || got[0].CWD != `C:\authoritative` || got[0].Source != "session_journal" {
 		t.Fatalf("journal did not replace reconstructed cwd: %+v", got[0])
 	}
-	wantArgv := []string{"fak", "guard", "--", "codex", "resume", "journal", "resume safely"}
+	wantArgv := []string{"fak", "guard", "--", "codex", "resume", "--cd", `D:\repos\real tree`, "journal", "resume safely"}
 	if got[1].CWD != `D:\repos\real tree` || got[1].Source != "session_journal" || !reflect.DeepEqual(got[1].Argv, wantArgv) {
 		t.Fatalf("journal request=%+v", got[1])
 	}

--- a/tools/concept_disambiguation_scorecard.data/_meta.json
+++ b/tools/concept_disambiguation_scorecard.data/_meta.json
@@ -12209,6 +12209,11 @@
           "category": "incidental",
           "reason": "Internal bounded-retry implementation detail; it does not define a new operator-facing plan concept.",
           "token": "auditDispatchWaveExecutionPlanWithFallback"
+        },
+        {
+          "category": "incidental",
+          "reason": "CLI-local data type for rendering profile sweep commands; not a new planning-domain concept",
+          "token": "agentProfileSweepPlan"
         }
       ],
       "exclude": [
@@ -12302,6 +12307,7 @@
         "WatchdogIncludeAbruptInteractive",
         "WatchdogPlanRows",
         "WriteMergePlan",
+        "agentProfileSweepPlan",
         "auditDispatchWaveExecutionPlanBounded",
         "auditDispatchWaveExecutionPlanWithFallback",
         "auditedPlan",


### PR DESCRIPTION
Closes #8062. Aligns fak diagnostics with the shipped DOS topology: PreToolUse, Stop, and SubagentStop remain mandatory; zero PostToolUse handlers is intentional because Codex renders declared advisory hook lifecycle rows in the foreground. Includes generated skill YAML hardening and focused tests. Fresh allow/deny runtime evidence is linked in #8062.