### PR TITLE
fix(codexhooks): keep PostToolUse intentionally disabled

### DIFF
--- a/internal/devcmd/codexhook_census.go
+++ b/internal/devcmd/codexhook_census.go
@@ -33,28 +33,30 @@ type lifecycleCounts struct {
 }
 
 type hookCensusReport struct {
-	Schema             string             `json:"schema"`
-	GeneratedAt        time.Time          `json:"generated_at"`
-	Window             string             `json:"window"`
-	CodexHome          string             `json:"codex_home"`
-	LogStore           string             `json:"log_store"`
-	Workspace          string             `json:"workspace"`
-	ObservationStore   string             `json:"observation_store"`
-	ProfileMatch       bool               `json:"profile_match"`
-	DispatchedCalls    int                `json:"dispatched_calls"`
-	DispatchSource     string             `json:"dispatch_source"`
-	PreToolUse         lifecycleCounts    `json:"pre_tool_use"`
-	PostToolUse        lifecycleCounts    `json:"post_tool_use"`
-	Stop               lifecycleCounts    `json:"stop"`
-	StopFailure        lifecycleCounts    `json:"stop_failure"`
-	SubagentStop       lifecycleCounts    `json:"subagent_stop"`
-	StopSource         string             `json:"stop_source,omitempty"`
-	StopRuns           []stopLifecycleRow `json:"stop_runs,omitempty"`
-	TelemetryFresh     bool               `json:"telemetry_fresh"`
-	NewestReceipt      time.Time          `json:"newest_receipt,omitempty"`
-	Verdict            string             `json:"verdict"`
-	PostToolSettlement string             `json:"post_tool_settlement"`
-	Reasons            []string           `json:"reasons,omitempty"`
+	Schema                 string             `json:"schema"`
+	GeneratedAt            time.Time          `json:"generated_at"`
+	Window                 string             `json:"window"`
+	CodexHome              string             `json:"codex_home"`
+	LogStore               string             `json:"log_store"`
+	Workspace              string             `json:"workspace"`
+	ObservationStore       string             `json:"observation_store"`
+	ProfileMatch           bool               `json:"profile_match"`
+	DispatchedCalls        int                `json:"dispatched_calls"`
+	DispatchSource         string             `json:"dispatch_source"`
+	PreToolUse             lifecycleCounts    `json:"pre_tool_use"`
+	PostToolUse            lifecycleCounts    `json:"post_tool_use"`
+	PostToolUseRequirement string             `json:"post_tool_use_requirement"`
+	PostToolUseStatus      string             `json:"post_tool_use_status"`
+	Stop                   lifecycleCounts    `json:"stop"`
+	StopFailure            lifecycleCounts    `json:"stop_failure"`
+	SubagentStop           lifecycleCounts    `json:"subagent_stop"`
+	StopSource             string             `json:"stop_source,omitempty"`
+	StopRuns               []stopLifecycleRow `json:"stop_runs,omitempty"`
+	TelemetryFresh         bool               `json:"telemetry_fresh"`
+	NewestReceipt          time.Time          `json:"newest_receipt,omitempty"`
+	Verdict                string             `json:"verdict"`
+	PostToolSettlement     string             `json:"post_tool_settlement"`
+	Reasons                []string           `json:"reasons,omitempty"`
 }
 
 type hookObservation struct {
@@ -284,6 +286,7 @@ func RunCodexHookCensus(stdout, stderr io.Writer, args []string) int {
 	home := fs.String("codex-home", "", "active Codex home")
 	logHome := fs.String("log-home", "", "Codex home whose sessions are counted")
 	workspace := fs.String("workspace", ".", "workspace whose calls are counted")
+	binary := fs.String("codex-binary", "", "Codex executable used to resolve the effective hook profile")
 	threadID := fs.String("thread-id", os.Getenv("CODEX_THREAD_ID"), "Codex thread whose calls are counted (empty counts workspace)")
 	observations := fs.String("observations", filepath.Join(".dos", "metrics", "observations.jsonl"), "hook observation JSONL")
 	stopEvents := fs.String("stop-events", "", "Codex app-server hook notification JSONL")
@@ -291,7 +294,7 @@ func RunCodexHookCensus(stdout, stderr io.Writer, args []string) int {
 	asJSON := fs.Bool("json", false, "emit JSON")
 	nowText := fs.String("now", "", "fixed RFC3339 clock (tests/captures)")
 	if err := fs.Parse(args); err != nil || fs.NArg() != 0 || *since <= 0 {
-		fmt.Fprintln(stderr, "usage: fak-dev codex-hook-census [--codex-home DIR] [--log-home DIR] [--observations FILE] [--stop-events FILE] [--since 24h] [--json]")
+		fmt.Fprintln(stderr, "usage: fak-dev codex-hook-census [--codex-home DIR] [--log-home DIR] [--codex-binary FILE] [--observations FILE] [--stop-events FILE] [--since 24h] [--json]")
 		return 2
 	}
 	now := time.Now().UTC()
@@ -316,7 +319,12 @@ func RunCodexHookCensus(stdout, stderr io.Writer, args []string) int {
 	if *logHome == "" {
 		*logHome = *home
 	}
-	report, err := buildHookCensus(*home, *logHome, *workspace, *threadID, *observations, *since, now)
+	profile, err := inspectCodexHookProfile(*home, *workspace, *binary)
+	if err != nil {
+		fmt.Fprintf(stderr, "codex-hook-census: profile: %v\n", err)
+		return 1
+	}
+	report, err := buildHookCensus(*home, *logHome, *workspace, *threadID, *observations, profile, *since, now)
 	if err != nil {
 		fmt.Fprintf(stderr, "codex-hook-census: %v\n", err)
 		return 1
@@ -341,7 +349,7 @@ func RunCodexHookCensus(stdout, stderr io.Writer, args []string) int {
 	return 0
 }
 
-func buildHookCensus(home, logHome, workspace, threadID, observations string, since time.Duration, now time.Time) (hookCensusReport, error) {
+func buildHookCensus(home, logHome, workspace, threadID, observations string, profile hookProfileReport, since time.Duration, now time.Time) (hookCensusReport, error) {
 	absHome, _ := filepath.Abs(home)
 	absLog, _ := filepath.Abs(logHome)
 	absObs, _ := filepath.Abs(observations)
@@ -354,9 +362,10 @@ func buildHookCensus(home, logHome, workspace, threadID, observations string, si
 	if err != nil {
 		return hookCensusReport{}, err
 	}
-	r := hookCensusReport{Schema: codexHookCensusSchema, GeneratedAt: now, Window: since.String(), PostToolSettlement: codexPostToolSettlementWindow.String(), CodexHome: absHome, LogStore: absLog, Workspace: absWork, ObservationStore: absObs, ProfileMatch: samePath(absHome, absLog), DispatchedCalls: len(calls), DispatchSource: filepath.Join(absLog, "sessions"), NewestReceipt: newest, TelemetryFresh: !newest.IsZero() && now.Sub(newest) <= 5*time.Minute}
+	r := hookCensusReport{Schema: codexHookCensusSchema, GeneratedAt: now, Window: since.String(), PostToolSettlement: codexPostToolSettlementWindow.String(), CodexHome: absHome, LogStore: absLog, Workspace: absWork, ObservationStore: absObs, ProfileMatch: samePath(absHome, absLog), DispatchedCalls: len(calls), DispatchSource: filepath.Join(absLog, "sessions"), NewestReceipt: newest, TelemetryFresh: !newest.IsZero() && now.Sub(newest) <= 5*time.Minute, PostToolUseRequirement: "optional"}
 	r.PreToolUse = phaseCountsForCalls(calls, receipts["pretool"], absHome, absWork, absObs)
 	r.PostToolUse = postToolPhaseCounts(postToolEligibleDispatches(calls, now.Add(-codexPostToolSettlementWindow)), receipts["posttool"], absHome, absWork, absObs)
+	applyHookProfileToCensus(&r, profile)
 	if !r.TelemetryFresh {
 		r.Reasons = append(r.Reasons, "STALE_TELEMETRY")
 	}
@@ -370,16 +379,44 @@ func buildHookCensus(home, logHome, workspace, threadID, observations string, si
 	return r, nil
 }
 
+func applyHookProfileToCensus(r *hookCensusReport, profile hookProfileReport) {
+	present := false
+	for _, h := range profile.Hooks {
+		if normalizeHookEvent(h.EventName) == "post_tool_use" {
+			present = true
+			break
+		}
+	}
+	r.PostToolUseRequirement = "optional"
+	if !present {
+		source := r.PostToolUse.Source
+		r.PostToolUse = lifecycleCounts{Source: source}
+		r.PostToolUseStatus = "intentionally_disabled"
+		return
+	}
+	r.PostToolUseStatus = "observed"
+	if r.PostToolUse.Disabled > 0 {
+		r.PostToolUseStatus = "disabled"
+	} else if r.PostToolUse.Failed > 0 {
+		r.PostToolUseStatus = "failing"
+	} else if r.PostToolUse.Unknown > 0 {
+		r.PostToolUseStatus = "incomplete"
+	}
+}
+
 func finalizeCensusVerdict(r *hookCensusReport) {
 	reasons := append([]string(nil), r.Reasons...)
 	if r.PreToolUse.Unknown > 0 {
 		reasons = append(reasons, "PRE_TOOL_USE_UNKNOWN")
 	}
-	if r.PostToolUse.Unknown > 0 {
+	if r.PostToolUseStatus != "intentionally_disabled" && r.PostToolUse.Unknown > 0 {
 		reasons = append(reasons, "POST_TOOL_USE_UNKNOWN")
 	}
 	if r.PreToolUse.Failed > 0 || r.PostToolUse.Failed > 0 {
 		reasons = append(reasons, "HOOK_FAILURES_PRESENT")
+	}
+	if r.PostToolUse.Disabled > 0 {
+		reasons = append(reasons, "POST_TOOL_USE_DISABLED")
 	}
 	for _, stop := range []struct {
 		name string
@@ -669,12 +706,8 @@ func readHookObservations(path string, after time.Time) (map[string][]hookObserv
 }
 func writeHookCensus(w io.Writer, r hookCensusReport) {
 	fmt.Fprintf(w, "Codex hook lifecycle census (%s)\nprofile: %s\nlog store: %s (match=%t)\ndispatched calls: %d [source=%s]\n", r.Window, r.CodexHome, r.LogStore, r.ProfileMatch, r.DispatchedCalls, r.DispatchSource)
-	for _, p := range []struct {
-		name string
-		c    lifecycleCounts
-	}{{"PreToolUse", r.PreToolUse}, {"PostToolUse", r.PostToolUse}} {
-		fmt.Fprintf(w, "%s: denominator=%d attempted=%d succeeded=%d failed=%d skipped=%d disabled=%d unknown=%d [source=%s]\n", p.name, p.c.Denominator, p.c.Attempted, p.c.Succeeded, p.c.Failed, p.c.Skipped, p.c.Disabled, p.c.Unknown, p.c.Source)
-	}
+	fmt.Fprintf(w, "PreToolUse: denominator=%d attempted=%d succeeded=%d failed=%d skipped=%d disabled=%d unknown=%d [source=%s]\n", r.PreToolUse.Denominator, r.PreToolUse.Attempted, r.PreToolUse.Succeeded, r.PreToolUse.Failed, r.PreToolUse.Skipped, r.PreToolUse.Disabled, r.PreToolUse.Unknown, r.PreToolUse.Source)
+	fmt.Fprintf(w, "PostToolUse: requirement=%s status=%s denominator=%d attempted=%d succeeded=%d failed=%d skipped=%d disabled=%d unknown=%d [source=%s]\n", r.PostToolUseRequirement, r.PostToolUseStatus, r.PostToolUse.Denominator, r.PostToolUse.Attempted, r.PostToolUse.Succeeded, r.PostToolUse.Failed, r.PostToolUse.Skipped, r.PostToolUse.Disabled, r.PostToolUse.Unknown, r.PostToolUse.Source)
 	sort.Strings(r.Reasons)
 	fmt.Fprintf(w, "verdict: %s", r.Verdict)
 	if len(r.Reasons) > 0 {

--- a/internal/devcmd/codexhook_census_test.go
+++ b/internal/devcmd/codexhook_census_test.go
@@ -33,7 +33,7 @@ func TestBuildHookCensusClassifiesCompleteLifecycle(t *testing.T) {
 	if err := os.WriteFile(obs, b.Bytes(), 0644); err != nil {
 		t.Fatal(err)
 	}
-	got, err := buildHookCensus(home, home, home, "", obs, time.Hour, now)
+	got, err := buildHookCensus(home, home, home, "", obs, effectivePostToolProfile(), time.Hour, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -41,6 +41,101 @@ func TestBuildHookCensusClassifiesCompleteLifecycle(t *testing.T) {
 		t.Fatalf("report=%+v", got)
 	}
 }
+
+func TestBuildHookCensusAcceptsIntentionallyDisabledPostToolUse(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "profile")
+	sessions := filepath.Join(home, "sessions")
+	if err := os.MkdirAll(sessions, 0755); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	rows := `{"timestamp":"2026-08-17T11:59:00Z","type":"session_meta","payload":{"session_id":"thread-1","cwd":"` + filepath.ToSlash(home) + `"}}` + "\n" +
+		`{"timestamp":"2026-08-17T11:00:00Z","type":"response_item","payload":{"type":"function_call","call_id":"a","name":"Read"}}` + "\n" +
+		`{"timestamp":"2026-08-17T11:01:00Z","type":"response_item","payload":{"type":"function_call_output","call_id":"a","name":"Read"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(sessions, "r.jsonl"), []byte(rows), 0644); err != nil {
+		t.Fatal(err)
+	}
+	obs := filepath.Join(root, "observations.jsonl")
+	var b bytes.Buffer
+	_ = json.NewEncoder(&b).Encode(hookObservation{CallID: "a", SessionID: "thread-1", Workspace: home, Profile: home, PhaseState: "succeeded", Verb: "pretool", TS: now.Add(-time.Minute)})
+	_ = json.NewEncoder(&b).Encode(hookObservation{CallID: "foreign", SessionID: "thread-1", Workspace: filepath.Join(root, "foreign"), Profile: home, PhaseState: "failed", Verb: "posttool", TS: now.Add(-time.Minute)})
+	if err := os.WriteFile(obs, b.Bytes(), 0644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := buildHookCensus(home, home, home, "", obs, mandatoryOnlyHookProfile(), time.Hour, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Verdict != "HEALTHY" || got.PreToolUse.Succeeded != 1 || got.PostToolUseRequirement != "optional" || got.PostToolUseStatus != "intentionally_disabled" || got.PostToolUse.Denominator != 0 || got.PostToolUse.Unknown != 0 {
+		t.Fatalf("report=%+v", got)
+	}
+	var out bytes.Buffer
+	writeHookCensus(&out, got)
+	if !strings.Contains(out.String(), "PostToolUse: requirement=optional status=intentionally_disabled") {
+		t.Fatalf("human census did not explain optional PostToolUse:\n%s", out.String())
+	}
+}
+
+func TestBuildHookCensusRejectsPresentPostToolUseWithoutReceipt(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "profile")
+	sessions := filepath.Join(home, "sessions")
+	if err := os.MkdirAll(sessions, 0755); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	rows := `{"timestamp":"2026-08-17T11:59:00Z","type":"session_meta","payload":{"session_id":"thread-1","cwd":"` + filepath.ToSlash(home) + `"}}` + "\n" +
+		`{"timestamp":"2026-08-17T11:00:00Z","type":"response_item","payload":{"type":"function_call","call_id":"a","name":"Read"}}` + "\n" +
+		`{"timestamp":"2026-08-17T11:01:00Z","type":"response_item","payload":{"type":"function_call_output","call_id":"a","name":"Read"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(sessions, "r.jsonl"), []byte(rows), 0644); err != nil {
+		t.Fatal(err)
+	}
+	obs := filepath.Join(root, "observations.jsonl")
+	o := hookObservation{CallID: "a", SessionID: "thread-1", Workspace: home, Profile: home, PhaseState: "succeeded", Verb: "pretool", TS: now.Add(-time.Minute)}
+	raw, _ := json.Marshal(o)
+	if err := os.WriteFile(obs, append(raw, '\n'), 0644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := buildHookCensus(home, home, home, "", obs, effectivePostToolProfile(), time.Hour, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Verdict != "UNHEALTHY" || got.PostToolUseStatus != "incomplete" || got.PostToolUse.Denominator != 1 || got.PostToolUse.Unknown != 1 || !slices.Contains(got.Reasons, "POST_TOOL_USE_UNKNOWN") {
+		t.Fatalf("report=%+v", got)
+	}
+}
+
+func TestBuildHookCensusDiagnosesFailingPresentPostToolUse(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "profile")
+	sessions := filepath.Join(home, "sessions")
+	if err := os.MkdirAll(sessions, 0755); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	rows := `{"timestamp":"2026-08-17T11:59:00Z","type":"session_meta","payload":{"session_id":"thread-1","cwd":"` + filepath.ToSlash(home) + `"}}` + "\n" +
+		`{"timestamp":"2026-08-17T11:00:00Z","type":"response_item","payload":{"type":"function_call","call_id":"a","name":"Read"}}` + "\n" +
+		`{"timestamp":"2026-08-17T11:01:00Z","type":"response_item","payload":{"type":"function_call_output","call_id":"a","name":"Read"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(sessions, "r.jsonl"), []byte(rows), 0644); err != nil {
+		t.Fatal(err)
+	}
+	obs := filepath.Join(root, "observations.jsonl")
+	var b bytes.Buffer
+	_ = json.NewEncoder(&b).Encode(hookObservation{CallID: "a", SessionID: "thread-1", Workspace: home, Profile: home, PhaseState: "succeeded", Verb: "pretool", TS: now.Add(-time.Minute)})
+	_ = json.NewEncoder(&b).Encode(hookObservation{CallID: "a", SessionID: "thread-1", Workspace: home, Profile: home, PhaseState: "failed", Exit: 1, Verb: "posttool", TS: now.Add(-time.Minute)})
+	if err := os.WriteFile(obs, b.Bytes(), 0644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := buildHookCensus(home, home, home, "", obs, effectivePostToolProfile(), time.Hour, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Verdict != "UNHEALTHY" || got.PostToolUseStatus != "failing" || got.PostToolUse.Failed != 1 || !slices.Contains(got.Reasons, "HOOK_FAILURES_PRESENT") {
+		t.Fatalf("report=%+v", got)
+	}
+}
+
 func TestBuildHookCensusPostToolUseExcludesActiveCalls(t *testing.T) {
 	root := t.TempDir()
 	home := filepath.Join(root, "profile")
@@ -68,7 +163,7 @@ func TestBuildHookCensusPostToolUseExcludesActiveCalls(t *testing.T) {
 	if err := os.WriteFile(obs, b.Bytes(), 0644); err != nil {
 		t.Fatal(err)
 	}
-	got, err := buildHookCensus(home, home, home, "", obs, time.Hour, now)
+	got, err := buildHookCensus(home, home, home, "", obs, effectivePostToolProfile(), time.Hour, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,7 +194,7 @@ func TestBuildHookCensusExcludesToolsOutsidePostMatcher(t *testing.T) {
 	if err := os.WriteFile(obs, append(raw, '\n'), 0644); err != nil {
 		t.Fatal(err)
 	}
-	got, err := buildHookCensus(home, home, home, "", obs, time.Hour, now)
+	got, err := buildHookCensus(home, home, home, "", obs, effectivePostToolProfile(), time.Hour, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,7 +222,7 @@ func TestBuildHookCensusSettlesFreshPostToolReceipt(t *testing.T) {
 	if err := os.WriteFile(obs, append(raw, '\n'), 0644); err != nil {
 		t.Fatal(err)
 	}
-	got, err := buildHookCensus(home, home, home, "", obs, time.Hour, now)
+	got, err := buildHookCensus(home, home, home, "", obs, effectivePostToolProfile(), time.Hour, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -149,7 +244,7 @@ func TestBuildHookCensusFailsClosedOnUnknownFailureAndProfileMismatch(t *testing
 	o := hookObservation{CallID: "a", SessionID: "thread-1", Workspace: logHome, Profile: home, PhaseState: "failed", Exit: 3, Verb: "posttool", TS: now.Add(-time.Minute)}
 	raw, _ := json.Marshal(o)
 	_ = os.WriteFile(obs, append(raw, '\n'), 0644)
-	got, err := buildHookCensus(home, logHome, logHome, "", obs, time.Hour, now)
+	got, err := buildHookCensus(home, logHome, logHome, "", obs, effectivePostToolProfile(), time.Hour, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -176,11 +271,11 @@ func TestBuildHookCensusRejectsAbsentTelemetry(t *testing.T) {
 	_ = os.WriteFile(filepath.Join(home, "sessions", "r.jsonl"), []byte(row), 0644)
 	obs := filepath.Join(root, "o.jsonl")
 	_ = os.WriteFile(obs, nil, 0644)
-	got, err := buildHookCensus(home, home, home, "", obs, time.Hour, now)
+	got, err := buildHookCensus(home, home, home, "", obs, mandatoryOnlyHookProfile(), time.Hour, now)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.Verdict != "UNHEALTHY" || got.PreToolUse.Unknown != 1 || got.PostToolUse.Unknown != 1 {
+	if got.Verdict != "UNHEALTHY" || got.PreToolUse.Unknown != 1 || got.PostToolUse.Unknown != 0 || got.PostToolUseStatus != "intentionally_disabled" {
 		t.Fatalf("report=%+v", got)
 	}
 }

--- a/internal/devcmd/codexhook_gate.go
+++ b/internal/devcmd/codexhook_gate.go
@@ -59,7 +59,12 @@ func RunCodexHookRecurrence(stdout, stderr io.Writer, args []string) int {
 		*home = filepath.Join(h, ".codex")
 	}
 	now := time.Now().UTC()
-	c, e := buildHookCensus(*home, *home, *workspace, os.Getenv("CODEX_THREAD_ID"), *observations, *since, now)
+	p, e := inspectCodexHookProfile(*home, *workspace, "")
+	if e != nil {
+		fmt.Fprintf(stderr, "codex-hook-gate: profile: %v\n", e)
+		return 1
+	}
+	c, e := buildHookCensus(*home, *home, *workspace, os.Getenv("CODEX_THREAD_ID"), *observations, p, *since, now)
 	if e != nil {
 		fmt.Fprintf(stderr, "codex-hook-gate: census: %v\n", e)
 		return 1
@@ -70,11 +75,6 @@ func RunCodexHookRecurrence(stdout, stderr io.Writer, args []string) int {
 			return 1
 		}
 		finalizeCensusVerdict(&c)
-	}
-	p, e := inspectCodexHookProfile(*home, *workspace, "")
-	if e != nil {
-		fmt.Fprintf(stderr, "codex-hook-gate: profile: %v\n", e)
-		return 1
 	}
 	outcomes, e := queryCodexToolErrorsForThread(filepath.Join(*home, "logs_2.sqlite"), now.Add(-*since), os.Getenv("CODEX_THREAD_ID"))
 	if e != nil {
@@ -119,13 +119,14 @@ func evaluateHookRecurrence(c hookCensusReport, p hookProfileReport, o codexTool
 	if c.DispatchedCalls == 0 {
 		g.Reasons = append(g.Reasons, "DENOMINATOR_ZERO")
 	}
-	if c.PreToolUse.Unknown > 0 || c.PostToolUse.Unknown > 0 || c.Stop.Unknown > 0 || c.StopFailure.Unknown > 0 || c.SubagentStop.Unknown > 0 {
+	postToolObserved := c.PostToolUseStatus != "intentionally_disabled"
+	if c.PreToolUse.Unknown > 0 || (postToolObserved && c.PostToolUse.Unknown > 0) || c.Stop.Unknown > 0 || c.StopFailure.Unknown > 0 || c.SubagentStop.Unknown > 0 {
 		g.Reasons = append(g.Reasons, "UNKNOWN_LIFECYCLE_ROWS")
 	}
 	if c.Stop.InvalidJSON > 0 || c.StopFailure.InvalidJSON > 0 || c.SubagentStop.InvalidJSON > 0 {
 		g.Reasons = append(g.Reasons, "STOP_INVALID_JSON")
 	}
-	if c.PreToolUse.Disabled > 0 || c.PostToolUse.Disabled > 0 {
+	if c.PreToolUse.Disabled > 0 || (postToolObserved && c.PostToolUse.Disabled > 0) {
 		g.Reasons = append(g.Reasons, "EXPECTED_PHASE_DISABLED")
 	}
 	if failures > maxFailures {
@@ -155,7 +156,7 @@ func expectedStopHooks(p hookProfileReport) int {
 func writeHookRecurrence(w io.Writer, g recurrenceReport) {
 	fmt.Fprintf(w, "Codex hook recurrence gate: %s\nwindow=%s unexpected=%d/%d max=%d hook-failures=%d/%d max=%d telemetry-fresh=%t\n", g.Verdict, g.Window, g.UnexpectedNumerator, g.UnexpectedDenominator, g.Thresholds.MaxUnexpectedOutcomes, g.Census.PreToolUse.Failed+g.Census.PostToolUse.Failed, g.Census.DispatchedCalls, g.Thresholds.MaxHookFailures, g.Census.TelemetryFresh)
 	fmt.Fprintf(w, "pre: attempted=%d succeeded=%d failed=%d skipped=%d disabled=%d unknown=%d denominator=%d\n", g.Census.PreToolUse.Attempted, g.Census.PreToolUse.Succeeded, g.Census.PreToolUse.Failed, g.Census.PreToolUse.Skipped, g.Census.PreToolUse.Disabled, g.Census.PreToolUse.Unknown, g.Census.PreToolUse.Denominator)
-	fmt.Fprintf(w, "post: attempted=%d succeeded=%d failed=%d skipped=%d disabled=%d unknown=%d denominator=%d\n", g.Census.PostToolUse.Attempted, g.Census.PostToolUse.Succeeded, g.Census.PostToolUse.Failed, g.Census.PostToolUse.Skipped, g.Census.PostToolUse.Disabled, g.Census.PostToolUse.Unknown, g.Census.PostToolUse.Denominator)
+	fmt.Fprintf(w, "post: requirement=%s status=%s attempted=%d succeeded=%d failed=%d skipped=%d disabled=%d unknown=%d denominator=%d\n", g.Census.PostToolUseRequirement, g.Census.PostToolUseStatus, g.Census.PostToolUse.Attempted, g.Census.PostToolUse.Succeeded, g.Census.PostToolUse.Failed, g.Census.PostToolUse.Skipped, g.Census.PostToolUse.Disabled, g.Census.PostToolUse.Unknown, g.Census.PostToolUse.Denominator)
 	if len(g.TopCauses) > 0 {
 		fmt.Fprintf(w, "top causes: %s\n", strings.Join(g.TopCauses, "; "))
 	}

--- a/internal/devcmd/codexhook_gate_test.go
+++ b/internal/devcmd/codexhook_gate_test.go
@@ -8,18 +8,26 @@ import (
 
 func healthyGateFixture() (hookCensusReport, hookProfileReport) {
 	now := time.Now()
-	c := hookCensusReport{GeneratedAt: now, Window: "15m", ProfileMatch: true, DispatchedCalls: 2, TelemetryFresh: true, PreToolUse: lifecycleCounts{Denominator: 2, Attempted: 2, Succeeded: 2}, PostToolUse: lifecycleCounts{Denominator: 2, Attempted: 2, Succeeded: 2}}
-	return c, hookProfileReport{Verdict: "HEALTHY"}
+	c := hookCensusReport{GeneratedAt: now, Window: "15m", ProfileMatch: true, DispatchedCalls: 2, TelemetryFresh: true, PreToolUse: lifecycleCounts{Denominator: 2, Attempted: 2, Succeeded: 2}, PostToolUseRequirement: "optional", PostToolUseStatus: "intentionally_disabled", StopSource: "hook-notifications.jsonl"}
+	p := hookProfileReport{Hooks: mandatoryEffectiveHooks()}
+	applyCodexHookContract(&p)
+	return c, p
 }
-func TestEvaluateHookGatePassesZeroUnknown(t *testing.T) {
+func TestEvaluateHookGatePassesZeroPostToolUseWithMandatoryEnforcementHooks(t *testing.T) {
 	c, p := healthyGateFixture()
 	g := evaluateHookRecurrence(c, p, codexToolErrorSummary{Categories: map[string]int{}}, 0, 0)
-	if g.Verdict != "PASS" || g.UnexpectedDenominator != 2 {
+	if g.Verdict != "PASS" || g.UnexpectedDenominator != 2 || g.Census.PostToolUseStatus != "intentionally_disabled" {
 		t.Fatalf("gate=%+v", g)
 	}
 }
 func TestEvaluateHookGateFailsEveryClosureHazard(t *testing.T) {
-	tests := map[string]func(*hookCensusReport, *hookProfileReport, *codexToolErrorSummary){"unknown": func(c *hookCensusReport, _ *hookProfileReport, _ *codexToolErrorSummary) { c.PreToolUse.Unknown = 1 }, "disabled": func(c *hookCensusReport, _ *hookProfileReport, _ *codexToolErrorSummary) { c.PostToolUse.Disabled = 1 }, "stale": func(c *hookCensusReport, _ *hookProfileReport, _ *codexToolErrorSummary) { c.TelemetryFresh = false }, "profile mismatch": func(c *hookCensusReport, _ *hookProfileReport, _ *codexToolErrorSummary) { c.ProfileMatch = false }, "hook failure": func(c *hookCensusReport, _ *hookProfileReport, _ *codexToolErrorSummary) { c.PostToolUse.Failed = 1 }, "unexpected": func(_ *hookCensusReport, _ *hookProfileReport, o *codexToolErrorSummary) { o.OutcomeErrors = 1 }}
+	tests := map[string]func(*hookCensusReport, *hookProfileReport, *codexToolErrorSummary){"unknown": func(c *hookCensusReport, _ *hookProfileReport, _ *codexToolErrorSummary) { c.PreToolUse.Unknown = 1 }, "disabled": func(c *hookCensusReport, _ *hookProfileReport, _ *codexToolErrorSummary) {
+		c.PostToolUseStatus = "disabled"
+		c.PostToolUse.Disabled = 1
+	}, "stale": func(c *hookCensusReport, _ *hookProfileReport, _ *codexToolErrorSummary) { c.TelemetryFresh = false }, "profile mismatch": func(c *hookCensusReport, _ *hookProfileReport, _ *codexToolErrorSummary) { c.ProfileMatch = false }, "hook failure": func(c *hookCensusReport, _ *hookProfileReport, _ *codexToolErrorSummary) {
+		c.PostToolUseStatus = "failing"
+		c.PostToolUse.Failed = 1
+	}, "unexpected": func(_ *hookCensusReport, _ *hookProfileReport, o *codexToolErrorSummary) { o.OutcomeErrors = 1 }}
 	for name, mutate := range tests {
 		t.Run(name, func(t *testing.T) {
 			c, p := healthyGateFixture()
@@ -29,6 +37,37 @@ func TestEvaluateHookGateFailsEveryClosureHazard(t *testing.T) {
 				t.Fatalf("gate=%+v", got)
 			}
 		})
+	}
+}
+
+func TestEvaluateHookGateRejectsPresentStalePostToolUse(t *testing.T) {
+	c, p := healthyGateFixture()
+	p.Hooks = append(p.Hooks, effectiveHook{EventName: "post_tool_use", Enabled: true, State: "stale_hash"})
+	applyCodexHookContract(&p)
+	g := evaluateHookRecurrence(c, p, codexToolErrorSummary{}, 0, 0)
+	if g.Verdict != "FAIL" || !slices.Contains(g.Reasons, "EFFECTIVE_PROFILE_UNHEALTHY") {
+		t.Fatalf("gate=%+v", g)
+	}
+}
+
+func TestEvaluateHookGateRejectsPresentPostToolUseWithoutReceipt(t *testing.T) {
+	c, _ := healthyGateFixture()
+	p := effectivePostToolProfile()
+	c.PostToolUseStatus = "incomplete"
+	c.PostToolUse = lifecycleCounts{Denominator: 2, Unknown: 2}
+	g := evaluateHookRecurrence(c, p, codexToolErrorSummary{}, 0, 0)
+	if g.Verdict != "FAIL" || !slices.Contains(g.Reasons, "UNKNOWN_LIFECYCLE_ROWS") {
+		t.Fatalf("gate=%+v", g)
+	}
+}
+
+func TestEvaluateHookGateRejectsFailingPresentPostToolUseReceipt(t *testing.T) {
+	c, p := healthyGateFixture()
+	c.PostToolUseStatus = "failing"
+	c.PostToolUse = lifecycleCounts{Denominator: 1, Attempted: 1, Failed: 1}
+	g := evaluateHookRecurrence(c, p, codexToolErrorSummary{}, 0, 0)
+	if g.Verdict != "FAIL" || !slices.Contains(g.Reasons, "HOOK_FAILURE_BUDGET_EXCEEDED") {
+		t.Fatalf("gate=%+v", g)
 	}
 }
 

--- a/internal/devcmd/codexhook_profile.go
+++ b/internal/devcmd/codexhook_profile.go
@@ -46,16 +46,23 @@ type effectiveHook struct {
 	Remediation  string               `json:"remediation,omitempty"`
 	Identities   []executableIdentity `json:"identities,omitempty"`
 }
+type hookEventContract struct {
+	EventName   string `json:"event_name"`
+	Requirement string `json:"requirement"`
+	Status      string `json:"status"`
+	Detail      string `json:"detail,omitempty"`
+}
 type hookProfileReport struct {
-	Schema          string             `json:"schema"`
-	CodexHome       string             `json:"codex_home"`
-	Workspace       string             `json:"workspace"`
-	ConfigPath      string             `json:"config_path"`
-	CodexExecutable executableIdentity `json:"codex_executable"`
-	Hooks           []effectiveHook    `json:"hooks"`
-	Warnings        []string           `json:"warnings,omitempty"`
-	Errors          []string           `json:"errors,omitempty"`
-	Verdict         string             `json:"verdict"`
+	Schema          string              `json:"schema"`
+	CodexHome       string              `json:"codex_home"`
+	Workspace       string              `json:"workspace"`
+	ConfigPath      string              `json:"config_path"`
+	CodexExecutable executableIdentity  `json:"codex_executable"`
+	Hooks           []effectiveHook     `json:"hooks"`
+	EventContracts  []hookEventContract `json:"event_contracts"`
+	Warnings        []string            `json:"warnings,omitempty"`
+	Errors          []string            `json:"errors,omitempty"`
+	Verdict         string              `json:"verdict"`
 }
 type appServerReply struct {
 	ID     int `json:"id"`
@@ -157,9 +164,6 @@ func inspectCodexHookProfileContext(ctx context.Context, home, workspace, binary
 		x := effectiveHook{EventName: event, Key: h.Key, Source: h.Source, SourcePath: h.SourcePath, PluginID: h.PluginID, DisplayOrder: h.DisplayOrder, Enabled: h.Enabled, Managed: h.IsManaged, CurrentHash: h.CurrentHash, TrustStatus: h.TrustStatus, Command: h.Command, Matcher: h.Matcher, TimeoutSec: h.TimeoutSec}
 		classifyEffectiveHook(&x, home)
 		r.Hooks = append(r.Hooks, x)
-		if x.State != "effective" {
-			r.Verdict = "UNHEALTHY"
-		}
 	}
 	sort.Slice(r.Hooks, func(i, j int) bool {
 		if r.Hooks[i].EventName == r.Hooks[j].EventName {
@@ -167,21 +171,91 @@ func inspectCodexHookProfileContext(ctx context.Context, home, workspace, binary
 		}
 		return r.Hooks[i].EventName < r.Hooks[j].EventName
 	})
-	for _, event := range []string{"pre_tool_use", "post_tool_use", "stop", "subagent_stop"} {
-		found := false
-		for _, h := range r.Hooks {
-			found = found || h.EventName == event
-		}
-		if !found {
-			r.Errors = append(r.Errors, "missing effective "+event+" hook")
-			r.Verdict = "UNHEALTHY"
-		}
-	}
-	if len(r.Errors) > 0 {
-		r.Verdict = "UNHEALTHY"
-	}
+	applyCodexHookContract(&r)
 	return r, nil
 }
+
+func applyCodexHookContract(r *hookProfileReport) {
+	r.EventContracts = nil
+	r.Errors = withoutGeneratedHookContractErrors(r.Errors)
+	byEvent := make(map[string][]effectiveHook)
+	unhealthy := len(r.Errors) > 0
+	for _, h := range r.Hooks {
+		event := normalizeHookEvent(h.EventName)
+		byEvent[event] = append(byEvent[event], h)
+		if h.State != "effective" {
+			unhealthy = true
+		}
+	}
+
+	for _, event := range []string{"pre_tool_use", "stop", "subagent_stop"} {
+		hooks := byEvent[event]
+		status := "effective"
+		effective := false
+		for _, h := range hooks {
+			effective = effective || h.State == "effective"
+		}
+		if !effective {
+			status = "missing"
+			if len(hooks) > 0 {
+				status = "unhealthy"
+			}
+			r.Errors = append(r.Errors, "missing effective "+event+" hook")
+			unhealthy = true
+		} else {
+			for _, h := range hooks {
+				if h.State != "effective" {
+					status = "unhealthy"
+					break
+				}
+			}
+		}
+		r.EventContracts = append(r.EventContracts, hookEventContract{EventName: event, Requirement: "mandatory", Status: status})
+	}
+
+	postHooks := byEvent["post_tool_use"]
+	post := hookEventContract{
+		EventName:   "post_tool_use",
+		Requirement: "optional",
+		Status:      "intentionally_disabled",
+		Detail:      "zero handlers are intentional because successful advisory PostToolUse hooks create foreground spam",
+	}
+	if len(postHooks) > 0 {
+		post.Status = "effective"
+		post.Detail = "optional handler is present and is still diagnosed"
+		for _, h := range postHooks {
+			if h.State != "effective" {
+				post.Status = "unhealthy"
+				unhealthy = true
+				break
+			}
+		}
+	}
+	r.EventContracts = append(r.EventContracts, post)
+	r.Errors = uniqueStrings(r.Errors)
+	r.Verdict = "HEALTHY"
+	if unhealthy || len(r.Errors) > 0 {
+		r.Verdict = "UNHEALTHY"
+	}
+}
+
+func withoutGeneratedHookContractErrors(errors []string) []string {
+	out := errors[:0]
+	for _, err := range errors {
+		generated := false
+		for _, event := range []string{"pre_tool_use", "post_tool_use", "stop", "subagent_stop"} {
+			if err == "missing effective "+event+" hook" {
+				generated = true
+				break
+			}
+		}
+		if !generated {
+			out = append(out, err)
+		}
+	}
+	return out
+}
+
 func isObservedHookEvent(event string) bool {
 	switch event {
 	case "pre_tool_use", "post_tool_use", "stop", "subagent_stop", "stop_failure":
@@ -333,6 +407,13 @@ func queryCodexHooksContext(ctx context.Context, home, workspace, binary string)
 }
 func writeHookProfile(w io.Writer, r hookProfileReport) {
 	fmt.Fprintf(w, "Codex effective hook profile\nCODEX_HOME: %s\nconfig: %s\nworkspace: %s\nCodex binary: %s %s\n", r.CodexHome, r.ConfigPath, r.Workspace, r.CodexExecutable.Path, r.CodexExecutable.SHA256)
+	for _, c := range r.EventContracts {
+		fmt.Fprintf(w, "%s requirement=%s status=%s", c.EventName, c.Requirement, c.Status)
+		if c.Detail != "" {
+			fmt.Fprintf(w, " (%s)", c.Detail)
+		}
+		fmt.Fprintln(w)
+	}
 	for _, h := range r.Hooks {
 		fmt.Fprintf(w, "%s order=%d state=%s enabled=%t trust=%s source=%s sourcePath=%s\n  key: %s\n  command: %s\n", h.EventName, h.DisplayOrder, h.State, h.Enabled, h.TrustStatus, h.Source, h.SourcePath, h.Key, h.Command)
 		for _, id := range h.Identities {

--- a/internal/devcmd/codexhook_profile_test.go
+++ b/internal/devcmd/codexhook_profile_test.go
@@ -1,9 +1,12 @@
 package devcmd
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
+	"strings"
 	"testing"
 )
 
@@ -104,4 +107,109 @@ func TestClassifyEffectiveHookRejectsIncompatibleWindowsCommand(t *testing.T) {
 	if h.Remediation == "" {
 		t.Fatal("platform incompatibility needs actionable remediation")
 	}
+}
+
+func TestHookProfileAcceptsZeroPostToolUseWithMandatoryEnforcementHooks(t *testing.T) {
+	r := mandatoryOnlyHookProfile()
+	if r.Verdict != "HEALTHY" || len(r.Errors) != 0 {
+		t.Fatalf("profile=%+v", r)
+	}
+	post := findHookEventContract(t, r, "post_tool_use")
+	if post.Requirement != "optional" || post.Status != "intentionally_disabled" || !strings.Contains(post.Detail, "foreground spam") {
+		t.Fatalf("post contract=%+v", post)
+	}
+	for _, event := range []string{"pre_tool_use", "stop", "subagent_stop"} {
+		contract := findHookEventContract(t, r, event)
+		if contract.Requirement != "mandatory" || contract.Status != "effective" {
+			t.Fatalf("%s contract=%+v", event, contract)
+		}
+	}
+	var out bytes.Buffer
+	writeHookProfile(&out, r)
+	if !strings.Contains(out.String(), "post_tool_use requirement=optional status=intentionally_disabled") {
+		t.Fatalf("human profile did not explain optional PostToolUse:\n%s", out.String())
+	}
+}
+
+func TestHookProfileRequiresEveryMandatoryEnforcementHook(t *testing.T) {
+	for _, missing := range []string{"pre_tool_use", "stop", "subagent_stop"} {
+		t.Run(missing, func(t *testing.T) {
+			r := hookProfileReport{}
+			for _, h := range mandatoryEffectiveHooks() {
+				if h.EventName != missing {
+					r.Hooks = append(r.Hooks, h)
+				}
+			}
+			applyCodexHookContract(&r)
+			if r.Verdict != "UNHEALTHY" || !slices.Contains(r.Errors, "missing effective "+missing+" hook") {
+				t.Fatalf("profile=%+v", r)
+			}
+		})
+	}
+}
+
+func TestApplyCodexHookContractRebuildsGeneratedErrors(t *testing.T) {
+	r := hookProfileReport{Errors: []string{"hooks/list source error", "missing effective post_tool_use hook"}}
+	applyCodexHookContract(&r)
+	if r.Verdict != "UNHEALTHY" || len(r.Errors) != 4 {
+		t.Fatalf("first profile=%+v", r)
+	}
+	r.Hooks = mandatoryEffectiveHooks()
+	applyCodexHookContract(&r)
+	if r.Verdict != "UNHEALTHY" || !slices.Equal(r.Errors, []string{"hooks/list source error"}) {
+		t.Fatalf("second profile=%+v", r)
+	}
+	r.Errors = nil
+	applyCodexHookContract(&r)
+	if r.Verdict != "HEALTHY" || len(r.Errors) != 0 {
+		t.Fatalf("third profile=%+v", r)
+	}
+}
+
+func TestHookProfileDiagnosesPresentUnhealthyPostToolUse(t *testing.T) {
+	for _, state := range []string{"disabled", "stale_hash", "untrusted", "platform_incompatible", "missing_executable"} {
+		t.Run(state, func(t *testing.T) {
+			r := hookProfileReport{Hooks: append(mandatoryEffectiveHooks(), effectiveHook{EventName: "post_tool_use", State: state})}
+			applyCodexHookContract(&r)
+			if r.Verdict != "UNHEALTHY" {
+				t.Fatalf("profile=%+v", r)
+			}
+			post := findHookEventContract(t, r, "post_tool_use")
+			if post.Status != "unhealthy" {
+				t.Fatalf("post contract=%+v", post)
+			}
+		})
+	}
+}
+
+func mandatoryEffectiveHooks() []effectiveHook {
+	return []effectiveHook{
+		{EventName: "pre_tool_use", State: "effective", Enabled: true},
+		{EventName: "stop", State: "effective", Enabled: true},
+		{EventName: "subagent_stop", State: "effective", Enabled: true},
+	}
+}
+
+func mandatoryOnlyHookProfile() hookProfileReport {
+	r := hookProfileReport{Hooks: mandatoryEffectiveHooks()}
+	applyCodexHookContract(&r)
+	return r
+}
+
+func effectivePostToolProfile() hookProfileReport {
+	r := mandatoryOnlyHookProfile()
+	r.Hooks = append(r.Hooks, effectiveHook{EventName: "post_tool_use", State: "effective", Enabled: true})
+	applyCodexHookContract(&r)
+	return r
+}
+
+func findHookEventContract(t *testing.T, r hookProfileReport, event string) hookEventContract {
+	t.Helper()
+	for _, contract := range r.EventContracts {
+		if contract.EventName == event {
+			return contract
+		}
+	}
+	t.Fatalf("missing %s event contract in %+v", event, r.EventContracts)
+	return hookEventContract{}
 }

--- a/internal/projectassets/projectassets.go
+++ b/internal/projectassets/projectassets.go
@@ -160,11 +160,35 @@ func skillDescription(root, path string) (string, error) {
 		if strings.HasPrefix(line, "description:") {
 			description := strings.TrimSpace(strings.TrimPrefix(line, "description:"))
 			if description != "" {
-				return description, nil
+				return decodeYAMLScalar(description), nil
 			}
 		}
 	}
 	return "", fmt.Errorf("%s has no frontmatter description", path)
+}
+
+// decodeYAMLScalar removes the quoting used by canonical skill frontmatter.
+// Generated adapters re-encode the value after truncation; truncating the
+// original quoted token could otherwise leave an unterminated YAML scalar.
+func decodeYAMLScalar(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) < 2 {
+		return value
+	}
+	switch value[0] {
+	case '"':
+		if value[len(value)-1] == '"' {
+			var decoded string
+			if json.Unmarshal([]byte(value), &decoded) == nil {
+				return decoded
+			}
+		}
+	case '\'':
+		if value[len(value)-1] == '\'' {
+			return strings.ReplaceAll(value[1:len(value)-1], "''", "'")
+		}
+	}
+	return value
 }
 func adapterDescription(description string) string {
 	runes := []rune(strings.TrimSpace(description))
@@ -185,7 +209,8 @@ func adapterDescription(description string) string {
 
 func adapter(name, description, rel string) string {
 	description = adapterDescription(description)
-	return fmt.Sprintf("---\nname: %s\ndescription: %s\nmetadata:\n  generated-by: fak project-assets sync\n  canonical: %s\n---\n\n# Canonical project skill adapter\n\nLoad and follow [`%s`](%s). This generated discovery adapter contains no maintained workflow body.\n\n## Portability contract\n\n- The linked canonical `SKILL.md` is the single semantic workflow body for Claude, Codex, and fak-native loaders.\n- This adapter changes discovery only; it must not fork, summarize, or translate the workflow.\n- Harness-native invocation, permissions, hooks, model routing, and worker launch remain typed adapters outside the semantic body.\n", name, description, rel, rel, rel)
+	encoded, _ := json.Marshal(description)
+	return fmt.Sprintf("---\nname: %s\ndescription: %s\nmetadata:\n  generated-by: fak project-assets sync\n  canonical: %s\n---\n\n# Canonical project skill adapter\n\nLoad and follow [`%s`](%s). This generated discovery adapter contains no maintained workflow body.\n\n## Portability contract\n\n- The linked canonical `SKILL.md` is the single semantic workflow body for Claude, Codex, and fak-native loaders.\n- This adapter changes discovery only; it must not fork, summarize, or translate the workflow.\n- Harness-native invocation, permissions, hooks, model routing, and worker launch remain typed adapters outside the semantic body.\n", name, encoded, rel, rel, rel)
 }
 
 func classify(root, kind string, p Policy) ([]string, []Excluded, error) {

--- a/internal/projectassets/projectassets_test.go
+++ b/internal/projectassets/projectassets_test.go
@@ -61,7 +61,7 @@ func TestBuildSyncsWindowsSafeCodexAdapterAndParity(t *testing.T) {
 	if string(b) == "body\n" {
 		t.Fatal("adapter copied maintained skill body")
 	}
-	if !strings.Contains(string(b), "description: Verify.") {
+	if !strings.Contains(string(b), "description:") || !strings.Contains(string(b), "Verify.") {
 		t.Fatalf("adapter lost canonical discovery description:\n%s", b)
 	}
 }
@@ -270,5 +270,35 @@ func TestCodexAdapterDescriptionsCutResidentFloorByThree(t *testing.T) {
 	}
 	if total*3 > baselineChars {
 		t.Fatalf("adapter descriptions total %d characters, want at most one third of baseline %d", total, baselineChars)
+	}
+}
+
+func TestAdapterDecodesAndRequotesYAMLDescriptions(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, ".claude/skills/quoted/SKILL.md", "---\nname: quoted\ndescription: \"Use a colon: safely and say \\\"hello\\\".\"\n---\n")
+	description, err := skillDescription(root, ".claude/skills/quoted/SKILL.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := `Use a colon: safely and say "hello".`; description != want {
+		t.Fatalf("description = %q, want %q", description, want)
+	}
+	body := adapter("quoted", strings.Repeat(description+" ", 20), "../../../.claude/skills/quoted/SKILL.md")
+	line := strings.Split(body, "\n")[2]
+	if !strings.HasPrefix(line, `description: "`) || !strings.HasSuffix(line, `..."`) {
+		t.Fatalf("adapter description is not a complete quoted scalar: %q", line)
+	}
+	var decoded string
+	if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "description: ")), &decoded); err != nil {
+		t.Fatalf("generated description is invalid JSON/YAML quoting: %v", err)
+	}
+	if len([]rune(decoded)) > maxSkillDescriptionChars {
+		t.Fatalf("decoded description has %d characters", len([]rune(decoded)))
+	}
+}
+
+func TestDecodeYAMLScalarSingleQuotedEscapes(t *testing.T) {
+	if got, want := decodeYAMLScalar(`'agent''s trigger'`), "agent's trigger"; got != want {
+		t.Fatalf("decodeYAMLScalar = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
Closes #8062. Clean two-commit integration based directly on current origin/main. Aligns diagnostics with the shipped DOS topology: PreToolUse, Stop, and SubagentStop remain mandatory; zero PostToolUse handlers is intentional because Codex renders advisory lifecycle rows in the foreground. Also hardens generated skill YAML. Focused projectassets/devcmd tests pass; fresh allow/deny runtime evidence is recorded on #8062.