### PR TITLE
fix(projectassets): emit valid adapter descriptions (#8745)

### DIFF
--- a/.agents/skills/dos-dispatch-loop/SKILL.md
+++ b/.agents/skills/dos-dispatch-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dos-dispatch-loop
-description: Run recurring `dos-dispatch` cycles, switching to `dos-replan` when the backlog drains and stopping on the kernel's loop verdict. Use when you need unattended dispatch->replan->dispatch work across disjoint lanes.
+description: Run recurring `dos-dispatch` cycles, switching to `dos-replan` when the backlog drains and stopping on the kernel's loop verdict. Use for unattended dispatch->replan->dispatch work across disjoint lanes.
 metadata:
   generated-by: fak project-assets sync
   canonical: ../../../.claude/skills/dos-dispatch-loop/SKILL.md

--- a/.agents/skills/dos-dispatch/SKILL.md
+++ b/.agents/skills/dos-dispatch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dos-dispatch
-description: "Plan and ship the next batch on one lane: run `dos-next-up`, acquire a lease with `dos arbitrate`, gate empty work, dispatch the packet, and archive the run. Use when a single lane should move end to end with...
+description: "Plan and ship the next batch on one lane: run `dos-next-up`, acquire a lease with `dos arbitrate`, gate empty work, dispatch the packet, and archive the run. Use when a single lane should move end to end with..."
 metadata:
   generated-by: fak project-assets sync
   canonical: ../../../.claude/skills/dos-dispatch/SKILL.md

--- a/.agents/skills/dos-next-up/SKILL.md
+++ b/.agents/skills/dos-next-up/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dos-next-up
-description: "Snapshot the repo's phased-plan portfolio into a dispatch packet: audit candidates with `dos verify`, render who-does-what, and emit a `dos gate` verdict. Use when you need the current next-work view before...
+description: "Snapshot the repo's phased-plan portfolio into a dispatch packet: audit candidates with `dos verify`, render who-does-what, and emit a `dos gate` verdict. Use when you need the current next-work view before..."
 metadata:
   generated-by: fak project-assets sync
   canonical: ../../../.claude/skills/dos-next-up/SKILL.md

--- a/.agents/skills/dos-plan-price/SKILL.md
+++ b/.agents/skills/dos-plan-price/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dos-plan-price
-description: "Price a proposed multi-agent fan-out before launching workers. Use when a packet, goal fleet, or hand-written plan would run several agents over declared file trees and you need DOS to catch collisions before any...
+description: Price a proposed multi-agent fan-out before launching workers. Use when a packet, goal fleet, or hand-written plan would run several agents over declared file trees and you need DOS to catch collisions before any...
 metadata:
   generated-by: fak project-assets sync
   canonical: ../../../.claude/skills/dos-plan-price/SKILL.md

--- a/.agents/skills/dos-replan/SKILL.md
+++ b/.agents/skills/dos-replan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dos-replan
-description: Refresh a plan portfolio from evidence: close shipped queue items, update cooldown state, and surface the few decisions an operator must make. Use when acting after dispatch bursts, drained backlogs, or recurring...
+description: "Refresh a plan portfolio from evidence: close shipped queue items, update cooldown state, and surface the few decisions an operator must make. Use after dispatch bursts, drained backlogs, or recurring findings."
 metadata:
   generated-by: fak project-assets sync
   canonical: ../../../.claude/skills/dos-replan/SKILL.md

--- a/.agents/skills/dos-witness-claim/SKILL.md
+++ b/.agents/skills/dos-witness-claim/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dos-witness-claim
-description: "Verify subagent or worker results before folding them into a synthesis. Use when another agent claims it shipped, created, found, or changed something and your next step would otherwise trust its return string."
+description: Verify subagent or worker results before folding them into a synthesis. Use when another agent claims it shipped, created, found, or changed something and your next step would otherwise trust its return string.
 metadata:
   generated-by: fak project-assets sync
   canonical: ../../../.claude/skills/dos-witness-claim/SKILL.md

--- a/.agents/skills/fleet-wave/SKILL.md
+++ b/.agents/skills/fleet-wave/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fleet-wave
-description: "Run ONE wave of N fak-guarded ultracode sessions against the top open issues under a closing target and a wall-clock deadline — price, render fuel, launch, monitor, reconcile from git, release. N defaults to 30 (30...
+description: Run ONE wave of N fak-guarded ultracode sessions against the top open issues under a closing target and a wall-clock deadline — price, render fuel, launch, monitor, reconcile from git, release. N defaults to 30 (30...
 metadata:
   generated-by: fak project-assets sync
   canonical: ../../../.claude/skills/fleet-wave/SKILL.md

--- a/.agents/skills/stability-score/SKILL.md
+++ b/.agents/skills/stability-score/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: stability-score
-description: One repeatable pass that keeps fak trustworthy while it iterates fast — the question no other scorecard asks: as we add items quickly, how do we KNOW a regression / tail-wag / confusion landed, and how do we REVERT...
+description: "One repeatable pass that keeps fak trustworthy while it iterates fast — the question no other scorecard asks: as we add items quickly, how do we KNOW a regression / tail-wag / confusion landed, and how do we REVERT..."
 metadata:
   generated-by: fak project-assets sync
   canonical: ../../../.claude/skills/stability-score/SKILL.md

--- a/.agents/skills/super-loop/SKILL.md
+++ b/.agents/skills/super-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: super-loop
-description: 'Plan, price, launch, monitor, and reconcile bulk headless issue-resolution work safely. Use when an operator asks for a super loop, worker wave, detached issue workers, backlog draining, capacity/status,...
+description: Plan, price, launch, monitor, and reconcile bulk headless issue-resolution work safely. Use when an operator asks for a super loop, worker wave, detached issue workers, backlog draining, capacity/status,...
 metadata:
   generated-by: fak project-assets sync
   canonical: ../../../.claude/skills/super-loop/SKILL.md

--- a/.agents/skills/trajectory-audit/SKILL.md
+++ b/.agents/skills/trajectory-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: trajectory-audit
-description: Audit recent Claude and Codex transcript JSONL with the first-class Go `fak trajectory audit` verb: exact token/cache buckets, source coverage, behavior, deterministic bottlenecks, and baseline regressions. Use for...
+description: "Audit recent Claude and Codex transcript JSONL with the first-class Go `fak trajectory audit` verb: exact token/cache buckets, source coverage, behavior, deterministic bottlenecks, and baseline regressions. Use for..."
 metadata:
   generated-by: fak project-assets sync
   canonical: ../../../.claude/skills/trajectory-audit/SKILL.md

--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify
-description: Bind a done-claim to a GREEN test run of the changed package, not just diff shape. Use when acting after a commit claims a package/feature is done and you want to run that commit's affected tests and report...
+description: Bind a done-claim to a GREEN test run of the changed package, not just diff shape. Use after a commit claims a package/feature is done and you want to run that commit's affected tests and report CLAIM_TEST_GREEN /...
 metadata:
   generated-by: fak project-assets sync
   canonical: ../../../.claude/skills/verify/SKILL.md

--- a/.agents/skills/wave-harvest/SKILL.md
+++ b/.agents/skills/wave-harvest/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wave-harvest
-description: The honest closing half of a super loop — after a detached bulk wave (`/super-loop`) has run, HARVEST it: witness what each headless worker actually shipped (not what its log claims), re-queue the leaves that were...
+description: "The honest closing half of a super loop — after a detached bulk wave (`/super-loop`) has run, HARVEST it: witness what each headless worker actually shipped (not what its log claims), re-queue the leaves that were..."
 metadata:
   generated-by: fak project-assets sync
   canonical: ../../../.claude/skills/wave-harvest/SKILL.md

--- a/internal/projectassets/projectassets.go
+++ b/internal/projectassets/projectassets.go
@@ -7,7 +7,10 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 )
 
 const (
@@ -160,16 +163,136 @@ func skillDescription(root, path string) (string, error) {
 		if strings.HasPrefix(line, "description:") {
 			description := strings.TrimSpace(strings.TrimPrefix(line, "description:"))
 			if description != "" {
-				return decodeYAMLScalar(description), nil
+				return normalizeYAMLScalar(description), nil
 			}
 		}
 	}
 	return "", fmt.Errorf("%s has no frontmatter description", path)
 }
 
-// decodeYAMLScalar removes the quoting used by canonical skill frontmatter.
-// Generated adapters re-encode the value after truncation; truncating the
-// original quoted token could otherwise leave an unterminated YAML scalar.
+// normalizeYAMLScalar turns the frontmatter representation into the description
+// text that loaders see. Canonical skills use plain, single-quoted, and
+// double-quoted scalars. Some older skills also carry a missing closing quote;
+// accepting an implied close lets sync repair their generated adapters instead
+// of copying the malformed delimiter into another file.
+func normalizeYAMLScalar(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+
+	switch value[0] {
+	case '"':
+		quoted := value
+		if !yamlDoubleQuotedClosed(quoted) {
+			quoted += `"`
+		}
+		if unquoted, err := unquoteYAMLDouble(quoted); err == nil {
+			return unquoted
+		}
+	case '\'':
+		end := len(value)
+		if end > 1 && value[end-1] == '\'' {
+			end--
+		}
+		return strings.ReplaceAll(value[1:end], "''", "'")
+	}
+
+	return value
+}
+
+func yamlDoubleQuotedClosed(value string) bool {
+	if len(value) < 2 || value[len(value)-1] != '"' {
+		return false
+	}
+	backslashes := 0
+	for i := len(value) - 2; i >= 0 && value[i] == '\\'; i-- {
+		backslashes++
+	}
+	return backslashes%2 == 0
+}
+
+// unquoteYAMLDouble maps YAML's extra one-character escapes to Go escapes and
+// then delegates Unicode and hex validation to strconv.Unquote. YAML and Go
+// otherwise share the escape forms used by skill descriptions.
+func unquoteYAMLDouble(value string) (string, error) {
+	if len(value) < 2 || value[0] != '"' || value[len(value)-1] != '"' {
+		return "", fmt.Errorf("not a double-quoted scalar")
+	}
+	var quoted strings.Builder
+	quoted.Grow(len(value) + 8)
+	quoted.WriteByte('"')
+	for i := 1; i < len(value)-1; i++ {
+		if value[i] != '\\' || i+1 >= len(value)-1 {
+			quoted.WriteByte(value[i])
+			continue
+		}
+		i++
+		switch value[i] {
+		case '0':
+			quoted.WriteString(`\x00`)
+		case 'e':
+			quoted.WriteString(`\x1b`)
+		case ' ':
+			quoted.WriteString(`\x20`)
+		case '/':
+			quoted.WriteByte('/')
+		case 'N':
+			quoted.WriteString(`\u0085`)
+		case '_':
+			quoted.WriteString(`\u00a0`)
+		case 'L':
+			quoted.WriteString(`\u2028`)
+		case 'P':
+			quoted.WriteString(`\u2029`)
+		case 'x':
+			if i+2 < len(value)-1 {
+				quoted.WriteString(`\u00`)
+				quoted.WriteByte(value[i+1])
+				quoted.WriteByte(value[i+2])
+				i += 2
+			} else {
+				quoted.WriteString(`\x`)
+			}
+		default:
+			quoted.WriteByte('\\')
+			quoted.WriteByte(value[i])
+		}
+	}
+	quoted.WriteByte('"')
+	return strconv.Unquote(quoted.String())
+}
+
+// yamlScalar emits a block-mapping-safe YAML string without adding quoting
+// churn to descriptions that are already safe as plain scalars. strconv.Quote
+// supplies the escaping for quotes, backslashes, newlines, and control runes.
+func yamlScalar(value string) string {
+	if yamlPlainScalarSafe(value) {
+		return value
+	}
+	return strconv.Quote(value)
+}
+
+func yamlPlainScalarSafe(value string) bool {
+	if value == "" || strings.TrimSpace(value) != value || value == "---" || value == "..." {
+		return false
+	}
+	first, _ := utf8.DecodeRuneInString(value)
+	if unicode.IsDigit(first) || strings.ContainsRune("-+?.:,[]{}#&*!|>'\"%@`", first) {
+		return false
+	}
+	for _, r := range value {
+		if unicode.IsControl(r) || (r != ' ' && unicode.IsSpace(r)) || r == ':' || r == '#' {
+			return false
+		}
+	}
+	switch strings.ToLower(value) {
+	case "null", "true", "false", "yes", "no", "on", "off", "~":
+		return false
+	}
+	return true
+}
+
 func decodeYAMLScalar(value string) string {
 	value = strings.TrimSpace(value)
 	if len(value) < 2 {
@@ -191,7 +314,7 @@ func decodeYAMLScalar(value string) string {
 	return value
 }
 func adapterDescription(description string) string {
-	runes := []rune(strings.TrimSpace(description))
+	runes := []rune(description)
 	if len(runes) <= maxSkillDescriptionChars {
 		return string(runes)
 	}
@@ -200,17 +323,16 @@ func adapterDescription(description string) string {
 	// Preserve its leading trigger instead of inventing a second summary.
 	const suffix = "..."
 	limit := maxSkillDescriptionChars - len([]rune(suffix))
-	cut := strings.TrimSpace(string(runes[:limit]))
+	cut := strings.TrimRightFunc(string(runes[:limit]), unicode.IsSpace)
 	if boundary := strings.LastIndexAny(cut, " \t\r\n"); boundary > limit/2 {
-		cut = strings.TrimSpace(cut[:boundary])
+		cut = strings.TrimRightFunc(cut[:boundary], unicode.IsSpace)
 	}
 	return cut + suffix
 }
 
 func adapter(name, description, rel string) string {
 	description = adapterDescription(description)
-	encoded, _ := json.Marshal(description)
-	return fmt.Sprintf("---\nname: %s\ndescription: %s\nmetadata:\n  generated-by: fak project-assets sync\n  canonical: %s\n---\n\n# Canonical project skill adapter\n\nLoad and follow [`%s`](%s). This generated discovery adapter contains no maintained workflow body.\n\n## Portability contract\n\n- The linked canonical `SKILL.md` is the single semantic workflow body for Claude, Codex, and fak-native loaders.\n- This adapter changes discovery only; it must not fork, summarize, or translate the workflow.\n- Harness-native invocation, permissions, hooks, model routing, and worker launch remain typed adapters outside the semantic body.\n", name, encoded, rel, rel, rel)
+	return fmt.Sprintf("---\nname: %s\ndescription: %s\nmetadata:\n  generated-by: fak project-assets sync\n  canonical: %s\n---\n\n# Canonical project skill adapter\n\nLoad and follow [`%s`](%s). This generated discovery adapter contains no maintained workflow body.\n\n## Portability contract\n\n- The linked canonical `SKILL.md` is the single semantic workflow body for Claude, Codex, and fak-native loaders.\n- This adapter changes discovery only; it must not fork, summarize, or translate the workflow.\n- Harness-native invocation, permissions, hooks, model routing, and worker launch remain typed adapters outside the semantic body.\n", name, yamlScalar(description), rel, rel, rel)
 }
 
 func classify(root, kind string, p Policy) ([]string, []Excluded, error) {

--- a/internal/projectassets/projectassets_test.go
+++ b/internal/projectassets/projectassets_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -247,6 +248,114 @@ func TestAdapterDescriptionHonorsAgentSkillsLimit(t *testing.T) {
 	short := "Use when a project needs portable skill discovery."
 	if got := adapterDescription(short); got != short {
 		t.Fatalf("short description = %q, want %q", got, short)
+	}
+}
+
+func TestSkillDescriptionNormalizesYAMLScalars(t *testing.T) {
+	tests := []struct {
+		name   string
+		scalar string
+		want   string
+	}{
+		{name: "quoted", scalar: `"Use when a quoted description is canonical."`, want: "Use when a quoted description is canonical."},
+		{name: "unquoted", scalar: "Use when a plain description is canonical.", want: "Use when a plain description is canonical."},
+		{name: "escaped", scalar: `"Say \"go\" from C:\\work."`, want: `Say "go" from C:\work.`},
+		{name: "YAML escapes", scalar: `"slash\/ nul\0 esc\e nbsp\_ nel\N line\L para\P"`, want: "slash/ nul\x00 esc\x1b nbsp\u00a0 nel\u0085 line\u2028 para\u2029"},
+		{name: "YAML hex escapes", scalar: `"latin\xE9 pair\xC3\xA9"`, want: "latin\u00e9 pair\u00c3\u00a9"},
+		{name: "colon", scalar: "Use when input has a colon: preserve it.", want: "Use when input has a colon: preserve it."},
+		{name: "newline", scalar: `"First line\nsecond line."`, want: "First line\nsecond line."},
+		{name: "single quoted", scalar: `'It''s portable.'`, want: "It's portable."},
+		{name: "quoted whitespace", scalar: `"  preserve semantic spacing  "`, want: "  preserve semantic spacing  "},
+		{name: "unterminated quote", scalar: `"Repair this legacy description`, want: "Repair this legacy description"},
+		{name: "unterminated escaped quote", scalar: `"Repair the trailing \"`, want: `Repair the trailing "`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			path := ".claude/skills/example/SKILL.md"
+			write(t, root, path, "---\nname: example\ndescription: "+tt.scalar+"\n---\n")
+			got, err := skillDescription(root, path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Fatalf("description = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAdapterEmitsRoundTrippableYAMLScalars(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want string
+	}{
+		{name: "plain", text: "Portable skill discovery.", want: "Portable skill discovery."},
+		{name: "colon", text: "Use when input has a colon: preserve it.", want: strconv.Quote("Use when input has a colon: preserve it.")},
+		{name: "escaped", text: `Say "go" from C:\work.`, want: strconv.Quote(`Say "go" from C:\work.`)},
+		{name: "newline", text: "First line\nsecond line.", want: strconv.Quote("First line\nsecond line.")},
+		{name: "semantic whitespace", text: "  preserve semantic spacing  ", want: strconv.Quote("  preserve semantic spacing  ")},
+		{name: "implicit positive number", text: "+1.0", want: strconv.Quote("+1.0")},
+		{name: "implicit fractional number", text: ".5", want: strconv.Quote(".5")},
+		{name: "implicit special float", text: ".nan", want: strconv.Quote(".nan")},
+		{name: "YAML line separator", text: "before\u2028after", want: strconv.Quote("before\u2028after")},
+		{name: "YAML paragraph separator", text: "before\u2029after", want: strconv.Quote("before\u2029after")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := adapter("example", tt.text, "../../../.claude/skills/example/SKILL.md")
+			line := ""
+			for _, candidate := range strings.Split(body, "\n") {
+				if strings.HasPrefix(candidate, "description: ") {
+					line = strings.TrimPrefix(candidate, "description: ")
+					break
+				}
+			}
+			if line != tt.want {
+				t.Fatalf("emitted scalar = %q, want %q\n%s", line, tt.want, body)
+			}
+			if got := normalizeYAMLScalar(line); got != tt.text {
+				t.Fatalf("round trip = %q, want %q", got, tt.text)
+			}
+		})
+	}
+}
+
+func TestQuotedDescriptionIsNormalizedBeforeTruncation(t *testing.T) {
+	semantic := strings.Repeat("quoted discovery trigger ", 20)
+	root := t.TempDir()
+	path := ".claude/skills/example/SKILL.md"
+	write(t, root, ManifestPath, baseManifest())
+	write(t, root, path, "---\nname: example\ndescription: "+strconv.Quote(semantic)+"\n---\n")
+	write(t, root, ".claude/memory/base.md", "memory\n")
+	write(t, root, ".claude/goal-prompts/base.md", "prompt\n")
+
+	description, err := skillDescription(root, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := adapterDescription(description)
+	if chars := len([]rune(got)); chars > maxSkillDescriptionChars {
+		t.Fatalf("description has %d characters, want at most %d", chars, maxSkillDescriptionChars)
+	}
+	if strings.HasPrefix(got, `"`) || !strings.HasSuffix(got, "...") {
+		t.Fatalf("truncated semantic description = %q", got)
+	}
+
+	if _, err = Build(root, true); err != nil {
+		t.Fatal(err)
+	}
+	bodyBytes, err := os.ReadFile(filepath.Join(root, ".agents", "skills", "example", "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(bodyBytes)
+	line := strings.SplitN(strings.SplitN(body, "description: ", 2)[1], "\n", 2)[0]
+	if roundTrip := normalizeYAMLScalar(line); roundTrip != got {
+		t.Fatalf("emitted description round trip = %q, want %q\n%s", roundTrip, got, body)
 	}
 }
 


### PR DESCRIPTION
Closes #8745.

## Result
- normalizes canonical frontmatter descriptions into semantic strings before truncation
- serializes generated descriptions as deterministic YAML-safe scalars
- regenerates affected Codex discovery adapters so quoted truncation never creates invalid YAML

## Witness
- `go test -count=1 ./internal/projectassets`
- `go vet ./internal/projectassets`
- clean `git show --check c31a20ae14`
- fresh `codex exec --ephemeral --ignore-user-config ...` loaded every generated adapter with no YAML loader errors and returned `OK`
- generator tests cover colon, `#`, mixed quotes, backslashes, multiline folding, single-quote escaping, and truncation boundaries

The branch is based directly on current `origin/main` (`2917ad6133`).