### PR TITLE
fix(studymonitor): report partial inventory completeness

### DIFF
--- a/internal/studymonitor/inventory_map.go
+++ b/internal/studymonitor/inventory_map.go
@@ -385,11 +385,13 @@ func inventorySourceClassDisposition(class string, evidence []string) (string, s
 }
 
 func inventoryCompletenessNote(classes []InventoryClassStatus, skipped []string) string {
-	var external, absent []string
+	var external, partial, absent []string
 	for _, class := range classes {
 		switch class.Status {
 		case InventoryClassExternalRequired:
 			external = append(external, class.Class)
+		case InventoryClassPartial:
+			partial = append(partial, class.Class)
 		case InventoryClassCheckedAbsent:
 			absent = append(absent, class.Class)
 		}
@@ -402,12 +404,14 @@ func inventoryCompletenessNote(classes []InventoryClassStatus, skipped []string)
 	if len(absent) > 0 {
 		parts = append(parts, fmt.Sprintf("classes checked absent in local tree: %s", strings.Join(absent, ", ")))
 	}
+	if len(partial) > 0 {
+		parts = append(parts, fmt.Sprintf("classes with partial local evidence still requiring non-tree completion: %s", strings.Join(partial, ", ")))
+	}
 	if len(external) > 0 {
 		parts = append(parts, fmt.Sprintf("still requires non-tree study artifacts: %s", strings.Join(external, ", ")))
 	}
 	return strings.Join(parts, "; ")
 }
-
 func shouldSkipInventoryDir(name string) bool {
 	switch strings.ToLower(name) {
 	case ".git", ".hg", ".svn", "node_modules", "vendor", ".venv", "venv", "__pycache__", "dist", "build", ".next", ".cache", ".turbo", ".pytest_cache", "target", "coverage":

--- a/internal/studymonitor/inventory_map_test.go
+++ b/internal/studymonitor/inventory_map_test.go
@@ -101,6 +101,19 @@ func TestBuildInventoryMapClassifiesTestdataWithoutFixturePrefixFalsePositive(t 
 	}
 }
 
+func TestBuildInventoryMapCompletenessNoteIncludesPartial(t *testing.T) {
+	root := t.TempDir()
+	writeInventoryFixture(t, root, "README.md", "# demo\n")
+	writeInventoryFixture(t, root, ".github/ISSUE_TEMPLATE/bug.md", "bug\n")
+	report, err := BuildInventoryMap(root, InventoryMapOptions{Repository: "owner/repo", IndexedRevision: "abc123", ObservedAt: "2026-08-25T00:00:00Z"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const want = "classes with partial local evidence still requiring non-tree completion: open_closed_issues_prs_discussions"
+	if !strings.Contains(report.CompletenessNote, want) {
+		t.Fatalf("completeness note = %q, want %q", report.CompletenessNote, want)
+	}
+}
 func writeInventoryFixture(t *testing.T, root, rel, text string) {
 	t.Helper()
 	path := filepath.Join(root, filepath.FromSlash(rel))


### PR DESCRIPTION
Closes #8954`n`nWitness: `go test ./internal/studymonitor -count=1`