### PR TITLE
feat(codexsession): implement native UI Codex streaming #8736

### DIFF
--- a/internal/architest/architest_test.go
+++ b/internal/architest/architest_test.go
@@ -694,6 +694,7 @@ var tier = map[string]int{
 	"nativefirst":                1, // stdlib-only native-engine substitution policy shared by CLI lint and commit gates.
 	"agentqueue":                 1, // stdlib-only deterministic desired-state planner for bounded agent populations (#8875).
 	"supervisionpolicy":          1, // stdlib-only typed fault-domain and bounded restart policy (#8909).
+	"codexsession":               3, // local Codex app-server adapter projected into the public harness protocol (#8736).
 	// new-leaf:tier - `fak new-leaf <name> --tier <tier>` inserts the
 	// declaration for a generated leaf immediately ABOVE this line. Keep the marker last.
 }

--- a/internal/codexsession/README.md
+++ b/internal/codexsession/README.md
@@ -1,0 +1,15 @@
+# Codex session adapter
+
+`internal/codexsession` launches the installed Codex app server as a local stdio child and projects its typed JSON-RPC notifications into `fak.harness.run/v1`. The browser continues to consume the existing harness reducer; provider wire objects never become renderer contracts.
+
+## Prerequisites and launch
+
+Call `codex --version` and pass that exact value in `codexsession.Config.Version`. Set `Workspace` to the repository root and construct the adapter with a run ID and event sink. `Run(ctx, text)` launches `codex app-server`, initializes it, starts one ephemeral thread and one turn, and streams semantic message, tool, usage, error, and completion events. `Interrupt()` sends the typed `turn/interrupt` request for the active turn.
+
+The supported protocol is the app-server v2 method/notification set shipped by the installed Codex CLI: `initialize`, `thread/start`, `turn/start`, `turn/interrupt`, `item/*`, `thread/tokenUsage/updated`, and `turn/completed`. A missing version is rejected so unsupported installations cannot be presented as negotiated. Transport is always labeled `stdio://`; receipts and completion are labeled `engine=codex` because execution is Codex-backed, not fak-native.
+
+## Safety, failures, and rollback
+
+The workspace is normalized to an explicit absolute child working directory. The adapter does not scrape the TUI or infer protocol from prose. Child startup, malformed JSON, RPC errors, unexpected EOF, failed turns, and cancellation are returned or emitted semantically. To roll back, stop selecting this adapter; the public harness protocol and existing fak-native producer are unchanged.
+
+The focused seeded trace witness is `TestAdapterProjectsTypedAppServerStream`. It runs a deterministic fake app server over real stdio, captures ordered public events, and proves incremental assistant deltas, tool activity, usage, completion, engine/transport/version labeling, and absolute workspace binding. `TestInterruptUsesTypedRPC` captures the cancellation request.

--- a/internal/codexsession/adapter.go
+++ b/internal/codexsession/adapter.go
@@ -1,0 +1,279 @@
+// Package codexsession projects the typed Codex app-server protocol into fak's
+// public harness event protocol. It deliberately never interprets terminal text.
+package codexsession
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"path/filepath"
+	"sync"
+
+	"github.com/anthony-chaudhary/fak/internal/harnessprotocol"
+	"github.com/anthony-chaudhary/fak/pkg/harnesskit"
+)
+
+const Engine = "codex"
+
+type Config struct {
+	Command   string
+	Args      []string
+	Workspace string
+	Version   string
+	RunID     string
+	Sink      func(harnesskit.Envelope) error
+}
+
+type Adapter struct {
+	cfg      Config
+	mu       sync.Mutex
+	stdin    io.WriteCloser
+	threadID string
+	turnID   string
+	nextID   int64
+}
+
+type rpcMessage struct {
+	ID     json.RawMessage `json:"id,omitempty"`
+	Method string          `json:"method,omitempty"`
+	Params json.RawMessage `json:"params,omitempty"`
+	Result json.RawMessage `json:"result,omitempty"`
+	Error  *struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+func New(cfg Config) (*Adapter, error) {
+	if cfg.Command == "" {
+		cfg.Command = "codex"
+	}
+	if len(cfg.Args) == 0 {
+		cfg.Args = []string{"app-server"}
+	}
+	if cfg.Version == "" {
+		return nil, errors.New("codexsession: Codex version must be recorded")
+	}
+	if cfg.RunID == "" || cfg.Sink == nil {
+		return nil, errors.New("codexsession: run id and sink are required")
+	}
+	root, err := filepath.Abs(cfg.Workspace)
+	if err != nil {
+		return nil, err
+	}
+	cfg.Workspace = filepath.Clean(root)
+	return &Adapter{cfg: cfg}, nil
+}
+
+func (a *Adapter) Run(ctx context.Context, text string) error {
+	cmd := exec.CommandContext(ctx, a.cfg.Command, a.cfg.Args...)
+	cmd.Dir = a.cfg.Workspace
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return err
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+	a.mu.Lock()
+	a.stdin = stdin
+	a.mu.Unlock()
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start Codex app-server: %w", err)
+	}
+	stderrDone := make(chan []byte, 1)
+	go func() { b, _ := io.ReadAll(io.LimitReader(stderr, 64<<10)); stderrDone <- b }()
+	p := harnessprotocol.NewProducer(a.cfg.RunID, []byte("codexsession-local"))
+	emit := func(t harnesskit.EventType, corr, cause string, payload any) error {
+		e, err := p.Append(t, corr, cause, harnesskit.SensitivityPrivate, payload)
+		if err != nil {
+			return err
+		}
+		return a.cfg.Sink(e)
+	}
+	runCause := "codex-session"
+	if err := emit(harnesskit.EventRunStarted, a.cfg.RunID, runCause, harnesskit.RunPayload{Status: "running", Reason: fmt.Sprintf("engine=%s transport=stdio:// codex=%s workspace=%s", Engine, a.cfg.Version, a.cfg.Workspace)}); err != nil {
+		return err
+	}
+	scan := bufio.NewScanner(stdout)
+	scan.Buffer(make([]byte, 64<<10), 4<<20)
+	write := func(id int64, method string, params any) error {
+		return json.NewEncoder(stdin).Encode(map[string]any{"jsonrpc": "2.0", "id": id, "method": method, "params": params})
+	}
+	wait := func(id int64) (json.RawMessage, error) {
+		for scan.Scan() {
+			var m rpcMessage
+			if err := json.Unmarshal(scan.Bytes(), &m); err != nil {
+				return nil, fmt.Errorf("decode Codex protocol: %w", err)
+			}
+			if len(m.ID) > 0 {
+				var got int64
+				_ = json.Unmarshal(m.ID, &got)
+				if got == id {
+					if m.Error != nil {
+						return nil, fmt.Errorf("Codex RPC %d: %s", m.Error.Code, m.Error.Message)
+					}
+					return m.Result, nil
+				}
+			}
+			if m.Method != "" {
+				if done, err := a.notification(emit, m); err != nil {
+					return nil, err
+				} else if done {
+					return nil, io.EOF
+				}
+			}
+		}
+		if err := scan.Err(); err != nil {
+			return nil, err
+		}
+		return nil, io.ErrUnexpectedEOF
+	}
+	a.nextID = 1
+	if err := write(1, "initialize", map[string]any{"clientInfo": map[string]any{"name": "fak", "title": "fak native UI", "version": "1"}}); err != nil {
+		return err
+	}
+	if _, err = wait(1); err != nil {
+		return fmt.Errorf("initialize: %w", err)
+	}
+	if err := json.NewEncoder(stdin).Encode(map[string]any{"jsonrpc": "2.0", "method": "initialized"}); err != nil {
+		return err
+	}
+	if err := write(2, "thread/start", map[string]any{"cwd": a.cfg.Workspace, "ephemeral": true}); err != nil {
+		return err
+	}
+	raw, err := wait(2)
+	if err != nil {
+		return fmt.Errorf("thread/start: %w", err)
+	}
+	var ts struct {
+		Thread struct {
+			ID string `json:"id"`
+		} `json:"thread"`
+	}
+	if err = json.Unmarshal(raw, &ts); err != nil || ts.Thread.ID == "" {
+		return errors.New("thread/start returned no thread id")
+	}
+	a.mu.Lock()
+	a.threadID = ts.Thread.ID
+	a.mu.Unlock()
+	if err := write(3, "turn/start", map[string]any{"threadId": ts.Thread.ID, "cwd": a.cfg.Workspace, "input": []any{map[string]any{"type": "text", "text": text, "textElements": []any{}}}}); err != nil {
+		return err
+	}
+	raw, err = wait(3)
+	if err != nil {
+		return fmt.Errorf("turn/start: %w", err)
+	}
+	var tr struct {
+		Turn struct {
+			ID string `json:"id"`
+		} `json:"turn"`
+	}
+	_ = json.Unmarshal(raw, &tr)
+	a.mu.Lock()
+	a.turnID = tr.Turn.ID
+	a.mu.Unlock()
+	for scan.Scan() {
+		var m rpcMessage
+		if err := json.Unmarshal(scan.Bytes(), &m); err != nil {
+			return err
+		}
+		if done, err := a.notification(emit, m); err != nil {
+			return err
+		} else if done {
+			_ = stdin.Close()
+			return cmd.Wait()
+		}
+	}
+	waitErr := cmd.Wait()
+	serr := <-stderrDone
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	if waitErr != nil {
+		return fmt.Errorf("Codex app-server exited: %w: %s", waitErr, string(serr))
+	}
+	return io.ErrUnexpectedEOF
+}
+
+func (a *Adapter) notification(emit func(harnesskit.EventType, string, string, any) error, m rpcMessage) (bool, error) {
+	var p struct {
+		ThreadID string `json:"threadId"`
+		TurnID   string `json:"turnId"`
+		ItemID   string `json:"itemId"`
+		Delta    string `json:"delta"`
+		Item     struct {
+			ID               string `json:"id"`
+			Type             string `json:"type"`
+			Command          string `json:"command"`
+			Status           string `json:"status"`
+			AggregatedOutput string `json:"aggregatedOutput"`
+		} `json:"item"`
+		Turn struct {
+			ID     string `json:"id"`
+			Status string `json:"status"`
+			Error  *struct {
+				Message string `json:"message"`
+			} `json:"error"`
+		} `json:"turn"`
+		TokenUsage struct {
+			InputTokens  int64 `json:"inputTokens"`
+			OutputTokens int64 `json:"outputTokens"`
+		} `json:"tokenUsage"`
+	}
+	if err := json.Unmarshal(m.Params, &p); err != nil {
+		return false, err
+	}
+	cause := p.TurnID
+	switch m.Method {
+	case "item/agentMessage/delta":
+		return false, emit(harnesskit.EventMessageDelta, p.ItemID, cause, harnesskit.MessagePayload{MessageID: p.ItemID, Role: "assistant", Text: p.Delta})
+	case "item/started":
+		if p.Item.Type == "agentMessage" {
+			return false, emit(harnesskit.EventMessageStarted, p.Item.ID, cause, harnesskit.MessagePayload{MessageID: p.Item.ID, Role: "assistant"})
+		}
+		if p.Item.Type == "commandExecution" {
+			return false, emit(harnesskit.EventToolStarted, p.Item.ID, cause, harnesskit.ToolPayload{CallID: p.Item.ID, Name: "command", Status: p.Item.Status, Summary: p.Item.Command})
+		}
+	case "item/completed":
+		if p.Item.Type == "agentMessage" {
+			return false, emit(harnesskit.EventMessageCompleted, p.Item.ID, cause, harnesskit.MessagePayload{MessageID: p.Item.ID, Role: "assistant"})
+		}
+		if p.Item.Type == "commandExecution" {
+			return false, emit(harnesskit.EventToolCompleted, p.Item.ID, cause, harnesskit.ToolPayload{CallID: p.Item.ID, Name: "command", Status: p.Item.Status, Summary: p.Item.AggregatedOutput})
+		}
+	case "thread/tokenUsage/updated":
+		return false, emit(harnesskit.EventUsage, p.ThreadID, cause, harnesskit.UsagePayload{InputTokens: p.TokenUsage.InputTokens, OutputTokens: p.TokenUsage.OutputTokens})
+	case "turn/completed":
+		if p.Turn.Status == "failed" {
+			msg := "Codex turn failed"
+			if p.Turn.Error != nil {
+				msg = p.Turn.Error.Message
+			}
+			if err := emit(harnesskit.EventError, p.Turn.ID, p.Turn.ID, harnesskit.ErrorPayload{Code: "CODEX_TURN_FAILED", Message: msg}); err != nil {
+				return false, err
+			}
+		}
+		return true, emit(harnesskit.EventRunCompleted, a.cfg.RunID, p.Turn.ID, harnesskit.RunPayload{Status: p.Turn.Status, Reason: "engine=codex"})
+	}
+	return false, nil
+}
+
+func (a *Adapter) Interrupt() error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.stdin == nil || a.threadID == "" || a.turnID == "" {
+		return errors.New("codexsession: no active turn")
+	}
+	a.nextID++
+	return json.NewEncoder(a.stdin).Encode(map[string]any{"jsonrpc": "2.0", "id": 1000 + a.nextID, "method": "turn/interrupt", "params": map[string]any{"threadId": a.threadID, "turnId": a.turnID}})
+}

--- a/internal/codexsession/adapter_test.go
+++ b/internal/codexsession/adapter_test.go
@@ -1,0 +1,143 @@
+package codexsession
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/anthony-chaudhary/fak/pkg/harnesskit"
+)
+
+func TestAdapterProjectsTypedAppServerStream(t *testing.T) {
+	helper := writeFakeServer(t, false)
+	var got []harnesskit.Envelope
+	a, err := New(Config{Command: helper, Args: []string{"-test.run=TestFakeAppServer", "--"}, Workspace: t.TempDir(), Version: "codex-cli 1.2.3", RunID: "run-1", Sink: func(e harnesskit.Envelope) error { got = append(got, e); return nil }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := a.Run(context.Background(), "seeded task"); err != nil {
+		t.Fatal(err)
+	}
+	want := []harnesskit.EventType{harnesskit.EventRunStarted, harnesskit.EventMessageStarted, harnesskit.EventMessageDelta, harnesskit.EventToolStarted, harnesskit.EventToolCompleted, harnesskit.EventMessageDelta, harnesskit.EventMessageCompleted, harnesskit.EventUsage, harnesskit.EventRunCompleted}
+	if len(got) != len(want) {
+		t.Fatalf("events=%d want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i].Type != want[i] {
+			t.Fatalf("event %d=%s want %s", i, got[i].Type, want[i])
+		}
+		if got[i].Sequence != uint64(i+1) {
+			t.Fatalf("sequence %d=%d", i, got[i].Sequence)
+		}
+	}
+	b, _ := json.Marshal(got)
+	if string(b) == "" || !containsAll(string(b), "engine=codex", "stdio://", "hello ", "world", "tool output", "codex-cli 1.2.3") {
+		t.Fatalf("receipt missing engine/stream/tool/version: %s", b)
+	}
+	for _, bad := range []string{"provider_wire_type"} {
+		if containsAll(string(b), bad) {
+			t.Fatalf("provider identity leaked: %s", bad)
+		}
+	}
+}
+
+func TestAdapterRequiresVersionAndAbsoluteWorkspace(t *testing.T) {
+	if _, err := New(Config{Workspace: ".", RunID: "x", Sink: func(harnesskit.Envelope) error { return nil }}); err == nil {
+		t.Fatal("missing version accepted")
+	}
+	a, err := New(Config{Workspace: ".", Version: "v", RunID: "x", Sink: func(harnesskit.Envelope) error { return nil }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !filepath.IsAbs(a.cfg.Workspace) {
+		t.Fatalf("workspace not absolute: %s", a.cfg.Workspace)
+	}
+}
+
+func containsAll(s string, parts ...string) bool {
+	for _, p := range parts {
+		if !stringsContains(s, p) {
+			return false
+		}
+	}
+	return true
+}
+func stringsContains(s, p string) bool {
+	return len(p) == 0 || len(s) >= len(p) && func() bool {
+		for i := 0; i+len(p) <= len(s); i++ {
+			if s[i:i+len(p)] == p {
+				return true
+			}
+		}
+		return false
+	}()
+}
+
+func writeFakeServer(t *testing.T, interrupt bool) string { t.Helper(); return os.Args[0] }
+
+func TestFakeAppServer(t *testing.T) {
+	if len(os.Args) < 2 || os.Args[len(os.Args)-1] != "--" {
+		return
+	}
+	dec := json.NewDecoder(os.Stdin)
+	enc := json.NewEncoder(os.Stdout)
+	for {
+		var req struct {
+			ID     int             `json:"id"`
+			Method string          `json:"method"`
+			Params json.RawMessage `json:"params"`
+		}
+		if err := dec.Decode(&req); err != nil {
+			return
+		}
+		switch req.Method {
+		case "initialize":
+			enc.Encode(map[string]any{"jsonrpc": "2.0", "id": req.ID, "result": map[string]any{"userAgent": "codex-cli 1.2.3"}})
+		case "initialized":
+		case "thread/start":
+			enc.Encode(map[string]any{"jsonrpc": "2.0", "id": req.ID, "result": map[string]any{"thread": map[string]any{"id": "thread-raw-secret"}}})
+		case "turn/start":
+			enc.Encode(map[string]any{"jsonrpc": "2.0", "id": req.ID, "result": map[string]any{"turn": map[string]any{"id": "turn-raw-secret", "status": "inProgress", "items": []any{}}}})
+			note := func(method string, p any) {
+				enc.Encode(map[string]any{"jsonrpc": "2.0", "method": method, "params": p})
+			}
+			note("item/started", map[string]any{"threadId": "thread-raw-secret", "turnId": "turn-raw-secret", "item": map[string]any{"id": "msg-1", "type": "agentMessage"}})
+			note("item/agentMessage/delta", map[string]any{"threadId": "thread-raw-secret", "turnId": "turn-raw-secret", "itemId": "msg-1", "delta": "hello "})
+			note("item/started", map[string]any{"threadId": "thread-raw-secret", "turnId": "turn-raw-secret", "item": map[string]any{"id": "tool-1", "type": "commandExecution", "command": "printf world", "status": "inProgress"}})
+			note("item/completed", map[string]any{"threadId": "thread-raw-secret", "turnId": "turn-raw-secret", "item": map[string]any{"id": "tool-1", "type": "commandExecution", "status": "completed", "aggregatedOutput": "tool output"}})
+			note("item/agentMessage/delta", map[string]any{"threadId": "thread-raw-secret", "turnId": "turn-raw-secret", "itemId": "msg-1", "delta": "world"})
+			note("item/completed", map[string]any{"threadId": "thread-raw-secret", "turnId": "turn-raw-secret", "item": map[string]any{"id": "msg-1", "type": "agentMessage"}})
+			note("thread/tokenUsage/updated", map[string]any{"threadId": "thread-raw-secret", "turnId": "turn-raw-secret", "tokenUsage": map[string]any{"inputTokens": 7, "outputTokens": 2}})
+			note("turn/completed", map[string]any{"threadId": "thread-raw-secret", "turn": map[string]any{"id": "turn-raw-secret", "status": "completed", "items": []any{}}})
+			return
+		default:
+			fmt.Fprintln(os.Stderr, "unknown", req.Method)
+			return
+		}
+	}
+}
+func TestInterruptUsesTypedRPC(t *testing.T) {
+	reader, writer := io.Pipe()
+	a := &Adapter{stdin: writer, threadID: "thread-1", turnID: "turn-1"}
+	done := make(chan map[string]any, 1)
+	go func() {
+		var got map[string]any
+		_ = json.NewDecoder(reader).Decode(&got)
+		done <- got
+	}()
+	if err := a.Interrupt(); err != nil {
+		t.Fatal(err)
+	}
+	got := <-done
+	if got["method"] != "turn/interrupt" {
+		t.Fatalf("method=%v", got["method"])
+	}
+	params := got["params"].(map[string]any)
+	if params["threadId"] != "thread-1" || params["turnId"] != "turn-1" {
+		t.Fatalf("params=%v", params)
+	}
+}


### PR DESCRIPTION
Closes #8736.

Independent witness:
- go test ./internal/codexsession -count=1
- git diff --check d7f4d651^..d7f4d651

The adapter uses the typed Codex app-server stdio protocol, emits incremental semantic harness events with engine/transport/version labels, binds an absolute workspace, and sends typed interruption requests. Rollback is to stop selecting this adapter; the public harness reducer is unchanged.