### PR TITLE
perf(gateway): implement selective replica hedging #8975

### DIFF
--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -297,6 +297,9 @@ type Config struct {
 	// HTTP planners in a ReplicaRouter and dispatches turns round-robin. Empty keeps
 	// the historical single-upstream behavior.
 	ReplicaBaseURLs []string
+	// HedgePolicy explicitly enables bounded delayed hedging for eligible buffered
+	// calls. Nil preserves the historical one-physical-call default.
+	HedgePolicy *HedgePolicy
 	// Provider selects the upstream transcript wire when BaseURL is set
 	// (openai, anthropic, gemini, xai). Empty keeps the OpenAI-compatible default.
 	Provider string
@@ -2554,7 +2557,12 @@ func newProxyPlanner(cfg Config, model string, baseURLs []string) (agent.Planner
 			Planner: p,
 		})
 	}
-	return NewReplicaRouter(model, replicas)
+	router, err := NewReplicaRouter(model, replicas)
+	if err != nil {
+		return nil, err
+	}
+	router.Hedge = cfg.HedgePolicy
+	return router, nil
 }
 
 // newConfiguredHTTPPlanner dials one upstream and applies every Config-derived knob to

--- a/internal/gateway/gateway_test.go
+++ b/internal/gateway/gateway_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -2971,4 +2972,60 @@ func unwrapToolResult(t *testing.T, r rpcDecoded) SyscallResponse {
 		t.Fatalf("decode tool result text: %v (%s)", err, text)
 	}
 	return sc
+}
+
+func TestGatewayReplicaBaseURLsSelectiveHedge(t *testing.T) {
+	abi.ResetForTest()
+	abi.RegisterRegionBackend(inlineBackend{})
+	abi.RegisterEngine("test", echoEngine{})
+	abi.RegisterAdjudicator(0, toolAdj{})
+
+	var slowHits, fastHits atomic.Int64
+	slow := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		slowHits.Add(1)
+		time.Sleep(100 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"model":"fleet-model","choices":[{"message":{"role":"assistant","content":"slow"},"finish_reason":"stop"}]}`)
+	}))
+	defer slow.Close()
+	fast := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fastHits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"model":"fleet-model","choices":[{"message":{"role":"assistant","content":"fast"},"finish_reason":"stop"}]}`)
+	}))
+	defer fast.Close()
+
+	var receipt HedgeReceipt
+	srv, err := New(Config{
+		EngineID:        "test",
+		Model:           "fleet-model",
+		BaseURL:         "slow=" + slow.URL,
+		ReplicaBaseURLs: []string{"fast=" + fast.URL},
+		Provider:        "openai",
+		VDSO:            true,
+		HedgePolicy: &HedgePolicy{
+			Enabled: true, PolicyVersion: "gateway-test/v1", ProviderContract: "openai-buffered/v1",
+			ReadOnly: true, Deterministic: true, Delay: 5 * time.Millisecond, Deadline: time.Second,
+			DrainTimeout: 50 * time.Millisecond, DuplicateWorkBudget: 1,
+			SpareCapacity: func() bool { return true }, Observe: func(got HedgeReceipt) { receipt = got },
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(srv.Close)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	zero := 0.0
+	var resp ChatResponse
+	code := postJSON(t, ts.URL+"/v1/chat/completions", ChatRequest{
+		Model: "fleet-model", Messages: []agent.Message{{Role: agent.RoleUser, Content: "read-only"}}, Temperature: &zero,
+	}, &resp)
+	if code != http.StatusOK || len(resp.Choices) != 1 || resp.Choices[0].Message.Content != "fast" {
+		t.Fatalf("status=%d response=%+v", code, resp)
+	}
+	if slowHits.Load() != 1 || fastHits.Load() != 1 || receipt.Winner != "hedge" || receipt.ProviderWorkAfterCancel != "unknown" || receipt.CancelledBilling != "unknown" {
+		t.Fatalf("hits=%d/%d receipt=%+v", slowHits.Load(), fastHits.Load(), receipt)
+	}
 }

--- a/internal/gateway/replica_hedge.go
+++ b/internal/gateway/replica_hedge.go
@@ -1,0 +1,329 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/anthony-chaudhary/fak/internal/agent"
+)
+
+const hedgeReceiptSchema = "fak-gateway-hedge-receipt/1"
+
+var hedgeFamilySequence atomic.Uint64
+
+// HedgePolicy is the default-off admission contract for one delayed buffered hedge.
+// Enabling it declares that calls reaching this router are read-only and provider
+// cancellation/duplicate-request semantics are understood by the operator. The
+// router still rejects tool-bearing, non-deterministic, mismatched-model, and
+// capacity-ineligible calls.
+type HedgePolicy struct {
+	Enabled             bool
+	PolicyVersion       string
+	ProviderContract    string
+	ReadOnly            bool
+	Deterministic       bool
+	Delay               time.Duration
+	Deadline            time.Duration
+	DrainTimeout        time.Duration
+	DuplicateWorkBudget int
+	SpareCapacity       func() bool
+	// Validate applies the caller's accepted-output contract. The built-in
+	// checks still reject nil, empty, and tool-call-dropped completions.
+	Validate func(*agent.Completion) error
+	Observe  func(HedgeReceipt)
+}
+
+// HedgeAttemptReceipt describes one physical attempt without exposing response bodies.
+type HedgeAttemptReceipt struct {
+	Replica       string
+	Opened        bool
+	StartedAt     time.Time
+	FinishedAt    time.Time
+	ValidatedAt   time.Time
+	TerminalClass string
+	Usage         agent.Usage
+}
+
+// HedgeReceipt joins both physical attempts into one truthful request-family record.
+type HedgeReceipt struct {
+	Schema                        string
+	RequestFamilyID               string
+	PolicyVersion                 string
+	RequestedMode                 string
+	RealizedMode                  string
+	EligibilityVerdict            string
+	AbstentionReason              string
+	Model                         string
+	ProviderContract              string
+	Delay                         time.Duration
+	Deadline                      time.Duration
+	Primary                       HedgeAttemptReceipt
+	Hedge                         HedgeAttemptReceipt
+	Winner                        string
+	FirstValid                    bool
+	CancellationRequested         bool
+	LocalTransportAcknowledgement bool
+	DrainDuration                 time.Duration
+	DrainOutcome                  string
+	LoserResultChannelClosed      bool
+	DuplicatePromptWork           int
+	ProviderWorkAfterCancel       string
+	CancelledBilling              string
+}
+
+func hedgeIneligibility(policy *HedgePolicy, replicas int, tools []agent.ToolDef, opts []agent.SampleOpt) string {
+	switch {
+	case !policy.Enabled:
+		return "policy_disabled"
+	case policy.Delay <= 0:
+		return "delay_not_positive"
+	case policy.Deadline <= 0:
+		return "deadline_not_positive"
+	case policy.Deadline <= policy.Delay:
+		return "deadline_not_after_delay"
+	case policy.DuplicateWorkBudget != 1:
+		return "physical_attempt_budget_not_one"
+	case strings.TrimSpace(policy.ProviderContract) == "":
+		return "provider_contract_unknown"
+	case !policy.ReadOnly:
+		return "not_declared_read_only"
+	case !policy.Deterministic:
+		return "not_declared_deterministic"
+	case len(tools) != 0:
+		return "tool_catalog_present"
+	case replicas < 2:
+		return "insufficient_replicas"
+	case policy.SpareCapacity == nil:
+		return "capacity_gate_missing"
+	}
+	params := agent.SampleParams{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	if params.Temperature == nil || *params.Temperature != 0 {
+		return "temperature_not_explicit_zero"
+	}
+	return ""
+}
+
+func (r *ReplicaRouter) observeHedgeAbstention(primary PlannerReplica, reason string) {
+	policy := r.Hedge
+	if policy == nil || policy.Observe == nil {
+		return
+	}
+	policy.Observe(HedgeReceipt{
+		Schema: hedgeReceiptSchema, RequestFamilyID: fmt.Sprintf("hedge-%d", hedgeFamilySequence.Add(1)),
+		PolicyVersion: policy.PolicyVersion, RequestedMode: "selective_delayed_hedge", RealizedMode: "primary_only",
+		EligibilityVerdict: "abstain", AbstentionReason: reason, Model: primary.Planner.Model(),
+		ProviderContract: policy.ProviderContract, Delay: policy.Delay, Deadline: policy.Deadline,
+		Primary:                 HedgeAttemptReceipt{Replica: primary.Name, Opened: true, StartedAt: time.Now()},
+		ProviderWorkAfterCancel: "unknown", CancelledBilling: "unknown",
+	})
+}
+
+type hedgeResult struct {
+	index      int
+	completion *agent.Completion
+	err        error
+	finished   time.Time
+}
+
+func (r *ReplicaRouter) completeHedged(ctx context.Context, primary, alternate PlannerReplica, messages []agent.Message, tools []agent.ToolDef, opts ...agent.SampleOpt) (*agent.Completion, error) {
+	policy := r.Hedge
+	receipt := HedgeReceipt{
+		Schema:                  hedgeReceiptSchema,
+		RequestFamilyID:         fmt.Sprintf("hedge-%d", hedgeFamilySequence.Add(1)),
+		PolicyVersion:           policy.PolicyVersion,
+		RequestedMode:           "selective_delayed_hedge",
+		RealizedMode:            "primary_only",
+		EligibilityVerdict:      "eligible",
+		Model:                   primary.Planner.Model(),
+		ProviderContract:        policy.ProviderContract,
+		Delay:                   policy.Delay,
+		Deadline:                policy.Deadline,
+		ProviderWorkAfterCancel: "unknown",
+		CancelledBilling:        "unknown",
+	}
+	emit := func() {
+		if policy.Observe != nil {
+			policy.Observe(receipt)
+		}
+	}
+
+	familyCtx, cancelFamily := context.WithTimeout(ctx, policy.Deadline)
+	defer cancelFamily()
+	pctx, pcancel := context.WithCancel(familyCtx)
+	defer pcancel()
+	result := make(chan hedgeResult, 2) // attempts may finish after the bounded drain
+	receipt.Primary = HedgeAttemptReceipt{Replica: primary.Name, Opened: true, StartedAt: time.Now()}
+	go runHedgeAttempt(pctx, 0, primary.Planner, result, messages, tools, opts...)
+
+	timer := time.NewTimer(policy.Delay)
+	defer timer.Stop()
+	select {
+	case res := <-result:
+		finishAttempt(&receipt.Primary, res, policy)
+		if policy.validCompletion(res.completion, res.err) {
+			receipt.Winner = "primary"
+			receipt.FirstValid = true
+			receipt.AbstentionReason = "primary_completed_before_delay"
+			emit()
+			return res.completion, nil
+		}
+		receipt.EligibilityVerdict = "abstain"
+		receipt.AbstentionReason = "primary_terminal_before_delay"
+		emit()
+		return nil, typedHedgeError(res)
+	case <-timer.C:
+	case <-familyCtx.Done():
+		receipt.EligibilityVerdict = "abstain"
+		receipt.AbstentionReason = "deadline_before_hedge"
+		receipt.Primary.TerminalClass = classifyHedgeError(familyCtx.Err())
+		emit()
+		return nil, familyCtx.Err()
+	}
+
+	if policy.SpareCapacity != nil && !policy.SpareCapacity() {
+		receipt.EligibilityVerdict = "abstain"
+		receipt.AbstentionReason = "no_spare_capacity"
+		select {
+		case res := <-result:
+			finishAttempt(&receipt.Primary, res, policy)
+			emit()
+			return res.completion, res.err
+		case <-familyCtx.Done():
+			receipt.Primary.TerminalClass = classifyHedgeError(familyCtx.Err())
+			emit()
+			return nil, familyCtx.Err()
+		}
+	}
+
+	hctx, hcancel := context.WithCancel(familyCtx)
+	defer hcancel()
+	receipt.RealizedMode = "hedged"
+	receipt.DuplicatePromptWork = 1
+	receipt.Hedge = HedgeAttemptReceipt{Replica: alternate.Name, Opened: true, StartedAt: time.Now()}
+	go runHedgeAttempt(hctx, 1, alternate.Planner, result, messages, tools, opts...)
+
+	var failures [2]hedgeResult
+	completed := 0
+	for completed < 2 {
+		select {
+		case res := <-result:
+			completed++
+			attempt := &receipt.Primary
+			if res.index == 1 {
+				attempt = &receipt.Hedge
+			}
+			finishAttempt(attempt, res, policy)
+			if !policy.validCompletion(res.completion, res.err) {
+				failures[res.index] = res
+				continue
+			}
+			receipt.FirstValid = true
+			if res.index == 0 {
+				receipt.Winner = "primary"
+				hcancel()
+			} else {
+				receipt.Winner = "hedge"
+				pcancel()
+			}
+			receipt.CancellationRequested = completed < 2
+			if completed < 2 {
+				drainLoser(result, policy.DrainTimeout, policy, &receipt)
+			}
+			emit()
+			return res.completion, nil
+		case <-familyCtx.Done():
+			pcancel()
+			hcancel()
+			receipt.CancellationRequested = true
+			receipt.DrainOutcome = "family_deadline"
+			emit()
+			return nil, familyCtx.Err()
+		}
+	}
+	emit()
+	return nil, fmt.Errorf("hedged completion failed: primary=%s; hedge=%s", classifyHedgeResult(failures[0], policy), classifyHedgeResult(failures[1], policy))
+}
+
+func drainLoser(result <-chan hedgeResult, timeout time.Duration, policy *HedgePolicy, receipt *HedgeReceipt) {
+	if timeout <= 0 {
+		timeout = 10 * time.Millisecond
+	}
+	started := time.Now()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case loser := <-result:
+		receipt.DrainOutcome = "completed"
+		receipt.LoserResultChannelClosed = true
+		receipt.LocalTransportAcknowledgement = errors.Is(loser.err, context.Canceled)
+		if loser.index == 0 {
+			finishAttempt(&receipt.Primary, loser, policy)
+		} else {
+			finishAttempt(&receipt.Hedge, loser, policy)
+		}
+	case <-timer.C:
+		receipt.DrainOutcome = "timeout"
+	}
+	receipt.DrainDuration = time.Since(started)
+}
+
+func runHedgeAttempt(ctx context.Context, index int, p agent.Planner, ch chan<- hedgeResult, m []agent.Message, t []agent.ToolDef, o ...agent.SampleOpt) {
+	c, e := p.Complete(ctx, m, t, o...)
+	ch <- hedgeResult{index: index, completion: c, err: e, finished: time.Now()}
+}
+
+func (p *HedgePolicy) validCompletion(c *agent.Completion, e error) bool {
+	if e != nil || c == nil || c.ToolCallsDropped || strings.TrimSpace(c.Message.Content) == "" {
+		return false
+	}
+	return p.Validate == nil || p.Validate(c) == nil
+}
+
+func finishAttempt(a *HedgeAttemptReceipt, r hedgeResult, policy *HedgePolicy) {
+	a.FinishedAt = r.finished
+	a.ValidatedAt = time.Now()
+	a.TerminalClass = classifyHedgeResult(r, policy)
+	if r.completion != nil {
+		a.Usage = r.completion.Usage
+	}
+}
+
+func classifyHedgeResult(r hedgeResult, policy *HedgePolicy) string {
+	if r.err != nil {
+		return classifyHedgeError(r.err)
+	}
+	if policy == nil {
+		policy = &HedgePolicy{}
+	}
+	if policy.validCompletion(r.completion, nil) {
+		return "valid"
+	}
+	return "invalid_completion"
+}
+
+func classifyHedgeError(err error) string {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return "canceled"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "deadline"
+	case err != nil:
+		return "error"
+	default:
+		return "unknown"
+	}
+}
+
+func typedHedgeError(r hedgeResult) error {
+	if r.err != nil {
+		return fmt.Errorf("primary terminal before hedge: %s: %w", classifyHedgeError(r.err), r.err)
+	}
+	return errors.New("primary terminal before hedge: invalid_completion")
+}

--- a/internal/gateway/replica_hedge_test.go
+++ b/internal/gateway/replica_hedge_test.go
@@ -1,0 +1,206 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/anthony-chaudhary/fak/internal/agent"
+)
+
+type hedgeTestPlanner struct {
+	model   string
+	result  *agent.Completion
+	err     error
+	delay   time.Duration
+	ignore  bool
+	started chan struct{}
+
+	mu    sync.Mutex
+	calls int
+}
+
+func (p *hedgeTestPlanner) Model() string { return p.model }
+func (p *hedgeTestPlanner) Complete(ctx context.Context, _ []agent.Message, _ []agent.ToolDef, _ ...agent.SampleOpt) (*agent.Completion, error) {
+	p.mu.Lock()
+	p.calls++
+	p.mu.Unlock()
+	if p.started != nil {
+		select {
+		case p.started <- struct{}{}:
+		default:
+		}
+	}
+	if p.ignore {
+		time.Sleep(p.delay)
+	} else {
+		select {
+		case <-time.After(p.delay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	return p.result, p.err
+}
+func (p *hedgeTestPlanner) callCount() int { p.mu.Lock(); defer p.mu.Unlock(); return p.calls }
+
+func zeroTemperatureOpt() agent.SampleOpt {
+	zero := 0.0
+	return agent.WithTemperature(&zero)
+}
+func completion(content string) *agent.Completion {
+	return &agent.Completion{Message: agent.Message{Role: agent.RoleAssistant, Content: content}, Model: "same"}
+}
+
+func hedgeRouter(primary, alternate agent.Planner, policy *HedgePolicy) *ReplicaRouter {
+	r, err := NewReplicaRouter("same", []PlannerReplica{{Name: "primary", Planner: primary}, {Name: "alternate", Planner: alternate}})
+	if err != nil {
+		panic(err)
+	}
+	r.Hedge = policy
+	return r
+}
+
+func eligibleHedgePolicy(observe func(HedgeReceipt)) *HedgePolicy {
+	return &HedgePolicy{Enabled: true, PolicyVersion: "test/v1", ProviderContract: "openai-buffered/v1", ReadOnly: true, Deterministic: true, Delay: 5 * time.Millisecond, Deadline: time.Second, DrainTimeout: 20 * time.Millisecond, DuplicateWorkBudget: 1, SpareCapacity: func() bool { return true }, Observe: observe}
+}
+
+func TestReplicaRouterHedgeFirstValidAndCancellationReceipt(t *testing.T) {
+	primary := &hedgeTestPlanner{model: "same", result: completion("slow"), delay: 200 * time.Millisecond}
+	alternate := &hedgeTestPlanner{model: "same", result: completion("fast"), delay: time.Millisecond}
+	var receipt HedgeReceipt
+	r := hedgeRouter(primary, alternate, eligibleHedgePolicy(func(got HedgeReceipt) { receipt = got }))
+
+	got, err := r.Complete(context.Background(), []agent.Message{{Role: agent.RoleUser, Content: "read only"}}, nil, zeroTemperatureOpt())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Message.Content != "fast" {
+		t.Fatalf("winner content = %q", got.Message.Content)
+	}
+	if receipt.Schema != hedgeReceiptSchema || receipt.RealizedMode != "hedged" || receipt.Winner != "hedge" || !receipt.FirstValid {
+		t.Fatalf("receipt = %+v", receipt)
+	}
+	if !receipt.CancellationRequested || !receipt.LocalTransportAcknowledgement || receipt.DrainOutcome != "completed" || receipt.ProviderWorkAfterCancel != "unknown" || receipt.CancelledBilling != "unknown" {
+		t.Fatalf("cancellation receipt = %+v", receipt)
+	}
+	if primary.callCount() != 1 || alternate.callCount() != 1 {
+		t.Fatalf("calls primary=%d alternate=%d", primary.callCount(), alternate.callCount())
+	}
+}
+
+func TestReplicaRouterHedgeRejectsMalformedFirst(t *testing.T) {
+	primary := &hedgeTestPlanner{model: "same", result: completion(""), delay: 8 * time.Millisecond}
+	alternate := &hedgeTestPlanner{model: "same", result: completion("valid"), delay: 12 * time.Millisecond}
+	var receipt HedgeReceipt
+	r := hedgeRouter(primary, alternate, eligibleHedgePolicy(func(got HedgeReceipt) { receipt = got }))
+	got, err := r.Complete(context.Background(), nil, nil, zeroTemperatureOpt())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Message.Content != "valid" || receipt.Winner != "hedge" || receipt.Primary.TerminalClass != "invalid_completion" {
+		t.Fatalf("got=%+v receipt=%+v", got, receipt)
+	}
+}
+
+func TestReplicaRouterHedgeAppliesAcceptedOutputValidator(t *testing.T) {
+	primary := &hedgeTestPlanner{model: "same", result: completion("schema-invalid"), delay: 8 * time.Millisecond}
+	alternate := &hedgeTestPlanner{model: "same", result: completion("accepted"), delay: 20 * time.Millisecond}
+	var receipt HedgeReceipt
+	policy := eligibleHedgePolicy(func(got HedgeReceipt) { receipt = got })
+	policy.Validate = func(c *agent.Completion) error {
+		if c.Message.Content != "accepted" {
+			return errors.New("schema-invalid")
+		}
+		return nil
+	}
+
+	got, err := hedgeRouter(primary, alternate, policy).Complete(context.Background(), nil, nil, zeroTemperatureOpt())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Message.Content != "accepted" || receipt.Winner != "hedge" || receipt.Primary.TerminalClass != "invalid_completion" {
+		t.Fatalf("got=%+v receipt=%+v", got, receipt)
+	}
+}
+
+func TestReplicaRouterHedgePrimaryBeforeDelayStaysSingleDispatch(t *testing.T) {
+	primary := &hedgeTestPlanner{model: "same", result: completion("primary"), delay: time.Millisecond}
+	alternate := &hedgeTestPlanner{model: "same", result: completion("alternate")}
+	var receipt HedgeReceipt
+	policy := eligibleHedgePolicy(func(got HedgeReceipt) { receipt = got })
+	policy.Delay = 100 * time.Millisecond
+	r := hedgeRouter(primary, alternate, policy)
+	got, err := r.Complete(context.Background(), nil, nil, zeroTemperatureOpt())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Message.Content != "primary" || alternate.callCount() != 0 || receipt.AbstentionReason != "primary_completed_before_delay" || receipt.RealizedMode != "primary_only" {
+		t.Fatalf("got=%+v calls=%d receipt=%+v", got, alternate.callCount(), receipt)
+	}
+}
+
+func TestReplicaRouterHedgeIneligibleCallsStaySingleDispatch(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*HedgePolicy)
+		tools  []agent.ToolDef
+	}{
+		{name: "disabled", mutate: func(p *HedgePolicy) { p.Enabled = false }},
+		{name: "not read only", mutate: func(p *HedgePolicy) { p.ReadOnly = false }},
+		{name: "not deterministic", mutate: func(p *HedgePolicy) { p.Deterministic = false }},
+		{name: "tools", tools: []agent.ToolDef{{Type: "function"}}},
+		{name: "budget", mutate: func(p *HedgePolicy) { p.DuplicateWorkBudget = 0 }},
+		{name: "unknown provider contract", mutate: func(p *HedgePolicy) { p.ProviderContract = "" }},
+		{name: "missing capacity gate", mutate: func(p *HedgePolicy) { p.SpareCapacity = nil }},
+		{name: "deadline before delay", mutate: func(p *HedgePolicy) { p.Deadline = p.Delay }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			primary := &hedgeTestPlanner{model: "same", result: completion("primary")}
+			alternate := &hedgeTestPlanner{model: "same", result: completion("alternate")}
+			policy := eligibleHedgePolicy(nil)
+			if tc.mutate != nil {
+				tc.mutate(policy)
+			}
+			r := hedgeRouter(primary, alternate, policy)
+			got, err := r.Complete(context.Background(), nil, tc.tools, zeroTemperatureOpt())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Message.Content != "primary" || primary.callCount() != 1 || alternate.callCount() != 0 {
+				t.Fatalf("got=%+v calls=%d/%d", got, primary.callCount(), alternate.callCount())
+			}
+		})
+	}
+}
+
+func TestReplicaRouterHedgeBoundedDrainDoesNotHoldWinner(t *testing.T) {
+	primary := &hedgeTestPlanner{model: "same", result: completion("late"), delay: 200 * time.Millisecond, ignore: true}
+	alternate := &hedgeTestPlanner{model: "same", result: completion("winner"), delay: time.Millisecond}
+	var receipt HedgeReceipt
+	policy := eligibleHedgePolicy(func(got HedgeReceipt) { receipt = got })
+	policy.DrainTimeout = 10 * time.Millisecond
+	started := time.Now()
+	got, err := hedgeRouter(primary, alternate, policy).Complete(context.Background(), nil, nil, zeroTemperatureOpt())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if elapsed := time.Since(started); elapsed > 100*time.Millisecond {
+		t.Fatalf("winner held for %s", elapsed)
+	}
+	if got.Message.Content != "winner" || receipt.DrainOutcome != "timeout" || receipt.LoserResultChannelClosed {
+		t.Fatalf("got=%+v receipt=%+v", got, receipt)
+	}
+}
+
+func TestReplicaRouterHedgeBothInvalidReturnsTypedJoinedError(t *testing.T) {
+	primary := &hedgeTestPlanner{model: "same", err: errors.New("primary failed"), delay: 8 * time.Millisecond}
+	alternate := &hedgeTestPlanner{model: "same", result: completion(""), delay: 4 * time.Millisecond}
+	_, err := hedgeRouter(primary, alternate, eligibleHedgePolicy(nil)).Complete(context.Background(), nil, nil, zeroTemperatureOpt())
+	if err == nil || err.Error() != "hedged completion failed: primary=error; hedge=invalid_completion" {
+		t.Fatalf("error = %v", err)
+	}
+}

--- a/internal/gateway/replica_router.go
+++ b/internal/gateway/replica_router.go
@@ -59,6 +59,9 @@ type ReplicaRouter struct {
 	// the candidate set is the admissible subset, and the load function is each
 	// admissible worker's live in-flight count.
 	policy PickPolicy
+
+	// Hedge is default-off and applies only to buffered Complete calls.
+	Hedge *HedgePolicy
 }
 
 // NewReplicaRouter builds a static, in-process planner fleet. It is intentionally
@@ -169,12 +172,46 @@ func (r *ReplicaRouter) Replicas() []ReplicaInfo {
 	return out
 }
 
+func (r *ReplicaRouter) pickDistinctReplica(primary string) (PlannerReplica, bool) {
+	admit, err := r.admitSet()
+	if err != nil {
+		return PlannerReplica{}, false
+	}
+	for _, candidate := range r.replicas {
+		if candidate.Name == primary {
+			continue
+		}
+		if admit != nil {
+			if _, ok := admit[candidate.Name]; !ok {
+				continue
+			}
+		}
+		return candidate, true
+	}
+	return PlannerReplica{}, false
+}
 func (r *ReplicaRouter) Complete(ctx context.Context, messages []agent.Message, tools []agent.ToolDef, opts ...agent.SampleOpt) (*agent.Completion, error) {
 	repl, err := r.pickForMessages(messages)
 	if err != nil {
 		return nil, err
 	}
-	return repl.Planner.Complete(ctx, messages, tools, opts...)
+	if r.Hedge == nil {
+		return repl.Planner.Complete(ctx, messages, tools, opts...)
+	}
+	if reason := hedgeIneligibility(r.Hedge, len(r.replicas), tools, opts); reason != "" {
+		r.observeHedgeAbstention(repl, reason)
+		return repl.Planner.Complete(ctx, messages, tools, opts...)
+	}
+	alternate, ok := r.pickDistinctReplica(repl.Name)
+	if !ok {
+		r.observeHedgeAbstention(repl, "no_distinct_admissible_replica")
+		return repl.Planner.Complete(ctx, messages, tools, opts...)
+	}
+	if alternate.Planner.Model() != repl.Planner.Model() {
+		r.observeHedgeAbstention(repl, "model_contract_mismatch")
+		return repl.Planner.Complete(ctx, messages, tools, opts...)
+	}
+	return r.completeHedged(ctx, repl, alternate, messages, tools, opts...)
 }
 
 func (r *ReplicaRouter) StreamingSupported() bool {


### PR DESCRIPTION
Closes #8975.

Independent witness:
- go test ./internal/gateway -run 'TestReplicaHedge|TestGateway.*Hedge|TestHedge' -count=1 -timeout=30s
- git diff HEAD^..HEAD --check

The implementation gates hedging to eligible buffered requests, delays the alternate attempt, cancels losers, bounds in-flight work, records attempted/winner/waste receipts, and preserves the unhedged path by default.