### PR TITLE
feat(agent): implement provider cache-hint negotiation #7309

### DIFF
--- a/docs/notes/PROVIDER-CACHE-HINT-LIVE-WITNESS-2026-08-25.md
+++ b/docs/notes/PROVIDER-CACHE-HINT-LIVE-WITNESS-2026-08-25.md
@@ -1,0 +1,32 @@
+# Provider cache-hint live witness — issue #7309
+
+Observed 2026-08-25. This artifact records the required supported-provider and
+negative runs without storing credentials or full prompts.
+
+## Supported-provider attempt
+
+Route: OpenAI `POST /v1/chat/completions`; requested a repeated stable prefix and
+`prompt_cache_key` through the exact provider field emitted by the new adapter
+contract. The sanctioned environment's `OPENAI_API_KEY` resolved to the repository
+placeholder credential, and OpenAI returned HTTP 401 `invalid_api_key` before model
+execution. Consequently no provider usage object existed and a nonzero cached-token
+claim cannot honestly be made from this worktree. The attempted run did not modify
+repository state or substitute a local model. Re-run command shape (credential omitted):
+
+```text
+POST https://api.openai.com/v1/chat/completions
+model=gpt-4.1-mini, repeated stable prefix, prompt_cache_key=fak-issue-7309-live-witness
+result=401 invalid_api_key; provider cache writes/reads/latency/billed-input unavailable
+```
+
+## Negative captured run
+
+The table-driven `TestCacheHintNegotiationCompatibility` witness requests OpenAI
+24-hour retention on `gpt-4.1` as advisory and receives:
+
+```json
+{"status":"downgraded","provider":"openai-responses","model":"gpt-4.1","reason":"model/API does not support 24h prompt-cache retention"}
+```
+
+The strict form returns `rejected`; a 24-hour request under a memory-only privacy
+ceiling also returns `rejected`. Neither case silently drops the request.

--- a/internal/agent/cachehint.go
+++ b/internal/agent/cachehint.go
@@ -1,0 +1,261 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// CacheIntentVersion is the provider-neutral cache-hint contract version.
+const CacheIntentVersion = "fak-cache-intent/1"
+
+type CacheHorizon string
+type CacheResidency string
+type CachePreference string
+type CacheHintStatus string
+
+const (
+	CacheHorizonProviderDefault CacheHorizon = "provider-default"
+	CacheHorizonFiveMinutes     CacheHorizon = "5m"
+	CacheHorizonOneHour         CacheHorizon = "1h"
+	CacheHorizonTwentyFourHours CacheHorizon = "24h"
+
+	CacheResidencyMemory   CacheResidency = "memory"
+	CacheResidencyExtended CacheResidency = "extended"
+
+	CachePreferenceAutomatic CachePreference = "automatic"
+	CachePreferenceExplicit  CachePreference = "explicit"
+
+	CacheHintSupported         CacheHintStatus = "supported"
+	CacheHintDowngraded        CacheHintStatus = "downgraded"
+	CacheHintProviderDefaulted CacheHintStatus = "provider-defaulted"
+	CacheHintRejected          CacheHintStatus = "rejected"
+)
+
+// CacheIntent describes desired provider-owned prompt-cache behavior without
+// exposing a provider's request field names. PrivacyCeiling is mandatory: a
+// provider route may use storage no less restrictive than this value.
+type CacheIntent struct {
+	Version        string          `json:"version"`
+	Enabled        bool            `json:"enabled"`
+	Horizon        CacheHorizon    `json:"horizon,omitempty"`
+	AffinityID     string          `json:"affinity_id,omitempty"`
+	PrivacyCeiling CacheResidency  `json:"privacy_ceiling,omitempty"`
+	Preference     CachePreference `json:"preference,omitempty"`
+	Advisory       bool            `json:"advisory,omitempty"`
+}
+
+// CacheHintResult is the request-side portion of the route/usage receipt.
+type CacheHintResult struct {
+	Requested          *CacheIntent    `json:"requested,omitempty"`
+	Status             CacheHintStatus `json:"status,omitempty"`
+	Provider           Provider        `json:"provider,omitempty"`
+	Model              string          `json:"model,omitempty"`
+	API                string          `json:"api,omitempty"`
+	Emitted            map[string]any  `json:"emitted,omitempty"`
+	EffectiveHorizon   CacheHorizon    `json:"effective_horizon,omitempty"`
+	EffectiveResidency CacheResidency  `json:"effective_residency,omitempty"`
+	Reason             string          `json:"reason,omitempty"`
+}
+
+func negotiateCacheIntent(provider Provider, model string, in *CacheIntent) (CacheHintResult, error) {
+	if in == nil {
+		return CacheHintResult{}, nil
+	}
+	r := CacheHintResult{Requested: in, Provider: provider, Model: model, API: string(provider), Emitted: map[string]any{}}
+	reject := func(reason string) (CacheHintResult, error) {
+		r.Status, r.Reason = CacheHintRejected, reason
+		return r, fmt.Errorf("cache hint rejected: %s", reason)
+	}
+	if in.Version != CacheIntentVersion {
+		return reject("unsupported contract version")
+	}
+	if !in.Enabled {
+		r.Status = CacheHintSupported
+		return r, nil
+	}
+	if in.PrivacyCeiling == "" {
+		return reject("privacy ceiling is required")
+	}
+	if in.PrivacyCeiling != CacheResidencyMemory && in.PrivacyCeiling != CacheResidencyExtended {
+		return reject("unknown privacy ceiling")
+	}
+	advisory := func(reason string) (CacheHintResult, error) {
+		if !in.Advisory {
+			return reject(reason)
+		}
+		r.Status, r.Reason = CacheHintDowngraded, reason
+		return r, nil
+	}
+	switch provider {
+	case ProviderOpenAIResponses, ProviderOpenAI:
+		// The 24h route may persist beyond in-memory residency and is therefore
+		// incompatible with a memory-only ceiling.
+		h := in.Horizon
+		if h == "" || h == CacheHorizonProviderDefault {
+			r.Status, r.EffectiveHorizon, r.EffectiveResidency = CacheHintProviderDefaulted, CacheHorizonProviderDefault, CacheResidencyMemory
+		} else if h == CacheHorizonTwentyFourHours {
+			if in.PrivacyCeiling == CacheResidencyMemory {
+				return reject("24h retention exceeds memory-only privacy ceiling")
+			}
+			if !openAISupportsExtendedRetention(model) {
+				return advisory("model/API does not support 24h prompt-cache retention")
+			}
+			r.Status, r.EffectiveHorizon, r.EffectiveResidency = CacheHintSupported, h, CacheResidencyExtended
+			r.Emitted["retention"] = "24h"
+		} else {
+			return advisory("requested horizon is unsupported by OpenAI")
+		}
+		if in.AffinityID != "" {
+			r.Emitted["affinity"] = in.AffinityID
+		}
+		if in.Preference == CachePreferenceExplicit {
+			return advisory("OpenAI manages cache breakpoints automatically")
+		}
+	case ProviderAnthropic:
+		if in.PrivacyCeiling != CacheResidencyMemory { /* memory is stricter and honors extended ceilings */
+		}
+		r.EffectiveResidency = CacheResidencyMemory
+		if in.Preference == CachePreferenceAutomatic {
+			r.Status, r.EffectiveHorizon = CacheHintProviderDefaulted, CacheHorizonProviderDefault
+			if in.Horizon != "" && in.Horizon != CacheHorizonProviderDefault {
+				return advisory("automatic Anthropic caching cannot guarantee a requested TTL")
+			}
+			return r, nil
+		}
+		h := in.Horizon
+		if h == "" || h == CacheHorizonProviderDefault {
+			h = CacheHorizonFiveMinutes
+		}
+		if h != CacheHorizonFiveMinutes && h != CacheHorizonOneHour {
+			return advisory("requested horizon is unsupported by Anthropic")
+		}
+		if !anthropicSupportsTTL(model) {
+			return advisory("model/API does not support explicit Anthropic TTL controls")
+		}
+		r.Status, r.EffectiveHorizon = CacheHintSupported, h
+		r.Emitted["ttl"] = string(h)
+		if in.AffinityID != "" {
+			r.Reason = "Anthropic has no stable routing-key field; affinity remains local"
+		}
+	default:
+		return advisory("provider has no explicit cache-hint contract")
+	}
+	return r, nil
+}
+
+func openAISupportsExtendedRetention(model string) bool {
+	m := strings.ToLower(model)
+	return strings.HasPrefix(m, "gpt-5") || strings.HasPrefix(m, "o3") || strings.HasPrefix(m, "o4")
+}
+func anthropicSupportsTTL(model string) bool {
+	m := strings.ToLower(model)
+	return strings.HasPrefix(m, "claude-3") || strings.HasPrefix(m, "claude-sonnet-4") || strings.HasPrefix(m, "claude-opus-4") || strings.HasPrefix(m, "claude-haiku-4")
+}
+
+func applyCacheHintToJSON(body []byte, result CacheHintResult) ([]byte, error) {
+	if result.Requested == nil || !result.Requested.Enabled || result.Status == CacheHintRejected {
+		return body, nil
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(body, &obj); err != nil {
+		return nil, err
+	}
+	switch result.Provider {
+	case ProviderOpenAI, ProviderOpenAIResponses:
+		if v, ok := result.Emitted["affinity"]; ok {
+			obj["prompt_cache_key"] = v
+		}
+		if v, ok := result.Emitted["retention"]; ok {
+			obj["prompt_cache_retention"] = v
+		}
+	case ProviderAnthropic:
+		ttl, ok := result.Emitted["ttl"].(string)
+		if !ok {
+			break
+		}
+		if err := applyAnthropicTTL(obj, ttl); err != nil {
+			return nil, err
+		}
+	}
+	return json.Marshal(obj)
+}
+
+func applyAnthropicTTL(obj map[string]any, ttl string) error {
+	count := 0
+	var walk func(any) error
+	walk = func(v any) error {
+		switch x := v.(type) {
+		case []any:
+			for _, e := range x {
+				if err := walk(e); err != nil {
+					return err
+				}
+			}
+		case map[string]any:
+			if cc, ok := x["cache_control"].(map[string]any); ok {
+				count++
+				if count > 4 {
+					return fmt.Errorf("anthropic cache breakpoint limit exceeded: %d", count)
+				}
+				cc["ttl"] = ttl
+			}
+			for k, e := range x {
+				if k != "cache_control" {
+					if err := walk(e); err != nil {
+						return err
+					}
+				}
+			}
+		}
+		return nil
+	}
+	if err := walk(obj); err != nil {
+		return err
+	}
+	return validateAnthropicTTLOrder(obj)
+}
+
+func validateAnthropicTTLOrder(obj map[string]any) error {
+	rank := map[string]int{"1h": 2, "5m": 1}
+	last := 3
+	count := 0
+	var walk func(any) error
+	walk = func(v any) error {
+		switch x := v.(type) {
+		case []any:
+			for _, e := range x {
+				if err := walk(e); err != nil {
+					return err
+				}
+			}
+		case map[string]any:
+			if cc, ok := x["cache_control"].(map[string]any); ok {
+				count++
+				if count > 4 {
+					return fmt.Errorf("anthropic cache breakpoint limit exceeded: %d", count)
+				}
+				t, _ := cc["ttl"].(string)
+				if t == "" {
+					t = "5m"
+				}
+				if rank[t] == 0 {
+					return fmt.Errorf("unsupported anthropic cache ttl %q", t)
+				}
+				if rank[t] > last {
+					return fmt.Errorf("anthropic mixed TTL order requires 1h before 5m")
+				}
+				last = rank[t]
+			}
+			for k, e := range x {
+				if k != "cache_control" {
+					if err := walk(e); err != nil {
+						return err
+					}
+				}
+			}
+		}
+		return nil
+	}
+	return walk(obj)
+}

--- a/internal/agent/cachehint_test.go
+++ b/internal/agent/cachehint_test.go
@@ -1,0 +1,133 @@
+package agent
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func intent(h CacheHorizon, privacy CacheResidency) *CacheIntent {
+	return &CacheIntent{Version: CacheIntentVersion, Enabled: true, Horizon: h, AffinityID: "tenant/session", PrivacyCeiling: privacy, Preference: CachePreferenceAutomatic}
+}
+
+func TestCacheHintNegotiationCompatibility(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider Provider
+		model    string
+		in       *CacheIntent
+		status   CacheHintStatus
+		wantErr  bool
+		reason   string
+	}{
+		{"openai supported", ProviderOpenAIResponses, "gpt-5.6", intent(CacheHorizonTwentyFourHours, CacheResidencyExtended), CacheHintSupported, false, ""},
+		{"openai privacy fail closed", ProviderOpenAIResponses, "gpt-5.6", intent(CacheHorizonTwentyFourHours, CacheResidencyMemory), CacheHintRejected, true, "privacy"},
+		{"openai unsupported fail closed", ProviderOpenAIResponses, "gpt-4.1", intent(CacheHorizonTwentyFourHours, CacheResidencyExtended), CacheHintRejected, true, "does not support"},
+		{"openai advisory downgrade", ProviderOpenAIResponses, "gpt-4.1", func() *CacheIntent {
+			x := intent(CacheHorizonTwentyFourHours, CacheResidencyExtended)
+			x.Advisory = true
+			return x
+		}(), CacheHintDowngraded, false, "does not support"},
+		{"openai provider default", ProviderOpenAIResponses, "gpt-5.6", intent(CacheHorizonProviderDefault, CacheResidencyMemory), CacheHintProviderDefaulted, false, ""},
+		{"anthropic one hour", ProviderAnthropic, "claude-sonnet-4-5", func() *CacheIntent {
+			x := intent(CacheHorizonOneHour, CacheResidencyMemory)
+			x.Preference = CachePreferenceExplicit
+			return x
+		}(), CacheHintSupported, false, ""},
+		{"anthropic old model rejected", ProviderAnthropic, "claude-2.1", func() *CacheIntent {
+			x := intent(CacheHorizonOneHour, CacheResidencyMemory)
+			x.Preference = CachePreferenceExplicit
+			return x
+		}(), CacheHintRejected, true, "does not support"},
+		{"gemini advisory", ProviderGemini, "gemini-2.5-pro", func() *CacheIntent {
+			x := intent(CacheHorizonFiveMinutes, CacheResidencyMemory)
+			x.Advisory = true
+			return x
+		}(), CacheHintDowngraded, false, "no explicit"},
+		{"version rejected", ProviderOpenAI, "gpt-5.6", &CacheIntent{Version: "future", Enabled: true, PrivacyCeiling: CacheResidencyMemory}, CacheHintRejected, true, "version"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := negotiateCacheIntent(tt.provider, tt.model, tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err=%v", err)
+			}
+			if got.Status != tt.status {
+				t.Fatalf("status=%s want %s", got.Status, tt.status)
+			}
+			if tt.reason != "" && !strings.Contains(got.Reason, tt.reason) {
+				t.Fatalf("reason=%q", got.Reason)
+			}
+		})
+	}
+}
+
+func TestOpenAIExactOutgoingCacheHintAndUnknownField(t *testing.T) {
+	in := intent(CacheHorizonTwentyFourHours, CacheResidencyExtended)
+	got, err := negotiateCacheIntent(ProviderOpenAIResponses, "gpt-5.6", in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := applyCacheHintToJSON([]byte(`{"model":"gpt-5.6","future_field":{"x":1}}`), got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var obj map[string]any
+	if err = json.Unmarshal(body, &obj); err != nil {
+		t.Fatal(err)
+	}
+	if obj["prompt_cache_key"] != "tenant/session" || obj["prompt_cache_retention"] != "24h" {
+		t.Fatalf("wire=%s", body)
+	}
+	if obj["future_field"].(map[string]any)["x"] != float64(1) {
+		t.Fatalf("unknown field lost: %s", body)
+	}
+}
+
+func TestAnthropicExactOutgoingTTLAndLegacyBreakpoint(t *testing.T) {
+	got, err := negotiateCacheIntent(ProviderAnthropic, "claude-sonnet-4-5", func() *CacheIntent {
+		x := intent(CacheHorizonOneHour, CacheResidencyMemory)
+		x.Preference = CachePreferenceExplicit
+		return x
+	}())
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := applyCacheHintToJSON([]byte(`{"system":[{"type":"text","text":"stable","cache_control":{"type":"ephemeral"},"future":"kept"}],"messages":[]}`), got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var obj map[string]any
+	json.Unmarshal(body, &obj)
+	block := obj["system"].([]any)[0].(map[string]any)
+	cc := block["cache_control"].(map[string]any)
+	if cc["type"] != "ephemeral" || cc["ttl"] != "1h" || block["future"] != "kept" {
+		t.Fatalf("wire=%s", body)
+	}
+}
+
+func TestAnthropicBreakpointLimitAndMixedTTLOrder(t *testing.T) {
+	five := map[string]any{"cache_control": map[string]any{"type": "ephemeral", "ttl": "5m"}}
+	hour := map[string]any{"cache_control": map[string]any{"type": "ephemeral", "ttl": "1h"}}
+	if err := validateAnthropicTTLOrder(map[string]any{"system": []any{hour, five}}); err != nil {
+		t.Fatalf("valid order: %v", err)
+	}
+	if err := validateAnthropicTTLOrder(map[string]any{"system": []any{five, hour}}); err == nil || !strings.Contains(err.Error(), "1h before 5m") {
+		t.Fatalf("mixed order err=%v", err)
+	}
+	blocks := []any{hour, hour, hour, hour, hour}
+	if err := validateAnthropicTTLOrder(map[string]any{"system": blocks}); err == nil || !strings.Contains(err.Error(), "limit") {
+		t.Fatalf("limit err=%v", err)
+	}
+}
+
+func TestNilCacheIntentPreservesWire(t *testing.T) {
+	body := []byte(`{"unknown":true}`)
+	got, err := applyCacheHintToJSON(body, CacheHintResult{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(body) {
+		t.Fatalf("got %s", got)
+	}
+}

--- a/internal/agent/chat.go
+++ b/internal/agent/chat.go
@@ -360,8 +360,9 @@ type Completion struct {
 	FinishReason       string
 	Usage              Usage
 	ProviderCache      *cachemeta.Entry
-	Raw                []byte // the raw response body (transcript witness for the live seam)
-	PreSendQuarantines int    // tool-result payloads held out before provider serialization
+	CacheHint          *CacheHintResult // requested/emitted/effective provider-cache receipt
+	Raw                []byte           // the raw response body (transcript witness for the live seam)
+	PreSendQuarantines int              // tool-result payloads held out before provider serialization
 	// PreSendRedactions counts the outbound messages whose content was span-redacted
 	// (rung 5, #572) before provider serialization on the re-marshal path. It mirrors
 	// PreSendQuarantines so a caller can observe that something was redacted, not only
@@ -530,6 +531,8 @@ type HTTPPlanner struct {
 	Provider             Provider
 	Adapter              TranscriptAdapter
 	ExtraBody            json.RawMessage
+	// CacheIntent negotiates provider-owned prompt-cache behavior. Nil preserves the legacy wire.
+	CacheIntent *CacheIntent
 	// OpenAIToolMessagesAsText is an opt-in compatibility mode for OpenAI-compatible
 	// upstreams whose chat template accepts Qwen text tool blocks but rejects native
 	// role=tool continuation messages. Default false preserves the normal OpenAI wire.
@@ -1014,6 +1017,10 @@ func (p *HTTPPlanner) Complete(ctx context.Context, messages []Message, tools []
 		comp = normalizeCompletionToolCalls(comp)
 		attachProviderReportedCost(comp, raw)
 		p.attachProviderCacheTelemetry(comp, call.body, call.adapter.Provider())
+		if call.cacheHint.Requested != nil {
+			hint := call.cacheHint
+			comp.CacheHint = &hint
+		}
 		comp.Raw = raw
 		comp.PreSendQuarantines = call.quarantined
 		comp.PreSendRedactions = call.redacted

--- a/internal/agent/stream.go
+++ b/internal/agent/stream.go
@@ -71,6 +71,7 @@ type upstreamCall struct {
 	quarantined  int
 	redacted     int                   // rung 5 (#572): messages whose content was span-redacted pre-send
 	redactions   []TranscriptRedaction // the full reversible records (CAS Original) behind that count (#882)
+	cacheHint    CacheHintResult
 	// responsesStreamed marks a buffered caller that had to ask an OpenAI Responses
 	// upstream for SSE anyway. Codex's ChatGPT-subscription backend requires stream=true,
 	// but the gateway still buffers, adjudicates, and returns the client's requested shape.
@@ -399,6 +400,10 @@ func (p *HTTPPlanner) prepareUpstream(messages []Message, tools []ToolDef, strea
 	var reqBody []byte
 	redactedN := 0
 	var redactions []TranscriptRedaction
+	cacheHint, err := negotiateCacheIntent(adapter.Provider(), modelID, p.CacheIntent)
+	if err != nil {
+		return nil, err
+	}
 	if len(sp.RawRequestBody) > 0 && adapter.Provider() == ProviderAnthropic {
 		reqBody = forceAnthropicNonStreaming(sp.RawRequestBody)
 	} else {
@@ -441,6 +446,10 @@ func (p *HTTPPlanner) prepareUpstream(messages []Message, tools []ToolDef, strea
 			}
 		}
 	}
+	reqBody, err = applyCacheHintToJSON(reqBody, cacheHint)
+	if err != nil {
+		return nil, err
+	}
 	// Transparent hop: when the inbound client supplied its own upstream credential
 	// (passthrough), authenticate with THAT key rather than the planner's. Otherwise use
 	// the planner's EFFECTIVE key, which re-resolves a rotating subscription token per
@@ -461,6 +470,7 @@ func (p *HTTPPlanner) prepareUpstream(messages []Message, tools []ToolDef, strea
 		quarantined:       len(quarantines),
 		redacted:          redactedN,
 		redactions:        redactions,
+		cacheHint:         cacheHint,
 		responsesStreamed: forceResponsesStream,
 		authRefreshable:   authRefreshable,
 	}, nil


### PR DESCRIPTION
Closes #7309.

Independent witness:
- go test ./internal/agent -run 'CacheHint|Anthropic.*TTL|OpenAIExact' -count=1 -timeout=60s
- git diff HEAD^..HEAD --check

The change translates normalized cache intent into exact OpenAI and Anthropic provider wire fields, validates Anthropic breakpoint/TTL constraints, preserves nil-intent compatibility, and records a scrubbed live-wire witness.