### PR TITLE
feat(orchestration): implement witnessed fast width #8961

### DIFF
--- a/cmd/fak/orchestration.go
+++ b/cmd/fak/orchestration.go
@@ -25,12 +25,12 @@ func runOrchestration(stdout, stderr io.Writer, args []string) int {
 		return runOrchestrationStatus(stdout, stderr, args[1:])
 	}
 	if len(args) == 0 || args[0] != "plan" {
-		fmt.Fprintln(stderr, "usage: fak orchestration plan --profile off|auto|ultracode (--task FIXTURE | --task-text TEXT) [--json] [--strict] [--launch] [--max-wall DURATION] [--selfcheck]")
+		fmt.Fprintln(stderr, "usage: fak orchestration plan --profile off|auto|fast|ultracode (--task FIXTURE | --task-text TEXT) [--json] [--strict] [--launch] [--max-wall DURATION] [--selfcheck]")
 		return 2
 	}
 	fs := flag.NewFlagSet("orchestration plan", flag.ContinueOnError)
 	fs.SetOutput(stderr)
-	profile := fs.String("profile", "auto", "orchestration profile: off, auto, or ultracode")
+	profile := fs.String("profile", "auto", "orchestration profile: off, auto, fast, or ultracode")
 	outputProfile := fs.String("output-profile", agentDefaultOutputStyle, "fleet response profile")
 	workProfile := fs.String("work-profile", agentDefaultWorkProfile, "fleet work profile")
 	taskPath := fs.String("task", "", "versioned task fixture JSON")
@@ -42,10 +42,12 @@ func runOrchestration(stdout, stderr io.Writer, args []string) int {
 	codexHome := fs.String("codex-home", "", "Codex home used for a session-linked invocation receipt")
 	capset := fs.String("capabilities", "native", "harness fixture: native or unsupported")
 	maxWorkers := orchestrationOptionalInt{}
+	exactWorkers := orchestrationOptionalInt{}
 	maxTokens := orchestrationOptionalInt64{}
 	maxWall := fs.Duration("max-wall", defaultUltracodeWallBudget, "one parent wall deadline shared by launch staggering and all workers")
 	attended := orchestrationOptionalBool{}
 	fs.Var(&maxWorkers, "max-workers", "operator worker cap")
+	fs.Var(&exactWorkers, "exact-workers", "operator exact-width pin (stronger than adaptive selection)")
 	fs.Var(&maxTokens, "max-tokens", "operator token cap")
 	fs.Var(&attended, "attended", "operator interaction policy (true or false)")
 	if err := fs.Parse(args[1:]); err != nil {
@@ -99,6 +101,9 @@ func runOrchestration(stdout, stderr io.Writer, args []string) int {
 	req := orchestration.OrchestrationProfile{Name: orchestration.Profile(*profile), Strict: *strict}
 	if maxWorkers.set {
 		req.MaxWorkers = &maxWorkers.value
+	}
+	if exactWorkers.set {
+		req.ExactWorkers = &exactWorkers.value
 	}
 	if maxTokens.set {
 		req.MaxTokens = &maxTokens.value
@@ -174,6 +179,9 @@ func runOrchestration(stdout, stderr io.Writer, args []string) int {
 			return 1
 		}
 		launchReceipt = &launched
+		if resolved.Resolved.Width != nil {
+			resolved.Resolved.Width.Realized = len(launched.Workers)
+		}
 		if !*jsonOut {
 			fmt.Fprintf(stdout, "launch=%s run_id=%s workers=%d decline=%s\n", launched.Status, launched.RunID, len(launched.Workers), launched.DeclineReason)
 		}

--- a/cmd/fak/orchestration_adaptive_width_test.go
+++ b/cmd/fak/orchestration_adaptive_width_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/anthony-chaudhary/fak/internal/orchestration"
+)
+
+func TestAdaptiveWidthDryRunReportsSelectionWithoutLaunch(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("..", "..", "internal", "orchestration", "testdata", "fast-width-scout.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var evidence orchestration.WidthEvidence
+	if err := json.Unmarshal(raw, &evidence); err != nil {
+		t.Fatal(err)
+	}
+	task := orchestration.TaskSpec{Schema: "fak-orchestration-task/1", ID: "fast-dry-run", WorkClass: orchestration.WorkGrind, Width: &orchestration.WidthRequest{ObjectiveMillis: 2000, AsOf: "2026-08-25T13:00:00Z", Key: evidence.Key, Evidence: &evidence}}
+	taskRaw, _ := json.Marshal(task)
+	path := filepath.Join(t.TempDir(), "task.json")
+	if err := os.WriteFile(path, taskRaw, 0600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := runOrchestration(&stdout, &stderr, []string{"plan", "--profile", "fast", "--task", path, "--json", "--selfcheck"}); code != 0 {
+		t.Fatalf("exit=%d stderr=%s", code, stderr.String())
+	}
+	var got orchestration.Resolution
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Resolved.Width == nil || got.Resolved.Width.Selected != 4 || got.Resolved.Width.EvidenceDigest != evidence.Digest || got.Resolved.Width.Realized != 0 {
+		t.Fatalf("width=%+v", got.Resolved.Width)
+	}
+	if got.Resolved.Budget.MaxWorkers != 4 || len(got.Resolved.Roles) != 4 {
+		t.Fatalf("plan=%+v", got.Resolved)
+	}
+}
+
+func TestAdaptiveWidthCLIExactPin(t *testing.T) {
+	task := orchestration.TaskSpec{Schema: "fak-orchestration-task/1", ID: "fast-pin", WorkClass: orchestration.WorkGrind}
+	raw, _ := json.Marshal(task)
+	path := filepath.Join(t.TempDir(), "task.json")
+	_ = os.WriteFile(path, raw, 0600)
+	var stdout, stderr bytes.Buffer
+	if code := runOrchestration(&stdout, &stderr, []string{"plan", "--profile", "fast", "--task", path, "--max-workers", "4", "--exact-workers", "3", "--json"}); code != 0 {
+		t.Fatalf("exit=%d stderr=%s", code, stderr.String())
+	}
+	var got orchestration.Resolution
+	_ = json.Unmarshal(stdout.Bytes(), &got)
+	if got.Resolved.Budget.MaxWorkers != 3 || got.Resolved.Width.Reason != "explicit operator exact-width pin" {
+		t.Fatalf("width=%+v", got.Resolved.Width)
+	}
+}

--- a/internal/orchestration/fast_width.go
+++ b/internal/orchestration/fast_width.go
@@ -1,0 +1,224 @@
+package orchestration
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+)
+
+const WidthEvidenceSchema = "fak-orchestration-width-evidence/1"
+
+type WidthVerdict string
+
+const (
+	WidthGain    WidthVerdict = "GAIN"
+	WidthNoGain  WidthVerdict = "NO_GAIN"
+	WidthAbstain WidthVerdict = "ABSTAIN"
+)
+
+type WidthEvidenceKey struct {
+	TaskClass           WorkClass `json:"task_class"`
+	AccessMix           string    `json:"access_mix"`
+	ModelProvider       string    `json:"model_provider"`
+	CachePosture        string    `json:"cache_posture"`
+	HarnessCapabilities []string  `json:"harness_capabilities"`
+	BenchmarkRevision   string    `json:"benchmark_revision"`
+}
+
+type WidthEvidenceCell struct {
+	Width                int          `json:"width"`
+	Verdict              WidthVerdict `json:"verdict"`
+	AcceptedOutcomeEqual bool         `json:"accepted_outcome_equal"`
+	TelemetryComplete    bool         `json:"telemetry_complete"`
+	CriticalPathMillis   int64        `json:"critical_path_millis"`
+	TotalWorkerMillis    int64        `json:"total_worker_millis"`
+	TotalTokens          int64        `json:"total_tokens"`
+	CacheCostTokens      int64        `json:"cache_cost_tokens"`
+	LeaseWaitMillis      int64        `json:"lease_wait_millis"`
+	ReconcileMillis      int64        `json:"reconcile_millis"`
+}
+
+type WidthEvidence struct {
+	Schema        string              `json:"schema"`
+	Digest        string              `json:"digest"`
+	GeneratedAt   string              `json:"generated_at"`
+	MaxAgeSeconds int64               `json:"max_age_seconds"`
+	Key           WidthEvidenceKey    `json:"key"`
+	Cells         []WidthEvidenceCell `json:"cells"`
+}
+
+type WidthRequest struct {
+	ObjectiveMillis int64            `json:"objective_millis"`
+	AsOf            string           `json:"as_of"`
+	Key             WidthEvidenceKey `json:"key"`
+	Evidence        *WidthEvidence   `json:"evidence,omitempty"`
+}
+
+type WidthHold string
+
+const (
+	WidthHoldMissing        WidthHold = "missing_evidence"
+	WidthHoldStale          WidthHold = "stale_evidence"
+	WidthHoldIncomparable   WidthHold = "incomparable_evidence"
+	WidthHoldUnequalOutcome WidthHold = "unequal_outcome"
+	WidthHoldIncomplete     WidthHold = "incomplete_telemetry"
+	WidthHoldNonGain        WidthHold = "non_gain"
+	WidthHoldNoQualifying   WidthHold = "no_qualifying_width"
+)
+
+type WidthConsideration struct {
+	Width     int          `json:"width"`
+	Verdict   WidthVerdict `json:"verdict,omitempty"`
+	Qualifies bool         `json:"qualifies"`
+	Reason    string       `json:"reason"`
+}
+
+type WidthSelection struct {
+	Adaptive           bool                 `json:"adaptive"`
+	Considered         []WidthConsideration `json:"considered,omitempty"`
+	Selected           int                  `json:"selected"`
+	Realized           int                  `json:"realized"`
+	EvidenceDigest     string               `json:"evidence_digest,omitempty"`
+	EvidenceAgeSeconds int64                `json:"evidence_age_seconds,omitempty"`
+	Reason             string               `json:"reason"`
+	Hold               WidthHold            `json:"hold,omitempty"`
+	Cap                int                  `json:"cap"`
+}
+
+func WidthEvidenceDigest(e WidthEvidence) (string, error) {
+	e.Digest = ""
+	raw, err := json.Marshal(e)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(raw)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+func validateWidthEvidence(e WidthEvidence) error {
+	if e.Schema != WidthEvidenceSchema {
+		return fmt.Errorf("width evidence schema must be %q", WidthEvidenceSchema)
+	}
+	if e.Digest == "" {
+		return errors.New("width evidence digest is required")
+	}
+	got, err := WidthEvidenceDigest(e)
+	if err != nil {
+		return err
+	}
+	if got != e.Digest {
+		return fmt.Errorf("width evidence digest mismatch: got %s want %s", e.Digest, got)
+	}
+	if e.Key.BenchmarkRevision == "" || e.Key.AccessMix == "" || e.Key.ModelProvider == "" || e.Key.CachePosture == "" {
+		return errors.New("width evidence comparison key is incomplete")
+	}
+	if e.MaxAgeSeconds <= 0 {
+		return errors.New("width evidence max_age_seconds must be positive")
+	}
+	if _, err := time.Parse(time.RFC3339, e.GeneratedAt); err != nil {
+		return fmt.Errorf("width evidence generated_at: %w", err)
+	}
+	seen := map[int]bool{}
+	for _, c := range e.Cells {
+		if c.Width < 1 || seen[c.Width] {
+			return errors.New("width evidence widths must be positive and unique")
+		}
+		seen[c.Width] = true
+	}
+	return nil
+}
+
+func equalWidthKey(a, b WidthEvidenceKey) bool {
+	aa, bb := append([]string(nil), a.HarnessCapabilities...), append([]string(nil), b.HarnessCapabilities...)
+	sort.Strings(aa)
+	sort.Strings(bb)
+	a.HarnessCapabilities, b.HarnessCapabilities = aa, bb
+	x, _ := json.Marshal(a)
+	y, _ := json.Marshal(b)
+	return string(x) == string(y)
+}
+
+func SelectFastWidth(req *WidthRequest, cap int, tokenCap int64) WidthSelection {
+	out := WidthSelection{Adaptive: true, Selected: 1, Cap: cap, Reason: "conservative width one", Hold: WidthHoldMissing}
+	if cap < 1 {
+		cap = 1
+		out.Cap = cap
+	}
+	if req == nil || req.Evidence == nil {
+		return out
+	}
+	e := *req.Evidence
+	out.EvidenceDigest = e.Digest
+	if err := validateWidthEvidence(e); err != nil {
+		out.Hold = WidthHoldIncomparable
+		out.Reason = err.Error()
+		return out
+	}
+	if !equalWidthKey(req.Key, e.Key) {
+		out.Hold = WidthHoldIncomparable
+		out.Reason = "evidence key does not match current task/access/capability envelope"
+		return out
+	}
+	asOf, err := time.Parse(time.RFC3339, req.AsOf)
+	if err != nil {
+		out.Hold = WidthHoldIncomparable
+		out.Reason = "invalid selection as_of"
+		return out
+	}
+	generated, _ := time.Parse(time.RFC3339, e.GeneratedAt)
+	age := asOf.Sub(generated)
+	if age < 0 {
+		out.Hold = WidthHoldIncomparable
+		out.Reason = "evidence is from the future"
+		return out
+	}
+	out.EvidenceAgeSeconds = int64(age / time.Second)
+	if out.EvidenceAgeSeconds > e.MaxAgeSeconds {
+		out.Hold = WidthHoldStale
+		out.Reason = "evidence exceeds max age"
+		return out
+	}
+	cells := append([]WidthEvidenceCell(nil), e.Cells...)
+	sort.Slice(cells, func(i, j int) bool { return cells[i].Width < cells[j].Width })
+	lastHold := WidthHoldNoQualifying
+	selected := 0
+	for _, c := range cells {
+		item := WidthConsideration{Width: c.Width, Verdict: c.Verdict}
+		switch {
+		case c.Width > cap:
+			item.Reason = "rejected by worker cap"
+		case c.TotalTokens > tokenCap:
+			item.Reason = "rejected by token cap"
+		case !c.TelemetryComplete:
+			item.Reason = "incomplete telemetry"
+			lastHold = WidthHoldIncomplete
+		case !c.AcceptedOutcomeEqual:
+			item.Reason = "accepted outcome is unequal"
+			lastHold = WidthHoldUnequalOutcome
+		case c.Verdict != WidthGain:
+			item.Reason = "net-value verdict is not GAIN"
+			lastHold = WidthHoldNonGain
+		case req.ObjectiveMillis <= 0 || c.CriticalPathMillis > req.ObjectiveMillis:
+			item.Reason = "latency objective not met"
+			lastHold = WidthHoldNoQualifying
+		case selected != 0:
+			item.Reason = "larger than smallest qualifying width"
+		default:
+			item.Qualifies = true
+			item.Reason = "equal accepted outcome, positive net value, and latency objective met"
+			selected = c.Width
+		}
+		out.Considered = append(out.Considered, item)
+	}
+	if selected != 0 {
+		out.Selected, out.Hold, out.Reason = selected, "", "smallest qualifying witnessed width"
+		return out
+	}
+	out.Hold = lastHold
+	out.Reason = "no qualifying witnessed width; selected conservative width one"
+	return out
+}

--- a/internal/orchestration/fast_width_test.go
+++ b/internal/orchestration/fast_width_test.go
@@ -1,0 +1,114 @@
+package orchestration
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func loadFastWidthFixture(t *testing.T, name string) WidthEvidence {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var e WidthEvidence
+	if err := json.Unmarshal(raw, &e); err != nil {
+		t.Fatal(err)
+	}
+	return e
+}
+
+func widthRequest(e WidthEvidence) *WidthRequest {
+	return &WidthRequest{ObjectiveMillis: 2000, AsOf: "2026-08-25T13:00:00Z", Key: e.Key, Evidence: &e}
+}
+
+func TestFastWidthFrozenFrontiers(t *testing.T) {
+	tests := []struct {
+		name string
+		want int
+		hold WidthHold
+	}{
+		{"fast-width-scout.json", 4, ""},
+		{"fast-width-writer.json", 1, WidthHoldNonGain},
+		{"fast-width-incomplete.json", 1, WidthHoldIncomplete},
+		{"fast-width-stale.json", 1, WidthHoldStale},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := loadFastWidthFixture(t, tt.name)
+			got := SelectFastWidth(widthRequest(e), 8, 65536)
+			if got.Selected != tt.want || got.Hold != tt.hold {
+				t.Fatalf("selection=%+v", got)
+			}
+			if got.EvidenceDigest != e.Digest {
+				t.Fatalf("digest=%q want %q", got.EvidenceDigest, e.Digest)
+			}
+		})
+	}
+}
+
+func TestFastWidthUnequalOutcomeHolds(t *testing.T) {
+	e := loadFastWidthFixture(t, "fast-width-scout.json")
+	for i := range e.Cells {
+		e.Cells[i].AcceptedOutcomeEqual = false
+	}
+	e.Digest, _ = WidthEvidenceDigest(e)
+	got := SelectFastWidth(widthRequest(e), 8, 65536)
+	if got.Selected != 1 || got.Hold != WidthHoldUnequalOutcome {
+		t.Fatalf("unequal=%+v", got)
+	}
+}
+
+func TestFastWidthRejectsTamperedDigest(t *testing.T) {
+	e := loadFastWidthFixture(t, "fast-width-scout.json")
+	e.Cells[0].CriticalPathMillis++
+	got := SelectFastWidth(widthRequest(e), 8, 65536)
+	if got.Selected != 1 || got.Hold != WidthHoldIncomparable {
+		t.Fatalf("tampered=%+v", got)
+	}
+}
+
+func TestFastWidthMissingAndIncomparableEvidenceHold(t *testing.T) {
+	if got := SelectFastWidth(nil, 8, 65536); got.Selected != 1 || got.Hold != WidthHoldMissing {
+		t.Fatalf("missing=%+v", got)
+	}
+	e := loadFastWidthFixture(t, "fast-width-scout.json")
+	req := widthRequest(e)
+	req.Key.ModelProvider = "other"
+	if got := SelectFastWidth(req, 8, 65536); got.Selected != 1 || got.Hold != WidthHoldIncomparable {
+		t.Fatalf("incomparable=%+v", got)
+	}
+}
+
+func TestFastWidthRespectsCapsAndChoosesSmallestQualifying(t *testing.T) {
+	e := loadFastWidthFixture(t, "fast-width-scout.json")
+	if got := SelectFastWidth(widthRequest(e), 2, 65536); got.Selected != 1 || got.Cap != 2 {
+		t.Fatalf("cap=%+v", got)
+	}
+	req := widthRequest(e)
+	req.ObjectiveMillis = 2700
+	if got := SelectFastWidth(req, 8, 65536); got.Selected != 2 {
+		t.Fatalf("smallest=%+v", got)
+	}
+}
+
+func TestAdaptiveWidthOperatorPinOverridesEvidenceWithinCap(t *testing.T) {
+	e := loadFastWidthFixture(t, "fast-width-writer.json")
+	exact, cap := 4, 8
+	got, err := Resolve(OrchestrationProfile{Name: ProfileFast, MaxWorkers: &cap, ExactWorkers: &exact}, TaskSpec{Schema: "fak-orchestration-task/1", ID: "pin", WorkClass: WorkGrind, Width: widthRequest(e)}, HarnessCapabilities{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Resolved.Budget.MaxWorkers != 4 || got.Resolved.Width == nil || got.Resolved.Width.Reason != "explicit operator exact-width pin" {
+		t.Fatalf("resolution=%+v", got.Resolved)
+	}
+}
+
+func TestAdaptiveWidthRejectsPinBeyondHardCap(t *testing.T) {
+	exact, cap := 8, 4
+	if _, err := Resolve(OrchestrationProfile{Name: ProfileFast, MaxWorkers: &cap, ExactWorkers: &exact}, TaskSpec{Schema: "fak-orchestration-task/1", ID: "pin"}, HarnessCapabilities{}); err == nil {
+		t.Fatal("expected hard-cap error")
+	}
+}

--- a/internal/orchestration/orchestration.go
+++ b/internal/orchestration/orchestration.go
@@ -20,6 +20,7 @@ type Profile string
 const (
 	ProfileOff       Profile = "off"
 	ProfileAuto      Profile = "auto"
+	ProfileFast      Profile = "fast"
 	ProfileUltracode Profile = "ultracode"
 )
 
@@ -44,6 +45,7 @@ type OrchestrationProfile struct {
 	Name           Profile `json:"name"`
 	Strict         bool    `json:"strict,omitempty"`
 	MaxWorkers     *int    `json:"max_workers,omitempty"`
+	ExactWorkers   *int    `json:"exact_workers,omitempty"`
 	MaxTokens      *int64  `json:"max_tokens,omitempty"`
 	Attended       *bool   `json:"attended,omitempty"`
 	RequireWitness *bool   `json:"require_independent_witness,omitempty"`
@@ -58,13 +60,15 @@ type HarnessCapabilities struct {
 }
 
 type TaskSpec struct {
-	Schema     string    `json:"schema"`
-	ID         string    `json:"id"`
-	WorkClass  WorkClass `json:"work_class,omitempty"`
-	Attended   *bool     `json:"attended,omitempty"`
-	MaxWorkers *int      `json:"max_workers,omitempty"`
-	MaxTokens  *int64    `json:"max_tokens,omitempty"`
-	EngineRef  string    `json:"engine_ref,omitempty"`
+	Schema       string        `json:"schema"`
+	ID           string        `json:"id"`
+	WorkClass    WorkClass     `json:"work_class,omitempty"`
+	Attended     *bool         `json:"attended,omitempty"`
+	MaxWorkers   *int          `json:"max_workers,omitempty"`
+	ExactWorkers *int          `json:"exact_workers,omitempty"`
+	Width        *WidthRequest `json:"width,omitempty"`
+	MaxTokens    *int64        `json:"max_tokens,omitempty"`
+	EngineRef    string        `json:"engine_ref,omitempty"`
 }
 
 type ChildAccessMode string
@@ -203,6 +207,7 @@ type WorkflowPlan struct {
 	SOLRoute     SOLRoute          `json:"sol_route"`
 	Degradations []Degradation     `json:"degradations"`
 	Explanation  []string          `json:"explanation"`
+	Width        *WidthSelection   `json:"width,omitempty"`
 }
 
 type Resolution struct {
@@ -315,7 +320,7 @@ func Resolve(req OrchestrationProfile, task TaskSpec, caps HarnessCapabilities) 
 	if req.Name == "" {
 		req.Name = ProfileAuto
 	}
-	if req.Name != ProfileOff && req.Name != ProfileAuto && req.Name != ProfileUltracode {
+	if req.Name != ProfileOff && req.Name != ProfileAuto && req.Name != ProfileFast && req.Name != ProfileUltracode {
 		return Resolution{}, fmt.Errorf("unknown profile %q", req.Name)
 	}
 	workers, tokens, attended, witness := 1, int64(4096), false, false
@@ -333,6 +338,10 @@ func Resolve(req OrchestrationProfile, task TaskSpec, caps HarnessCapabilities) 
 			resolvedProfile = ProfileOff
 		}
 		prov = append(prov, Provenance{"profile", "task.work_class", resolvedProfile})
+	} else if req.Name == ProfileFast {
+		workers, tokens = 8, 65536
+		resolvedProfile = ProfileFast
+		prov = append(prov, Provenance{"profile", "preset.fast", resolvedProfile})
 	} else if req.Name == ProfileUltracode {
 		workers, tokens, witness = 4, 65536, true
 		prov = append(prov, Provenance{"profile", "preset.ultracode", resolvedProfile})
@@ -368,8 +377,35 @@ func Resolve(req OrchestrationProfile, task TaskSpec, caps HarnessCapabilities) 
 		witness = *req.RequireWitness
 		prov = append(prov, Provenance{"witness.independent", "operator", witness})
 	}
-	if workers < 1 || tokens < 1 {
+	if workers < 1 || tokens < 1 || (task.MaxWorkers != nil && *task.MaxWorkers < 1) || (req.MaxWorkers != nil && *req.MaxWorkers < 1) {
 		return Resolution{}, errors.New("budgets must be positive")
+	}
+	var width *WidthSelection
+	if resolvedProfile == ProfileFast {
+		workers = 8
+		if task.MaxWorkers != nil && *task.MaxWorkers < workers {
+			workers = *task.MaxWorkers
+		}
+		if req.MaxWorkers != nil && *req.MaxWorkers < workers {
+			workers = *req.MaxWorkers
+		}
+		selected := SelectFastWidth(task.Width, workers, tokens)
+		if task.ExactWorkers != nil {
+			if *task.ExactWorkers < 1 || *task.ExactWorkers > workers {
+				return Resolution{}, errors.New("task exact_workers must be positive and within max_workers")
+			}
+			selected.Selected, selected.Hold, selected.Reason = *task.ExactWorkers, "", "explicit task exact-width pin"
+			prov = append(prov, Provenance{"budget.max_workers", "task.exact_workers", selected.Selected})
+		}
+		if req.ExactWorkers != nil {
+			if *req.ExactWorkers < 1 || *req.ExactWorkers > workers {
+				return Resolution{}, errors.New("operator exact_workers must be positive and within max_workers")
+			}
+			selected.Selected, selected.Hold, selected.Reason = *req.ExactWorkers, "", "explicit operator exact-width pin"
+			prov = append(prov, Provenance{"budget.max_workers", "operator.exact_workers", selected.Selected})
+		}
+		workers = selected.Selected
+		width = &selected
 	}
 	multi := resolvedProfile != ProfileOff && workers > 1
 	required := map[string]bool{"concurrency": multi, "task_messaging": multi, "cancellation": multi, "leases": multi, "independent_witness": witness}
@@ -408,7 +444,7 @@ func Resolve(req OrchestrationProfile, task TaskSpec, caps HarnessCapabilities) 
 	for _, d := range deg {
 		explain = append(explain, "degraded: "+d.Reason)
 	}
-	plan := WorkflowPlan{SchemaVersion, resolvedProfile, task.ID, task.WorkClass, roles, dag, Budget{workers, tokens}, LeasePolicy{"taskmgr", multi}, WitnessPolicy{witness, witness}, ReconcilePolicy{multi, "effect-readback"}, InteractionPolicy{attended, multi, multi}, engine, solRoute, deg, explain}
+	plan := WorkflowPlan{Schema: SchemaVersion, Profile: resolvedProfile, TaskID: task.ID, WorkClass: task.WorkClass, Roles: roles, DAG: dag, Budget: Budget{workers, tokens}, Leases: LeasePolicy{"taskmgr", multi}, Witness: WitnessPolicy{witness, witness}, Reconcile: ReconcilePolicy{multi, "effect-readback"}, Interaction: InteractionPolicy{attended, multi, multi}, EngineRef: engine, SOLRoute: solRoute, Degradations: deg, Explanation: explain, Width: width}
 	return Resolution{SchemaVersion, req, plan, prov, deg}, nil
 }
 

--- a/internal/orchestration/testdata/fast-width-incomplete.json
+++ b/internal/orchestration/testdata/fast-width-incomplete.json
@@ -1,0 +1,70 @@
+{
+  "schema": "fak-orchestration-width-evidence/1",
+  "digest": "sha256:c9d482b320e93fba0f211be92f0d17d7e9b9b843b5e8e2e8db51cd890ff53267",
+  "generated_at": "2026-08-25T12:00:00Z",
+  "max_age_seconds": 86400,
+  "key": {
+    "task_class": "grind",
+    "access_mix": "mixed",
+    "model_provider": "openai/gpt-5.6-sol",
+    "cache_posture": "warm-prefix",
+    "harness_capabilities": [
+      "cancellation",
+      "concurrency",
+      "independent_witness",
+      "leases",
+      "task_messaging"
+    ],
+    "benchmark_revision": "frontier-r1"
+  },
+  "cells": [
+    {
+      "width": 1,
+      "verdict": "GAIN",
+      "accepted_outcome_equal": true,
+      "telemetry_complete": true,
+      "critical_path_millis": 4000,
+      "total_worker_millis": 4000,
+      "total_tokens": 1000,
+      "cache_cost_tokens": 100,
+      "lease_wait_millis": 10,
+      "reconcile_millis": 10
+    },
+    {
+      "width": 2,
+      "verdict": "GAIN",
+      "accepted_outcome_equal": true,
+      "telemetry_complete": false,
+      "critical_path_millis": 2600,
+      "total_worker_millis": 5200,
+      "total_tokens": 1000,
+      "cache_cost_tokens": 100,
+      "lease_wait_millis": 10,
+      "reconcile_millis": 10
+    },
+    {
+      "width": 4,
+      "verdict": "GAIN",
+      "accepted_outcome_equal": true,
+      "telemetry_complete": false,
+      "critical_path_millis": 1800,
+      "total_worker_millis": 7200,
+      "total_tokens": 1000,
+      "cache_cost_tokens": 100,
+      "lease_wait_millis": 10,
+      "reconcile_millis": 10
+    },
+    {
+      "width": 8,
+      "verdict": "GAIN",
+      "accepted_outcome_equal": true,
+      "telemetry_complete": false,
+      "critical_path_millis": 1400,
+      "total_worker_millis": 11200,
+      "total_tokens": 1000,
+      "cache_cost_tokens": 100,
+      "lease_wait_millis": 10,
+      "reconcile_millis": 10
+    }
+  ]
+}

--- a/internal/orchestration/testdata/fast-width-scout.json
+++ b/internal/orchestration/testdata/fast-width-scout.json
@@ -1,0 +1,70 @@
+{
+  "schema": "fak-orchestration-width-evidence/1",
+  "digest": "sha256:9e0934e439ea387a4daa37e5a2d7c2d234363068f908993506df2bbae7653b80",
+  "generated_at": "2026-08-25T12:00:00Z",
+  "max_age_seconds": 86400,
+  "key": {
+    "task_class": "grind",
+    "access_mix": "read-only-scouts",
+    "model_provider": "openai/gpt-5.6-sol",
+    "cache_posture": "warm-prefix",
+    "harness_capabilities": [
+      "cancellation",
+      "concurrency",
+      "independent_witness",
+      "leases",
+      "task_messaging"
+    ],
+    "benchmark_revision": "frontier-r1"
+  },
+  "cells": [
+    {
+      "width": 1,
+      "verdict": "GAIN",
+      "accepted_outcome_equal": true,
+      "telemetry_complete": true,
+      "critical_path_millis": 4000,
+      "total_worker_millis": 4000,
+      "total_tokens": 1000,
+      "cache_cost_tokens": 100,
+      "lease_wait_millis": 10,
+      "reconcile_millis": 10
+    },
+    {
+      "width": 2,
+      "verdict": "GAIN",
+      "accepted_outcome_equal": true,
+      "telemetry_complete": true,
+      "critical_path_millis": 2600,
+      "total_worker_millis": 5200,
+      "total_tokens": 1000,
+      "cache_cost_tokens": 100,
+      "lease_wait_millis": 10,
+      "reconcile_millis": 10
+    },
+    {
+      "width": 4,
+      "verdict": "GAIN",
+      "accepted_outcome_equal": true,
+      "telemetry_complete": true,
+      "critical_path_millis": 1800,
+      "total_worker_millis": 7200,
+      "total_tokens": 1000,
+      "cache_cost_tokens": 100,
+      "lease_wait_millis": 10,
+      "reconcile_millis": 10
+    },
+    {
+      "width": 8,
+      "verdict": "NO_GAIN",
+      "accepted_outcome_equal": true,
+      "telemetry_complete": true,
+      "critical_path_millis": 1700,
+      "total_worker_millis": 13600,
+      "total_tokens": 1000,
+      "cache_cost_tokens": 100,
+      "lease_wait_millis": 10,
+      "reconcile_millis": 10
+    }
+  ]
+}

--- a/internal/orchestration/testdata/fast-width-stale.json
+++ b/internal/orchestration/testdata/fast-width-stale.json
@@ -1,0 +1,70 @@
+{
+  "schema": "fak-orchestration-width-evidence/1",
+  "digest": "sha256:987a164554cfb7affb87d0aebd448366e5ab9af134aca2dc18356859c55ccde5",
+  "generated_at": "2026-08-20T12:00:00Z",
+  "max_age_seconds": 3600,
+  "key": {
+    "task_class": "grind",
+    "access_mix": "read-only-scouts",
+    "model_provider": "openai/gpt-5.6-sol",
+    "cache_posture": "warm-prefix",
+    "harness_capabilities": [
+      "cancellation",
+      "concurrency",
+      "independent_witness",
+      "leases",
+      "task_messaging"
+    ],
+    "benchmark_revision": "frontier-r1"
+  },
+  "cells": [
+    {
+      "width": 1,
+      "verdict": "GAIN",
+      "accepted_outcome_equal": true,
+      "telemetry_complete": true,
+      "critical_path_millis": 4000,
+      "total_worker_millis": 4000,
+      "total_tokens": 1000,
+      "cache_cost_tokens": 100,
+      "lease_wait_millis": 10,
+      "reconcile_millis": 10
+    },
+    {
+      "width": 2,
+      "verdict": "GAIN",
+      "accepted_outcome_equal": true,
+      "telemetry_complete": true,
+      "critical_path_millis": 2600,
+      "total_worker_millis": 5200,
+      "total_tokens": 1000,
+      "cache_cost_tokens": 100,
+      "lease_wait_millis": 10,
+      "reconcile_millis": 10
+    },
+    {
+      "width": 4,
+      "verdict": "GAIN",
+      "accepted_outcome_equal": true,
+      "telemetry_complete": true,
+      "critical_path_millis": 1800,
+      "total_worker_millis": 7200,
+      "total_tokens": 1000,
+      "cache_cost_tokens": 100,
+      "lease_wait_millis": 10,
+      "reconcile_millis": 10
+    },
+    {
+      "width": 8,
+      "verdict": "GAIN",
+      "accepted_outcome_equal": true,
+      "telemetry_complete": true,
+      "critical_path_millis": 1400,
+      "total_worker_millis": 11200,
+      "total_tokens": 1000,
+      "cache_cost_tokens": 100,
+      "lease_wait_millis": 10,
+      "reconcile_millis": 10
+    }
+  ]
+}

--- a/internal/orchestration/testdata/fast-width-writer.json
+++ b/internal/orchestration/testdata/fast-width-writer.json
@@ -1,0 +1,70 @@
+{
+  "schema": "fak-orchestration-width-evidence/1",
+  "digest": "sha256:02280cf5a10470508f795821c08b41d51ccff234efc58864a5257a8c477f1674",
+  "generated_at": "2026-08-25T12:00:00Z",
+  "max_age_seconds": 86400,
+  "key": {
+    "task_class": "grind",
+    "access_mix": "contending-writers",
+    "model_provider": "openai/gpt-5.6-sol",
+    "cache_posture": "warm-prefix",
+    "harness_capabilities": [
+      "cancellation",
+      "concurrency",
+      "independent_witness",
+      "leases",
+      "task_messaging"
+    ],
+    "benchmark_revision": "frontier-r1"
+  },
+  "cells": [
+    {
+      "width": 1,
+      "verdict": "GAIN",
+      "accepted_outcome_equal": true,
+      "telemetry_complete": true,
+      "critical_path_millis": 4000,
+      "total_worker_millis": 4000,
+      "total_tokens": 1000,
+      "cache_cost_tokens": 100,
+      "lease_wait_millis": 10,
+      "reconcile_millis": 10
+    },
+    {
+      "width": 2,
+      "verdict": "NO_GAIN",
+      "accepted_outcome_equal": true,
+      "telemetry_complete": true,
+      "critical_path_millis": 3900,
+      "total_worker_millis": 7800,
+      "total_tokens": 1000,
+      "cache_cost_tokens": 100,
+      "lease_wait_millis": 10,
+      "reconcile_millis": 10
+    },
+    {
+      "width": 4,
+      "verdict": "NO_GAIN",
+      "accepted_outcome_equal": true,
+      "telemetry_complete": true,
+      "critical_path_millis": 4100,
+      "total_worker_millis": 16400,
+      "total_tokens": 1000,
+      "cache_cost_tokens": 100,
+      "lease_wait_millis": 10,
+      "reconcile_millis": 10
+    },
+    {
+      "width": 8,
+      "verdict": "NO_GAIN",
+      "accepted_outcome_equal": true,
+      "telemetry_complete": true,
+      "critical_path_millis": 5000,
+      "total_worker_millis": 40000,
+      "total_tokens": 1000,
+      "cache_cost_tokens": 100,
+      "lease_wait_millis": 10,
+      "reconcile_millis": 10
+    }
+  ]
+}


### PR DESCRIPTION
Closes #8961.

Independent witness:
- go test ./internal/orchestration -run 'Fast|Width' -count=1 -timeout=60s
- go test ./cmd/fak -run 'AdaptiveWidth|FastWidth' -count=1 -timeout=60s
- git diff 87b087df16..7fd969305d --check

The resolver uses captured coordination-break-even fixtures, rejects stale/incomplete evidence, distinguishes scout and writer envelopes, caps width, and exposes the decision in dry-run output.