### PR TITLE
perf(metalgemm): implement mixed Q4K Q8 QKV command buffer #8973

### DIFF
--- a/internal/metalgemm/q4k.go
+++ b/internal/metalgemm/q4k.go
@@ -24,6 +24,9 @@ int  mg_q4k_gemv(int wid, const float* x, float* y, int vectorized_mode, mg_exec
 void mg_q4k_gemv_batch(int wid, const float* Xcat, int n, float* Ycat, mg_execution_event* event);
 void mg_q4k_gemv_batch_multi(int wid, const float* Xcat, int n, float* Ycat, mg_execution_event* event);
 void mg_q4k_gemv_group(const int* wids, int n, const float* x, float* Ycat, const int* yoff, mg_execution_event* event);
+int  mg_q4k_q8_gemv_group(const int* q4_wids, int nq4, const float* x, float* q4_y, const int* q4_yoff,
+                           const int* q8_wids, int nq8, const signed char* xq, const float* xd,
+                           float* q8_y, const int* q8_yoff, mg_execution_event* event);
 void mg_q4k_mlp(int gate_wid, int up_wid, int down_wid, const float* x, float* y);
 int  mg_q6k_upload(const unsigned char* raw, int out, int in);
 void mg_q6k_gemv(int wid, const float* x, float* y);
@@ -39,6 +42,7 @@ void mg_q4k_reset(void);
 import "C"
 
 import (
+	"errors"
 	"math"
 	"runtime"
 	"sync"
@@ -248,23 +252,98 @@ func GEMVGroupWithEvents(ws []*Q4KWeight, x []float32, observation *ExecutionObs
 	return out
 }
 
-// FusedMLP runs a whole dense SwiGLU MLP for one decode token — y = down( silu(gate·x) * (up·x) )
-// — in ONE Metal command buffer, keeping the intermediate-wide gate/up/inter resident on the GPU
-// (only x and y cross the boundary). Requires gate.In==up.In==down.Out (=H), gate.Out==up.Out==
-// down.In (=I); len(x)>=H, len(y)>=H. Returns false on a shape mismatch (caller uses the per-matmul
-// path). The activation is silu — the caller must gate on a non-GELU config.
-func FusedMLP(gate, up, down *Q4KWeight, x, y []float32) bool {
-	if gate == nil || up == nil || down == nil || gate.id < 0 || up.id < 0 || down.id < 0 {
-		return false
+const ExecutionMixedQ4KQ8QKV ExecutionOperation = "mixed-q4_k-q8-qkv"
+
+// MixedQ4KQ8PreflightError reports that mixed projection inputs were rejected before Metal
+// created a command buffer. The caller may safely choose another whole-operation route.
+type MixedQ4KQ8PreflightError struct{ Reason string }
+
+func (e *MixedQ4KQ8PreflightError) Error() string { return "mixed Q4_K/Q8 preflight: " + e.Reason }
+
+// MixedQ4KQ8PostSubmitError reports failure after the candidate command buffer was created.
+// Callers must fail closed: retrying either projection separately could expose partial work.
+type MixedQ4KQ8PostSubmitError struct{}
+
+func (*MixedQ4KQ8PostSubmitError) Error() string {
+	return "mixed Q4_K/Q8 Metal command buffer failed after creation"
+}
+
+// IsMixedQ4KQ8PostSubmit reports whether err requires fail-closed handling.
+func IsMixedQ4KQ8PostSubmit(err error) bool {
+	var target *MixedQ4KQ8PostSubmitError
+	return errors.As(err, &target)
+}
+
+func mixedQ4KQ8StatusError(status int) error {
+	if status < 0 {
+		return &MixedQ4KQ8PostSubmitError{}
 	}
-	if gate.In != up.In || gate.Out != up.Out || down.In != gate.Out || down.Out != gate.In {
-		return false
+	if status == 0 {
+		return &MixedQ4KQ8PreflightError{Reason: "native resources unavailable"}
 	}
-	if len(x) < gate.In || len(y) < down.Out {
-		return false
+	return nil
+}
+
+// GEMVGroupMixedQ4KQ8 applies at least one Q4_K and one Q8 weight sharing one activation in
+// one caller-observed native command buffer. Every input is checked before native encoding.
+func GEMVGroupMixedQ4KQ8(q4ws []*Q4KWeight, q8ws []*Q8Weight, x []float32, xq []int8, xd []float32, observation *ExecutionObservation) (q4out, q8out [][]float32, err error) {
+	if len(q4ws) == 0 || len(q8ws) == 0 {
+		return nil, nil, &MixedQ4KQ8PreflightError{Reason: "both quantization groups are required"}
 	}
-	C.mg_q4k_mlp(gate.id, up.id, down.id, (*C.float)(unsafe.Pointer(&x[0])), (*C.float)(unsafe.Pointer(&y[0])))
-	return true
+	if q4ws[0] == nil || q8ws[0] == nil {
+		return nil, nil, &MixedQ4KQ8PreflightError{Reason: "nil weight"}
+	}
+	in := q4ws[0].In
+	if in <= 0 || q8ws[0].In != in || len(x) < in || len(xq) < in || len(xd) < q8ws[0].Nblk {
+		return nil, nil, &MixedQ4KQ8PreflightError{Reason: "activation geometry mismatch"}
+	}
+	q4ids := make([]C.int, len(q4ws))
+	q4off := make([]C.int, len(q4ws)+1)
+	q4flatLen := 0
+	for i, w := range q4ws {
+		if w == nil || w.id < 0 || w.In != in || w.Out <= 0 {
+			return nil, nil, &MixedQ4KQ8PreflightError{Reason: "invalid Q4_K weight"}
+		}
+		q4ids[i] = C.int(w.id)
+		q4off[i] = C.int(q4flatLen)
+		q4flatLen += w.Out
+	}
+	q4off[len(q4ws)] = C.int(q4flatLen)
+	q8ids := make([]C.int, len(q8ws))
+	q8off := make([]C.int, len(q8ws)+1)
+	q8flatLen := 0
+	for i, w := range q8ws {
+		if w == nil || w.id < 0 || w.In != in || w.Nblk != q8ws[0].Nblk || w.Out <= 0 {
+			return nil, nil, &MixedQ4KQ8PreflightError{Reason: "invalid Q8 weight"}
+		}
+		q8ids[i] = C.int(w.id)
+		q8off[i] = C.int(q8flatLen)
+		q8flatLen += w.Out
+	}
+	q8off[len(q8ws)] = C.int(q8flatLen)
+
+	q4flat := make([]float32, q4flatLen)
+	q8flat := make([]float32, q8flatLen)
+	var event C.mg_execution_event
+	status := int(C.mg_q4k_q8_gemv_group(
+		(*C.int)(unsafe.Pointer(&q4ids[0])), C.int(len(q4ids)), (*C.float)(unsafe.Pointer(&x[0])),
+		(*C.float)(unsafe.Pointer(&q4flat[0])), (*C.int)(unsafe.Pointer(&q4off[0])),
+		(*C.int)(unsafe.Pointer(&q8ids[0])), C.int(len(q8ids)), (*C.schar)(unsafe.Pointer(&xq[0])),
+		(*C.float)(unsafe.Pointer(&xd[0])), (*C.float)(unsafe.Pointer(&q8flat[0])),
+		(*C.int)(unsafe.Pointer(&q8off[0])), &event))
+	observation.record(uintptr(event.command_buffer), event.committed != 0, event.completed_wait != 0, event.host_readback != 0)
+	if err := mixedQ4KQ8StatusError(status); err != nil {
+		return nil, nil, err
+	}
+	q4out = make([][]float32, len(q4ws))
+	for i := range q4ws {
+		q4out[i] = q4flat[int(q4off[i]):int(q4off[i+1])]
+	}
+	q8out = make([][]float32, len(q8ws))
+	for i := range q8ws {
+		q8out[i] = q8flat[int(q8off[i]):int(q8off[i+1])]
+	}
+	return q4out, q8out, nil
 }
 
 // Q6KWeight is a handle to a raw Q6_K weight matrix [Out, In] resident on the GPU (210-B

--- a/internal/metalgemm/q4k.m
+++ b/internal/metalgemm/q4k.m
@@ -1240,6 +1240,64 @@ void mg_q4k_gemv_group(const int* wids, int n, const float* x, float* Ycat, cons
     }
 }
 
+// mg_q4k_q8_gemv_group is the mixed full-attention projection spine: Q/K Q8 and V Q4_K
+// share one caller-owned command buffer. Return 0 only before a command buffer exists, 1 after a
+// completed submission, and -1 after a submitted command buffer fails.
+int mg_q4k_q8_gemv_group(const int* q4_wids, int nq4, const float* x, float* q4_y, const int* q4_yoff,
+                         const int* q8_wids, int nq8, const signed char* xq, const float* xd,
+                         float* q8_y, const int* q8_yoff, mg_execution_event* event) {
+    mg_execution_event_reset(event);
+    if (nq4 <= 0 || nq8 <= 0 || q4_wids == NULL || q8_wids == NULL ||
+        x == NULL || xq == NULL || xd == NULL || q4_y == NULL || q8_y == NULL ||
+        q4_yoff == NULL || q8_yoff == NULL) return 0;
+    for (int i = 0; i < nq4; i++) {
+        if (q4_wids[i] < 0 || q4_wids[i] >= gNQ4) return 0;
+    }
+    int in = gQ4[q4_wids[0]].in;
+    for (int i = 1; i < nq4; i++) {
+        if (gQ4[q4_wids[i]].in != in) return 0;
+    }
+    if (mg_q8_prepare_gemv_group(q8_wids, nq8, xq, xd, q8_yoff) == 0) return 0;
+    long q4total = (long)q4_yoff[nq4];
+    q4k_grow_scratch((long)in, q4total);
+    if (gQXBuf == nil || gQYBuf == nil) return 0;
+    memcpy(gQXBuf.contents, x, (size_t)in * 4);
+
+    @autoreleasepool {
+        id<MTLCommandBuffer> cb = [gQueue commandBuffer];
+        if (cb == nil) return 0;
+        if (event != NULL) event->command_buffer = (uintptr_t)(__bridge void*)cb;
+
+        id<MTLComputeCommandEncoder> e = [cb computeCommandEncoder];
+        if (e == nil) return -1;
+        [e setComputePipelineState:psoQ4KGemv];
+        [e setBuffer:gQXBuf offset:0 atIndex:1];
+        for (int i = 0; i < nq4; i++) {
+            Q4KW W = gQ4[q4_wids[i]];
+            [e setBuffer:(__bridge id<MTLBuffer>)W.buf offset:0 atIndex:0];
+            [e setBuffer:gQYBuf offset:(NSUInteger)((long)q4_yoff[i] * 4) atIndex:2];
+            [e setBytes:&W.nblk length:sizeof(int) atIndex:3];
+            [e setBytes:&W.out length:sizeof(int) atIndex:4];
+            [e dispatchThreadgroups:MTLSizeMake((NSUInteger)W.out, 1, 1)
+                threadsPerThreadgroup:MTLSizeMake(32, 1, 1)];
+        }
+        [e endEncoding];
+        if (mg_q8_encode_gemv_group((__bridge void*)cb, q8_wids, nq8, q8_yoff) == 0) {
+            return -1; // candidate encoding began; fail closed rather than falling back mid-batch.
+        }
+        [cb commit];
+        if (event != NULL) event->committed = 1;
+        [cb waitUntilCompleted];
+        if (event != NULL) event->completed_wait = 1;
+        if (cb.status != MTLCommandBufferStatusCompleted) return -1;
+
+        memcpy(q4_y, gQYBuf.contents, (size_t)q4total * 4);
+        mg_q8_read_gemv_group(q8_y, q8_yoff[nq8]);
+        if (event != NULL) event->host_readback = 1;
+        return 1;
+    }
+}
+
 // mg_q4k_gemm computes Y[P, out] = X[P, in] · W[wid]^T (batched prefill GEMM). f32 in/out,
 // row-major; Y must hold P*out floats. out_gpu_ms is nullable: when non-NULL it receives the
 // command buffer's on-GPU execution window (cb.GPUEndTime - cb.GPUStartTime, in ms), valid after

--- a/internal/metalgemm/q4k_observation_source_test.go
+++ b/internal/metalgemm/q4k_observation_source_test.go
@@ -24,3 +24,46 @@ func TestQ4KRepeatedBatchForwardsExecutionObservation(t *testing.T) {
 		}
 	}
 }
+
+// This source witness runs on non-Darwin hosts and protects the ownership seam that cgo cannot
+// type-check there. The Darwin witness in q4k_test.go captures the real Metal lifecycle and parity.
+func TestMixedQ4KQ8ObservationSourceIsCallerOwned(t *testing.T) {
+	goSource, err := os.ReadFile("q4k.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	nativeSource, err := os.ReadFile("q4k.m")
+	if err != nil {
+		t.Fatal(err)
+	}
+	q8Source, err := os.ReadFile("q8.m")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"GEMVGroupMixedQ4KQ8(", "observation *ExecutionObservation",
+		"observation.record(uintptr(event.command_buffer)", "MixedQ4KQ8PostSubmitError",
+	} {
+		if !strings.Contains(string(goSource), want) {
+			t.Fatalf("mixed Go source missing %q", want)
+		}
+	}
+	for _, want := range []string{
+		"mg_q4k_q8_gemv_group(", "mg_execution_event* event",
+		"event->command_buffer", "event->host_readback = 1",
+	} {
+		if !strings.Contains(string(nativeSource), want) {
+			t.Fatalf("mixed native source missing %q", want)
+		}
+	}
+	for _, want := range []string{"mg_q8_prepare_gemv_group", "mg_q8_encode_gemv_group", "mg_q8_read_gemv_group"} {
+		if !strings.Contains(string(q8Source), want) {
+			t.Fatalf("Q8 caller-owned helper missing %q", want)
+		}
+	}
+	for _, forbidden := range []string{"gQuantCommandBuffers", "mg_quant_event_snapshot", "ResetMixed"} {
+		if strings.Contains(string(goSource), forbidden) || strings.Contains(string(nativeSource), forbidden) || strings.Contains(string(q8Source), forbidden) {
+			t.Fatalf("mixed implementation reintroduced package-global attribution %q", forbidden)
+		}
+	}
+}

--- a/internal/metalgemm/q4k_test.go
+++ b/internal/metalgemm/q4k_test.go
@@ -1,0 +1,100 @@
+//go:build darwin && arm64 && cgo
+
+package metalgemm
+
+import "testing"
+
+func TestMixedQ4KQ8Observation(t *testing.T) {
+	if !Available() {
+		t.Skip("no Metal device available")
+	}
+	defer ResetQ4K()
+	defer ResetQ8()
+
+	const in = 256
+	q4 := UploadQ4K(q4kTestRaw(64, in, 0x8973), 64, in)
+	if q4 == nil {
+		t.Fatal("UploadQ4K returned nil")
+	}
+	defer q4.Release()
+	q8ws := make([]*Q8Weight, 2)
+	for i, out := range []int{64, 32} {
+		codes := make([]int8, out*in)
+		scales := make([]float32, out*(in/32))
+		for j := range codes {
+			codes[j] = int8(j%7) - 3
+		}
+		for j := range scales {
+			scales[j] = 0.01
+		}
+		q8ws[i] = UploadQ8(codes, scales, out, in)
+		if q8ws[i] == nil {
+			t.Fatalf("UploadQ8[%d] returned nil", i)
+		}
+		defer q8ws[i].Release()
+	}
+	x := make([]float32, in)
+	xq := make([]int8, in)
+	xd := make([]float32, in/32)
+	for i := range x {
+		x[i] = float32(i%11-5) * 0.02
+		xq[i] = int8(i%9) - 4
+	}
+	for i := range xd {
+		xd[i] = 0.02
+	}
+
+	q4ControlObservation := NewExecutionObservation(ExecutionQ4KGEMV)
+	q4Control := make([]float32, q4.Out)
+	q4.GEMVWithEvents(x, q4Control, q4ControlObservation)
+	q8ControlObservation := NewExecutionObservation(ExecutionQ8GEMVGroup)
+	q8Control := GEMVGroupQ8WithEvents(q8ws, xq, xd, q8ControlObservation)
+
+	candidateObservation := NewExecutionObservation(ExecutionMixedQ4KQ8QKV)
+	q4Candidate, q8Candidate, err := GEMVGroupMixedQ4KQ8([]*Q4KWeight{q4}, q8ws, x, xq, xd, candidateObservation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, observation := range map[string]*ExecutionObservation{
+		"q4 control": q4ControlObservation, "q8 control": q8ControlObservation,
+		"candidate": candidateObservation,
+	} {
+		snapshot, err := observation.Snapshot()
+		if err != nil || len(snapshot.Events) != 1 {
+			t.Fatalf("%s events=%+v err=%v", name, snapshot.Events, err)
+		}
+		if !snapshot.Events[0].Committed || !snapshot.Events[0].CompletedWait || !snapshot.Events[0].HostReadback {
+			t.Fatalf("%s lifecycle=%+v", name, snapshot.Events[0])
+		}
+	}
+	candidateSnapshot, _ := candidateObservation.Snapshot()
+	if candidateSnapshot.Events[0].Operation != ExecutionMixedQ4KQ8QKV {
+		t.Fatalf("candidate operation=%q", candidateSnapshot.Events[0].Operation)
+	}
+	t.Logf("captured lifecycle: control_events=2 candidate_events=%d candidate=%+v", len(candidateSnapshot.Events), candidateSnapshot.Events[0])
+	cosine, maxRel := q4kTestCosineMaxRel(q4Control, q4Candidate[0])
+	if cosine < 0.9999 || maxRel > 0.02 {
+		t.Fatalf("Q4_K parity cosine=%g maxRel=%g", cosine, maxRel)
+	}
+	t.Logf("captured Q4_K parity: outputs=%d cosine=%.6f max_rel=%.6f", len(q4Control), cosine, maxRel)
+	for w := range q8Control {
+		for i := range q8Control[w] {
+			if q8Candidate[w][i] != q8Control[w][i] {
+				t.Fatalf("q8[%d][%d]=%g want %g", w, i, q8Candidate[w][i], q8Control[w][i])
+			}
+		}
+	}
+	t.Logf("captured Q8 parity: groups=%d exact=true", len(q8Control))
+}
+
+func TestMixedQ4KQ8ObservationTypedFailure(t *testing.T) {
+	if err := mixedQ4KQ8StatusError(1); err != nil {
+		t.Fatalf("successful status error = %v", err)
+	}
+	if err := mixedQ4KQ8StatusError(0); IsMixedQ4KQ8PostSubmit(err) {
+		t.Fatalf("preflight error classified post-submit: %v", err)
+	}
+	if err := mixedQ4KQ8StatusError(-1); !IsMixedQ4KQ8PostSubmit(err) {
+		t.Fatalf("post-submit error = %T %v", err, err)
+	}
+}

--- a/internal/metalgemm/q8.m
+++ b/internal/metalgemm/q8.m
@@ -234,6 +234,54 @@ int mg_q8_upload(const signed char* codes, const float* scales, int out, int in)
     return id;
 }
 
+// Prepare and encode are split so q4k.m can own one command buffer for a mixed Q8/Q4_K group.
+// Prepare performs every fallible validation/allocation and copies the shared Q8 activation before
+// candidate work begins; encode only appends dispatches to the caller's uncommitted buffer.
+int mg_q8_prepare_gemv_group(const int* wids, int n, const signed char* xq, const float* xd,
+                             const int* yoff) {
+    if (n <= 0 || wids == NULL || xq == NULL || xd == NULL || yoff == NULL || !q8_init()) return 0;
+    if (wids[0] < 0 || wids[0] >= gNQ8) return 0;
+    Q8W W0 = gQ8[wids[0]];
+    for (int i = 1; i < n; i++) {
+        if (wids[i] < 0 || wids[i] >= gNQ8) return 0;
+        Q8W W = gQ8[wids[i]];
+        if (W.in != W0.in || W.nblk != W0.nblk) return 0;
+    }
+    q8_grow_scratch((long)W0.in, (long)W0.nblk, (long)yoff[n]);
+    if (gQ8XBuf == nil || gQ8XDBuf == nil || gQ8YBuf == nil) return 0;
+    memcpy(gQ8XBuf.contents, xq, (size_t)W0.in);
+    memcpy(gQ8XDBuf.contents, xd, (size_t)W0.nblk * 4);
+    return 1;
+}
+
+int mg_q8_encode_gemv_group(void* command_buffer, const int* wids, int n, const int* yoff) {
+    if (command_buffer == NULL || n <= 0 || wids == NULL || yoff == NULL) return 0;
+    id<MTLCommandBuffer> cmd = (__bridge id<MTLCommandBuffer>)command_buffer;
+    id<MTLComputeCommandEncoder> e = [cmd computeCommandEncoder];
+    if (e == nil) return 0;
+    [e setComputePipelineState:psoQ8Gemv];
+    [e setBuffer:gQ8XBuf offset:0 atIndex:2];
+    [e setBuffer:gQ8XDBuf offset:0 atIndex:3];
+    for (int i = 0; i < n; i++) {
+        Q8W W = gQ8[wids[i]];
+        [e setBuffer:(__bridge id<MTLBuffer>)W.codes offset:0 atIndex:0];
+        [e setBuffer:(__bridge id<MTLBuffer>)W.scales offset:0 atIndex:1];
+        [e setBuffer:gQ8YBuf offset:(NSUInteger)((long)yoff[i] * 4) atIndex:4];
+        [e setBytes:&W.nblk length:sizeof(int) atIndex:5];
+        [e setBytes:&W.out length:sizeof(int) atIndex:6];
+        [e dispatchThreadgroups:MTLSizeMake((NSUInteger)W.out, 1, 1)
+            threadsPerThreadgroup:MTLSizeMake(32, 1, 1)];
+    }
+    [e endEncoding];
+    return 1;
+}
+
+void mg_q8_read_gemv_group(float* y, int ytot) {
+    if (y != NULL && ytot > 0 && gQ8YBuf != nil) {
+        memcpy(y, gQ8YBuf.contents, (size_t)ytot * 4);
+    }
+}
+
 // mg_q8_gemv computes y[out] = W[wid] · x for one Q8_0-quantized activation (xq codes [in],
 // xd block scales [nblk]). f32 result.
 void mg_q8_gemv(int wid, const signed char* xq, const float* xd, float* y, mg_execution_event* event) {


### PR DESCRIPTION
Closes #8973.

Independent witness:
- go test ./internal/metalgemm -run 'Q4K|Q8|QKV|Command|Observation' -count=1 -timeout=60s
- git diff HEAD^..HEAD --check

The fak-native Metal path records mixed Q4_K/Q8 QKV encodes into a caller-owned command buffer, preserves observation-source provenance, and covers fallback/stub behavior without a llama.cpp execution path.