### PR TITLE
fix(model): implement measured streamed Q4K capacity bound #8971

### DIFF
--- a/cmd/fak/serve_load_helpers.go
+++ b/cmd/fak/serve_load_helpers.go
@@ -325,6 +325,20 @@ func resetOnBudgetHook(enabled bool, freshContextTokens int) gateway.ResetOnBudg
 // Qwen3.8-27B Q4_K_M campaign on an M3 Pro, not a GGUF steady-state estimate.
 const metalGGUFObservedPeakMultiplier = 3.5
 
+const (
+	// streamedQ4KMeasuredPeakBytes is the maximum sampled RSS from the current-head,
+	// exact-checkpoint native Metal control receipt at
+	// docs/_witnesses/issue-CHILD-qwen38-startup-bisect/bisect.json, committed as
+	// 4ffff11fc3cb4d363cb187fad364b7a575b967b5. The receipt records 17,895,520 KiB,
+	// engine=inkernel, backend=metal, no fallback, no llama.cpp, and no swap growth.
+	streamedQ4KMeasuredPeakBytes int64 = 17895520 * 1024
+
+	// Round the measured high-water mark up to the next whole GiB. This reserves
+	// 1,002,340,352 bytes above the control without pretending macOS's larger
+	// /usr/bin/time footprint field is allocated physical memory.
+	streamedQ4KMetalCapacityBytes int64 = 18 << 30
+)
+
 func metalGGUFPeakCapacity(metal bool, steady, total int64, known bool) (peak int64, refuse bool) {
 	if !metal || steady <= 0 || total <= 0 || !known {
 		return 0, false
@@ -337,11 +351,25 @@ func metalGGUFPeakCapacity(metal bool, steady, total int64, known bool) (peak in
 	return peak, peak > total
 }
 
-func refuseOversubscribedMetalGGUF(path string) error {
-	// The streamed dense-Q4_K experiment replaces the all-resident startup shape this
-	// observed multiplier guards. Its acceptance run measures the new bound directly.
-	if os.Getenv("FAK_STREAM_Q4K") == "1" || os.Getenv("FAK_METAL_STREAM_Q4K") == "1" {
+func streamedQ4KMetalCapacity(total int64, known bool) (required int64, refuse bool) {
+	if total <= 0 || !known {
+		return 0, false
+	}
+	return streamedQ4KMetalCapacityBytes, streamedQ4KMetalCapacityBytes > total
+}
+
+func refuseStreamedQ4KMetalCapacity(total int64, known bool) error {
+	required, refuse := streamedQ4KMetalCapacity(total, known)
+	if !refuse {
 		return nil
+	}
+	return fmt.Errorf("fak serve: METAL_STREAM_Q4K_PEAK_TOO_BIG: native streamed Q4_K startup requires %d bytes (%.2f GiB), host has %d bytes (%.2f GiB); use a larger-memory Mac", required, float64(required)/(1<<30), total, float64(total)/(1<<30))
+}
+
+func refuseOversubscribedMetalGGUF(path string) error {
+	if os.Getenv("FAK_STREAM_Q4K") == "1" || os.Getenv("FAK_METAL_STREAM_Q4K") == "1" {
+		total, _, known := compute.HostSystemMemoryInfo()
+		return refuseStreamedQ4KMetalCapacity(total, known)
 	}
 	ws, err := ggufload.OpenWeights(path)
 	if err != nil {

--- a/cmd/fak/serve_metal_capacity_test.go
+++ b/cmd/fak/serve_metal_capacity_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestMetalGGUFPeakCapacity(t *testing.T) {
 	const gib = int64(1 << 30)
@@ -55,9 +58,44 @@ func TestMetalGGUFPeakCapacity(t *testing.T) {
 	}
 }
 
-func TestStreamedDenseQ4KBypassesAllResidentMetalPeakGuard(t *testing.T) {
-	t.Setenv("FAK_METAL_STREAM_Q4K", "1")
-	if err := refuseOversubscribedMetalGGUF("missing-checkpoint.gguf"); err != nil {
-		t.Fatalf("streamed dense Q4_K was rejected by all-resident guard: %v", err)
+func TestStreamedQ4KMetalCapacityUsesMeasuredNativePeak(t *testing.T) {
+	if streamedQ4KMeasuredPeakBytes != 17895520*1024 {
+		t.Fatalf("measured peak = %d, want current-head receipt's 17,895,520 KiB", streamedQ4KMeasuredPeakBytes)
+	}
+	if streamedQ4KMetalCapacityBytes < streamedQ4KMeasuredPeakBytes {
+		t.Fatalf("capacity bound %d is below measured peak %d", streamedQ4KMetalCapacityBytes, streamedQ4KMeasuredPeakBytes)
+	}
+
+	tests := []struct {
+		name      string
+		total     int64
+		known     bool
+		required  int64
+		refuse    bool
+		wantError bool
+	}{
+		{name: "one byte below measured bound refuses", total: streamedQ4KMetalCapacityBytes - 1, known: true, required: streamedQ4KMetalCapacityBytes, refuse: true, wantError: true},
+		{name: "measured bound admits", total: streamedQ4KMetalCapacityBytes, known: true, required: streamedQ4KMetalCapacityBytes},
+		{name: "36 GiB receipt host admits", total: 36 << 30, known: true, required: streamedQ4KMetalCapacityBytes},
+		{name: "unknown host memory preserves existing behavior", known: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			required, refuse := streamedQ4KMetalCapacity(tt.total, tt.known)
+			if required != tt.required || refuse != tt.refuse {
+				t.Fatalf("capacity = (%d, %v), want (%d, %v)", required, refuse, tt.required, tt.refuse)
+			}
+			err := refuseStreamedQ4KMetalCapacity(tt.total, tt.known)
+			if (err != nil) != tt.wantError {
+				t.Fatalf("error = %v, wantError %v", err, tt.wantError)
+			}
+			if err != nil {
+				for _, want := range []string{"METAL_STREAM_Q4K_PEAK_TOO_BIG", "requires 19327352832 bytes", "host has 19327352831 bytes"} {
+					if !strings.Contains(err.Error(), want) {
+						t.Errorf("error %q does not contain %q", err, want)
+					}
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Closes #8971.

Independent witness:
- go test ./cmd/fak -run 'Metal.*Capacity|Capacity.*Q4K|Streamed' -count=1 -timeout=30s
- git diff HEAD^..HEAD --check

The native Metal admission path replaces the streamed-Q4K bypass with measured resident/streaming capacity accounting and explicit rejection tests; it does not add a llama.cpp fallback.