### PR TITLE
feat(orchestration): implement explainable fast execution plan #8960

### DIFF
--- a/cmd/fak/orchestration.go
+++ b/cmd/fak/orchestration.go
@@ -112,6 +112,9 @@ func runOrchestration(stdout, stderr io.Writer, args []string) int {
 		req.Attended = &attended.value
 	}
 	resolved, err := orchestration.Resolve(req, task, caps)
+	if err == nil {
+		bindFastClaudeSpeed(&resolved)
+	}
 	if err == nil && taskText != nil && *taskText != "" {
 		orchestration.RouteResolution(&resolved, *taskText, guardCodexDefaultModelID)
 	}
@@ -252,6 +255,24 @@ func readCodexOrchestrationInvocationReceipt(codexHome, sessionID string) (codex
 	return receipt, ok
 }
 
+// bindFastClaudeSpeed compiles the portable fast control through the shipped
+// Claude auto|fast|standard resolver rather than maintaining a second router.
+// Realized remains unknown until the launch sidecar is read back.
+func bindFastClaudeSpeed(resolution *orchestration.Resolution) {
+	if resolution == nil || resolution.Resolved.Fast == nil {
+		return
+	}
+	fast := resolution.Resolved.Fast
+	for _, outcome := range fast.Outcomes {
+		if outcome.Mechanism == "claude_speed" && outcome.Outcome == orchestration.SupportNative {
+			if speed := resolveClaudeSpeed("claude", "latency", fast.Resolved.Speed, false); speed != "" {
+				fast.Launched.Speed = speed
+			}
+			return
+		}
+	}
+}
+
 func orchestrationCapabilities(name string) (orchestration.HarnessCapabilities, error) {
 	switch strings.ToLower(name) {
 	case "native":
@@ -261,6 +282,7 @@ func orchestrationCapabilities(name string) (orchestration.HarnessCapabilities, 
 			Cancellation:       orchestration.SupportNative,
 			Leases:             orchestration.SupportNative,
 			IndependentWitness: orchestration.SupportNative,
+			ClaudeSpeed:        orchestration.SupportNative,
 		}, nil
 	case "unsupported":
 		return orchestration.HarnessCapabilities{}, nil

--- a/cmd/fak/orchestration_test.go
+++ b/cmd/fak/orchestration_test.go
@@ -64,3 +64,39 @@ func TestOrchestrationPlanStrictRejectsDegradation(t *testing.T) {
 		t.Fatalf("exit=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
 }
+
+func TestOrchestrationFastPlanFixtureSelfcheck(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	fixture := filepath.Join("..", "..", "internal", "orchestration", "testdata", "fast-claude.json")
+	code := runOrchestration(&stdout, &stderr, []string{"plan", "--profile", "fast", "--task", fixture, "--selfcheck", "--json"})
+	if code != 0 {
+		t.Fatalf("code=%d stderr=%s", code, stderr.String())
+	}
+	var got orchestration.Resolution
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Resolved.Fast == nil || got.Resolved.Fast.Launched.Speed != "fast" || got.Resolved.Fast.Realized.Speed != "unknown" {
+		t.Fatalf("unexpected fast receipt: %+v", got.Resolved.Fast)
+	}
+}
+
+func TestOrchestrationFastUnsupportedAndOverrideFixtures(t *testing.T) {
+	for _, tc := range []struct{ name, capset, wantSpeed string }{{"fast-unsupported.json", "unsupported", "standard"}, {"fast-override.json", "native", "standard"}} {
+		t.Run(tc.name, func(t *testing.T) {
+			var out, errout bytes.Buffer
+			fixture := filepath.Join("..", "..", "internal", "orchestration", "testdata", tc.name)
+			code := runOrchestration(&out, &errout, []string{"plan", "--profile", "fast", "--task", fixture, "--capabilities", tc.capset, "--json"})
+			if code != 0 {
+				t.Fatalf("code=%d stderr=%s", code, errout.String())
+			}
+			var got orchestration.Resolution
+			if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+				t.Fatal(err)
+			}
+			if got.Resolved.Fast.Launched.Speed != tc.wantSpeed || got.Resolved.Fast.Realized.Speed != "unknown" {
+				t.Fatalf("receipt=%+v", got.Resolved.Fast)
+			}
+		})
+	}
+}

--- a/internal/orchestration/determinism_test.go
+++ b/internal/orchestration/determinism_test.go
@@ -9,7 +9,7 @@ import (
 func TestResolveDeterminismConcurrent(t *testing.T) {
 	workers := 3
 	task := TaskSpec{Schema: "fak-orchestration-task/1", ID: "determinism", WorkClass: WorkRigor, MaxWorkers: &workers}
-	caps := HarnessCapabilities{SupportNative, SupportNative, SupportNative, SupportNative, SupportNative}
+	caps := HarnessCapabilities{SupportNative, SupportNative, SupportNative, SupportNative, SupportNative, SupportNative}
 	const runs = 64
 	results := make(chan []byte, runs)
 	var wg sync.WaitGroup

--- a/internal/orchestration/orchestration.go
+++ b/internal/orchestration/orchestration.go
@@ -31,6 +31,7 @@ const (
 	SupportEmulated    SupportLevel = "emulated"
 	SupportDegraded    SupportLevel = "degraded"
 	SupportUnsupported SupportLevel = "unsupported"
+	SupportNotSelected SupportLevel = "not_selected"
 )
 
 type WorkClass string
@@ -57,6 +58,29 @@ type HarnessCapabilities struct {
 	Cancellation       SupportLevel `json:"cancellation"`
 	Leases             SupportLevel `json:"leases"`
 	IndependentWitness SupportLevel `json:"independent_witness"`
+	ClaudeSpeed        SupportLevel `json:"claude_speed,omitempty"`
+}
+
+const FastIntentSchemaVersion = "fak-fast-intent/1"
+
+type FastIntent struct {
+	Schema             string `json:"schema"`
+	LatencyClass       string `json:"latency_class,omitempty"`
+	TargetCompletionMS int64  `json:"target_completion_ms,omitempty"`
+	QualityFloor       string `json:"quality_floor"`
+	CostCeiling        string `json:"cost_ceiling"`
+	CachePolicy        string `json:"cache_policy"`
+	FallbackPolicy     string `json:"fallback_policy"`
+}
+
+type FastPins struct {
+	Model      string `json:"model,omitempty"`
+	Speed      string `json:"speed,omitempty"`
+	Effort     string `json:"effort,omitempty"`
+	Output     string `json:"output,omitempty"`
+	Cache      string `json:"cache,omitempty"`
+	MaxWorkers *int   `json:"max_workers,omitempty"`
+	MaxTokens  *int64 `json:"max_tokens,omitempty"`
 }
 
 type TaskSpec struct {
@@ -69,6 +93,9 @@ type TaskSpec struct {
 	Width        *WidthRequest `json:"width,omitempty"`
 	MaxTokens    *int64        `json:"max_tokens,omitempty"`
 	EngineRef    string        `json:"engine_ref,omitempty"`
+	FastIntent   *FastIntent   `json:"fast_intent,omitempty"`
+	Pins         FastPins      `json:"pins,omitempty"`
+	ClaudeSpeed  bool          `json:"claude_speed,omitempty"`
 }
 
 type ChildAccessMode string
@@ -191,23 +218,50 @@ type Provenance struct {
 	Value  any    `json:"value"`
 }
 
+// MechanismOutcome makes every fast-profile choice closed and explainable.
+type MechanismOutcome struct {
+	Mechanism string       `json:"mechanism"`
+	Outcome   SupportLevel `json:"outcome"`
+	Reason    string       `json:"reason"`
+}
+
+type FastControls struct {
+	Model     string `json:"model"`
+	Speed     string `json:"speed"`
+	Effort    string `json:"effort"`
+	Output    string `json:"output"`
+	Cache     string `json:"cache"`
+	Workers   int    `json:"workers"`
+	MaxTokens int64  `json:"max_tokens"`
+}
+
+type FastExecutionPlan struct {
+	Schema    string             `json:"schema"`
+	Requested FastIntent         `json:"requested"`
+	Resolved  FastControls       `json:"resolved"`
+	Launched  FastControls       `json:"launched"`
+	Realized  FastControls       `json:"realized"`
+	Outcomes  []MechanismOutcome `json:"capability_outcomes"`
+}
+
 type WorkflowPlan struct {
-	Schema       string            `json:"schema"`
-	Profile      Profile           `json:"profile"`
-	TaskID       string            `json:"task_id"`
-	WorkClass    WorkClass         `json:"work_class"`
-	Roles        []Role            `json:"roles"`
-	DAG          []Edge            `json:"dag"`
-	Budget       Budget            `json:"budget"`
-	Leases       LeasePolicy       `json:"leases"`
-	Witness      WitnessPolicy     `json:"witness"`
-	Reconcile    ReconcilePolicy   `json:"reconcile"`
-	Interaction  InteractionPolicy `json:"interaction"`
-	EngineRef    string            `json:"engine_ref"`
-	SOLRoute     SOLRoute          `json:"sol_route"`
-	Degradations []Degradation     `json:"degradations"`
-	Explanation  []string          `json:"explanation"`
-	Width        *WidthSelection   `json:"width,omitempty"`
+	Schema       string             `json:"schema"`
+	Profile      Profile            `json:"profile"`
+	TaskID       string             `json:"task_id"`
+	WorkClass    WorkClass          `json:"work_class"`
+	Roles        []Role             `json:"roles"`
+	DAG          []Edge             `json:"dag"`
+	Budget       Budget             `json:"budget"`
+	Leases       LeasePolicy        `json:"leases"`
+	Witness      WitnessPolicy      `json:"witness"`
+	Reconcile    ReconcilePolicy    `json:"reconcile"`
+	Interaction  InteractionPolicy  `json:"interaction"`
+	EngineRef    string             `json:"engine_ref"`
+	SOLRoute     SOLRoute           `json:"sol_route"`
+	Degradations []Degradation      `json:"degradations"`
+	Explanation  []string           `json:"explanation"`
+	Fast         *FastExecutionPlan `json:"fast,omitempty"`
+	Width        *WidthSelection    `json:"width,omitempty"`
 }
 
 type Resolution struct {
@@ -349,6 +403,14 @@ func Resolve(req OrchestrationProfile, task TaskSpec, caps HarnessCapabilities) 
 		resolvedProfile = ProfileOff
 		prov = append(prov, Provenance{"profile", "preset.off", resolvedProfile})
 	}
+	if task.Pins.MaxWorkers != nil {
+		workers = *task.Pins.MaxWorkers
+		prov = append(prov, Provenance{"budget.max_workers", "task.pin", workers})
+	}
+	if task.Pins.MaxTokens != nil {
+		tokens = *task.Pins.MaxTokens
+		prov = append(prov, Provenance{"budget.max_tokens", "task.pin", tokens})
+	}
 	if task.MaxWorkers != nil {
 		workers = *task.MaxWorkers
 		prov = append(prov, Provenance{"budget.max_workers", "task", workers})
@@ -382,7 +444,6 @@ func Resolve(req OrchestrationProfile, task TaskSpec, caps HarnessCapabilities) 
 	}
 	var width *WidthSelection
 	if resolvedProfile == ProfileFast {
-		workers = 8
 		if task.MaxWorkers != nil && *task.MaxWorkers < workers {
 			workers = *task.MaxWorkers
 		}
@@ -390,6 +451,9 @@ func Resolve(req OrchestrationProfile, task TaskSpec, caps HarnessCapabilities) 
 			workers = *req.MaxWorkers
 		}
 		selected := SelectFastWidth(task.Width, workers, tokens)
+		if task.Pins.MaxWorkers != nil {
+			selected.Selected, selected.Hold, selected.Reason = *task.Pins.MaxWorkers, "", "explicit fast max-workers pin"
+		}
 		if task.ExactWorkers != nil {
 			if *task.ExactWorkers < 1 || *task.ExactWorkers > workers {
 				return Resolution{}, errors.New("task exact_workers must be positive and within max_workers")
@@ -445,7 +509,89 @@ func Resolve(req OrchestrationProfile, task TaskSpec, caps HarnessCapabilities) 
 		explain = append(explain, "degraded: "+d.Reason)
 	}
 	plan := WorkflowPlan{Schema: SchemaVersion, Profile: resolvedProfile, TaskID: task.ID, WorkClass: task.WorkClass, Roles: roles, DAG: dag, Budget: Budget{workers, tokens}, Leases: LeasePolicy{"taskmgr", multi}, Witness: WitnessPolicy{witness, witness}, Reconcile: ReconcilePolicy{multi, "effect-readback"}, Interaction: InteractionPolicy{attended, multi, multi}, EngineRef: engine, SOLRoute: solRoute, Degradations: deg, Explanation: explain, Width: width}
+	if resolvedProfile == ProfileFast && task.FastIntent != nil {
+		fast, fastProv, err := resolveFast(task, caps, workers, tokens)
+		if err != nil {
+			return Resolution{}, err
+		}
+		plan.Fast = &fast
+		prov = append(prov, fastProv...)
+	}
 	return Resolution{SchemaVersion, req, plan, prov, deg}, nil
+}
+
+func resolveFast(task TaskSpec, caps HarnessCapabilities, workers int, tokens int64) (FastExecutionPlan, []Provenance, error) {
+	if task.FastIntent == nil {
+		return FastExecutionPlan{}, nil, errors.New("fast profile requires task fast_intent")
+	}
+	intent := *task.FastIntent
+	if intent.Schema != FastIntentSchemaVersion {
+		return FastExecutionPlan{}, nil, fmt.Errorf("fast intent: unsupported schema %q", intent.Schema)
+	}
+	if (intent.LatencyClass == "") == (intent.TargetCompletionMS == 0) {
+		return FastExecutionPlan{}, nil, errors.New("fast intent: exactly one of latency_class or target_completion_ms is required")
+	}
+	if intent.LatencyClass != "" && intent.LatencyClass != "interactive" {
+		return FastExecutionPlan{}, nil, fmt.Errorf("fast intent: unknown latency_class %q", intent.LatencyClass)
+	}
+	if intent.TargetCompletionMS < 0 {
+		return FastExecutionPlan{}, nil, errors.New("fast intent: target_completion_ms must be positive")
+	}
+	if intent.QualityFloor != "accepted" {
+		return FastExecutionPlan{}, nil, fmt.Errorf("fast intent: unknown quality_floor %q", intent.QualityFloor)
+	}
+	if intent.CostCeiling != "bounded" {
+		return FastExecutionPlan{}, nil, fmt.Errorf("fast intent: unknown cost_ceiling %q", intent.CostCeiling)
+	}
+	if intent.CachePolicy != "preserve" && intent.CachePolicy != "allow_invalidation" {
+		return FastExecutionPlan{}, nil, fmt.Errorf("fast intent: unknown cache_policy %q", intent.CachePolicy)
+	}
+	if intent.FallbackPolicy != "degrade" && intent.FallbackPolicy != "refuse" {
+		return FastExecutionPlan{}, nil, fmt.Errorf("fast intent: unknown fallback_policy %q", intent.FallbackPolicy)
+	}
+
+	resolved := FastControls{Model: "auto", Speed: "fast", Effort: "high", Output: "concise", Cache: intent.CachePolicy, Workers: workers, MaxTokens: tokens}
+	prov := []Provenance{{"fast.speed", "preset.fast", resolved.Speed}, {"fast.model", "preset.fast", resolved.Model}, {"fast.effort", "preset.fast", resolved.Effort}, {"fast.output", "preset.fast", resolved.Output}, {"fast.cache", "intent", resolved.Cache}}
+	pins := []struct {
+		field, value string
+		dst          *string
+	}{{"model", task.Pins.Model, &resolved.Model}, {"speed", task.Pins.Speed, &resolved.Speed}, {"effort", task.Pins.Effort, &resolved.Effort}, {"output", task.Pins.Output, &resolved.Output}, {"cache", task.Pins.Cache, &resolved.Cache}}
+	for _, pin := range pins {
+		if pin.value != "" {
+			*pin.dst = pin.value
+			prov = append(prov, Provenance{"fast." + pin.field, "operator.pin", pin.value})
+		}
+	}
+	if resolved.Speed != "auto" && resolved.Speed != "fast" && resolved.Speed != "standard" {
+		return FastExecutionPlan{}, nil, fmt.Errorf("fast intent: invalid speed pin %q", resolved.Speed)
+	}
+	level := caps.ClaudeSpeed
+	if level == "" {
+		level = SupportUnsupported
+	}
+	outcomes := make([]MechanismOutcome, 0, 6)
+	selected := func(name string, outcome SupportLevel, reason string) {
+		outcomes = append(outcomes, MechanismOutcome{name, outcome, reason})
+	}
+	for _, name := range []string{"model", "effort", "output", "cache", "orchestration"} {
+		selected(name, SupportEmulated, "resolved through existing portable control")
+	}
+	if task.Pins.Speed != "" && task.Pins.Speed != "fast" {
+		selected("claude_speed", SupportNotSelected, "operator speed pin overrides fast binding")
+	} else if level == SupportNative {
+		selected("claude_speed", SupportNative, "existing Claude speed launch binding selected")
+	} else if intent.FallbackPolicy == "refuse" {
+		return FastExecutionPlan{}, nil, fmt.Errorf("fast intent: claude_speed unsupported and fallback_policy is refuse")
+	} else {
+		selected("claude_speed", SupportDegraded, "Claude speed binding unsupported; launch retains standard harness behavior")
+	}
+	launched := resolved
+	if level != SupportNative && task.Pins.Speed == "" {
+		launched.Speed = "standard"
+	}
+	// Realized is deliberately unknown until launch-side readback supplies evidence.
+	realized := FastControls{Model: "unknown", Speed: "unknown", Effort: "unknown", Output: "unknown", Cache: "unknown", Workers: 0, MaxTokens: 0}
+	return FastExecutionPlan{Schema: FastIntentSchemaVersion, Requested: intent, Resolved: resolved, Launched: launched, Realized: realized, Outcomes: outcomes}, prov, nil
 }
 
 func StableJSON(r Resolution) ([]byte, error) {

--- a/internal/orchestration/orchestration_test.go
+++ b/internal/orchestration/orchestration_test.go
@@ -1,6 +1,7 @@
 package orchestration
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"os"
@@ -11,7 +12,7 @@ import (
 
 func ptr[T any](v T) *T { return &v }
 func nativeCaps() HarnessCapabilities {
-	return HarnessCapabilities{SupportNative, SupportNative, SupportNative, SupportNative, SupportNative}
+	return HarnessCapabilities{SupportNative, SupportNative, SupportNative, SupportNative, SupportNative, SupportNative}
 }
 
 func TestPrecedence(t *testing.T) {
@@ -212,4 +213,76 @@ func TestStableJSONSortsDuplicateFieldProvenance(t *testing.T) {
 	if string(first) != string(second) {
 		t.Fatalf("unstable JSON:\n%s\n---\n%s", first, second)
 	}
+}
+
+func TestFastIntentSupportedClaudeBinding(t *testing.T) {
+	task := fastTask("supported")
+	got, err := Resolve(OrchestrationProfile{Name: ProfileFast}, task, nativeCaps())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fast := got.Resolved.Fast
+	if fast == nil || fast.Resolved.Speed != "fast" || fast.Launched.Speed != "fast" || fast.Realized.Speed != "unknown" {
+		t.Fatalf("unexpected receipt: %+v", fast)
+	}
+	if outcome(fast.Outcomes, "claude_speed") != SupportNative {
+		t.Fatalf("claude outcome: %+v", fast.Outcomes)
+	}
+}
+
+func TestFastIntentUnsupportedHarnessDegradesOrRefuses(t *testing.T) {
+	task := fastTask("unsupported")
+	got, err := Resolve(OrchestrationProfile{Name: ProfileFast}, task, HarnessCapabilities{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Resolved.Fast.Launched.Speed != "standard" || got.Resolved.Fast.Realized.Speed != "unknown" || outcome(got.Resolved.Fast.Outcomes, "claude_speed") != SupportDegraded {
+		t.Fatalf("unexpected degradation: %+v", got.Resolved.Fast)
+	}
+	task.FastIntent.FallbackPolicy = "refuse"
+	if _, err := Resolve(OrchestrationProfile{Name: ProfileFast}, task, HarnessCapabilities{}); err == nil || !strings.Contains(err.Error(), "fallback_policy is refuse") {
+		t.Fatalf("expected refusal, got %v", err)
+	}
+}
+
+func TestFastIntentOperatorPinsWinWithProvenance(t *testing.T) {
+	task := fastTask("override")
+	task.Pins.Speed = "standard"
+	task.Pins.Model = "pinned-model"
+	w := 2
+	task.Pins.MaxWorkers = &w
+	got, err := Resolve(OrchestrationProfile{Name: ProfileFast}, task, nativeCaps())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Resolved.Fast.Resolved.Speed != "standard" || got.Resolved.Fast.Resolved.Model != "pinned-model" || got.Resolved.Budget.MaxWorkers != 2 {
+		t.Fatalf("pins lost: %+v", got.Resolved)
+	}
+	if outcome(got.Resolved.Fast.Outcomes, "claude_speed") != SupportNotSelected {
+		t.Fatalf("speed should not be selected: %+v", got.Resolved.Fast.Outcomes)
+	}
+	stable, _ := StableJSON(got)
+	if !bytes.Contains(stable, []byte(`"source": "operator.pin"`)) {
+		t.Fatalf("missing provenance: %s", stable)
+	}
+}
+
+func TestFastIntentInvalidFieldsRefuse(t *testing.T) {
+	task := fastTask("invalid")
+	task.FastIntent.CachePolicy = "magic"
+	if _, err := Resolve(OrchestrationProfile{Name: ProfileFast}, task, nativeCaps()); err == nil || !strings.Contains(err.Error(), "cache_policy") {
+		t.Fatalf("expected typed refusal, got %v", err)
+	}
+}
+
+func fastTask(id string) TaskSpec {
+	return TaskSpec{Schema: "fak-orchestration-task/1", ID: id, FastIntent: &FastIntent{Schema: FastIntentSchemaVersion, LatencyClass: "interactive", QualityFloor: "accepted", CostCeiling: "bounded", CachePolicy: "preserve", FallbackPolicy: "degrade"}}
+}
+func outcome(all []MechanismOutcome, name string) SupportLevel {
+	for _, o := range all {
+		if o.Mechanism == name {
+			return o.Outcome
+		}
+	}
+	return ""
 }

--- a/internal/orchestration/testdata/fast-claude.json
+++ b/internal/orchestration/testdata/fast-claude.json
@@ -1,0 +1,1 @@
+{"schema":"fak-orchestration-task/1","id":"fast-claude","fast_intent":{"schema":"fak-fast-intent/1","latency_class":"interactive","quality_floor":"accepted","cost_ceiling":"bounded","cache_policy":"preserve","fallback_policy":"degrade"}}

--- a/internal/orchestration/testdata/fast-override.json
+++ b/internal/orchestration/testdata/fast-override.json
@@ -1,0 +1,1 @@
+{"schema":"fak-orchestration-task/1","id":"fast-override","fast_intent":{"schema":"fak-fast-intent/1","latency_class":"interactive","quality_floor":"accepted","cost_ceiling":"bounded","cache_policy":"allow_invalidation","fallback_policy":"refuse"},"pins":{"model":"operator-model","speed":"standard","max_workers":2,"max_tokens":8192}}

--- a/internal/orchestration/testdata/fast-unsupported.json
+++ b/internal/orchestration/testdata/fast-unsupported.json
@@ -1,0 +1,1 @@
+{"schema":"fak-orchestration-task/1","id":"fast-unsupported","fast_intent":{"schema":"fak-fast-intent/1","target_completion_ms":30000,"quality_floor":"accepted","cost_ceiling":"bounded","cache_policy":"preserve","fallback_policy":"degrade"}}


### PR DESCRIPTION
Closes #8960.

Independent witness:
- go test ./internal/orchestration -run 'Fast|Profile|Width|Adaptive|Determin' -count=1 -timeout=60s
- go test ./cmd/fak -run 'Orchestration.*Fast|Fast.*Orchestration|AdaptiveWidth' -count=1 -timeout=60s
- git diff HEAD^..HEAD --check

This current-trunk implementation composes FastExecutionPlan with landed adaptive WidthSelection, preserves operator pins, emits deterministic provenance and degradations, and covers supported and unsupported profiles.