### PR TITLE
perf(model): gate confidence depth on calibration #8938

### DIFF
--- a/internal/model/specdepthconfidence.go
+++ b/internal/model/specdepthconfidence.go
@@ -1,0 +1,21 @@
+package model
+
+import "github.com/anthony-chaudhary/fak/internal/polymodel"
+
+// DraftDepthWithConfidence composes the existing scalar/economic governor with
+// the optional calibrated per-position controller. The scalar decision is made
+// first and remains authoritative whenever the confidence gate is disabled or
+// cannot prove calibration, preserving the pre-existing decode path.
+func (g *SelfSpecGovernor) DraftDepthWithConfidence(
+	acceptRate float64,
+	pageInsPerDraft float64,
+	observedDrafts int,
+	gate polymodel.SpecDepthConfidenceGate,
+	predicted []float64,
+	profile []polymodel.AcceptancePosition,
+	calibrationErrorBound float64,
+	maxVerifyBudget int,
+) polymodel.SpecDepthConfidenceDecision {
+	fallbackDepth := g.DraftDepth(acceptRate, pageInsPerDraft, observedDrafts)
+	return gate.DraftDepth(predicted, profile, calibrationErrorBound, maxVerifyBudget, fallbackDepth)
+}

--- a/internal/model/specdepthconfidence_test.go
+++ b/internal/model/specdepthconfidence_test.go
@@ -1,0 +1,43 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/anthony-chaudhary/fak/internal/polymodel"
+)
+
+func TestDraftDepthWithConfidenceFallsBackToEconomicGovernor(t *testing.T) {
+	governor := SelfSpecGovernor{MaxDraftDepth: 4, WarmupDrafts: 0, BasePageInsPerToken: govBasePageIns}
+	gate := polymodel.SpecDepthConfidenceGate{Enabled: true, MinCumulativeAcceptance: 0.70}
+	predicted := []float64{0.98, 0.95, 0.90, 0.85}
+	profile := confidenceProfile(100, 97, 93, 40, 35)
+
+	want := governor.DraftDepth(0.95, 0, 100)
+	decision := governor.DraftDepthWithConfidence(0.95, 0, 100, gate, predicted, profile, 0.03, 4)
+	if want != 4 || decision.DraftDepth != want || decision.UsedConfidence {
+		t.Fatalf("scalar=%d confidence decision=%+v, want unchanged scalar depth 4", want, decision)
+	}
+}
+
+func TestDraftDepthWithConfidenceCanShortenVerifiedBudgetOnly(t *testing.T) {
+	governor := SelfSpecGovernor{MaxDraftDepth: 5, WarmupDrafts: 0, BasePageInsPerToken: govBasePageIns}
+	gate := polymodel.SpecDepthConfidenceGate{Enabled: true, MinCumulativeAcceptance: 0.60}
+	decision := governor.DraftDepthWithConfidence(
+		0.95, 0, 100, gate,
+		[]float64{0.96, 0.92, 0.86, 0.50, 0.40},
+		confidenceProfile(100, 95, 90, 84, 48, 39),
+		0.021, 5,
+	)
+	if decision.DraftDepth != 3 || !decision.UsedConfidence {
+		t.Fatalf("decision = %+v, want calibrated depth 3", decision)
+	}
+}
+
+func confidenceProfile(proposed int, accepted ...int) []polymodel.AcceptancePosition {
+	profile := make([]polymodel.AcceptancePosition, len(accepted))
+	for position, count := range accepted {
+		rate := float64(count) / float64(proposed)
+		profile[position] = polymodel.AcceptancePosition{Position: position, Proposed: proposed, Accepted: count, Rate: &rate}
+	}
+	return profile
+}

--- a/internal/polymodel/specdepthconfidence.go
+++ b/internal/polymodel/specdepthconfidence.go
@@ -1,0 +1,109 @@
+package polymodel
+
+import "math"
+
+// SpecDepthConfidenceGate chooses a bounded speculative prefix from calibrated,
+// per-position acceptance predictions. It is deliberately a controller seam:
+// callers still perform draft/verify/accept with the existing deterministic
+// decoder, and a disabled or untrusted gate returns the caller's scalar depth.
+type SpecDepthConfidenceGate struct {
+	// Enabled is explicit so the zero value cannot change decode behavior.
+	Enabled bool
+	// MinCumulativeAcceptance is the minimum conservative probability that every
+	// token in the selected prefix is accepted. It must be in (0, 1].
+	MinCumulativeAcceptance float64
+}
+
+// SpecDepthConfidenceDecision records whether confidence, rather than the
+// existing scalar/economic governor, selected DraftDepth.
+type SpecDepthConfidenceDecision struct {
+	DraftDepth     int
+	UsedConfidence bool
+	Reason         string
+}
+
+// DraftDepth returns the longest prefix within maxVerifyBudget whose cumulative
+// conservative acceptance probability remains at least the configured threshold.
+//
+// calibrationErrorBound serves two purposes: every empirical AcceptanceProfile
+// rate must be within that absolute distance of its corresponding prediction,
+// and the same bound is subtracted from each prediction before multiplying the
+// prefix probability. Missing, sparse, malformed, or miscalibrated observations
+// fall back rather than silently shortening a draft. fallbackDepth is expected
+// to be the result of the existing scalar/economic governor.
+func (g SpecDepthConfidenceGate) DraftDepth(
+	predicted []float64,
+	observed []AcceptancePosition,
+	calibrationErrorBound float64,
+	maxVerifyBudget int,
+	fallbackDepth int,
+) SpecDepthConfidenceDecision {
+	fallback := func(reason string) SpecDepthConfidenceDecision {
+		return SpecDepthConfidenceDecision{DraftDepth: fallbackDepth, Reason: reason}
+	}
+
+	if !g.Enabled {
+		return fallback("disabled")
+	}
+	if fallbackDepth < 0 || maxVerifyBudget <= 0 {
+		return fallback("invalid budget or fallback depth")
+	}
+	if !finiteProbability(g.MinCumulativeAcceptance) || g.MinCumulativeAcceptance == 0 {
+		return fallback("invalid cumulative acceptance threshold")
+	}
+	if math.IsNaN(calibrationErrorBound) || math.IsInf(calibrationErrorBound, 0) || calibrationErrorBound < 0 || calibrationErrorBound > 1 {
+		return fallback("invalid calibration error bound")
+	}
+
+	if fallbackDepth == 0 {
+		return fallback("scalar governor disabled drafting")
+	}
+	limit := min(len(predicted), maxVerifyBudget, fallbackDepth)
+	if limit == 0 || len(observed) < limit {
+		return fallback("insufficient confidence or calibration observations")
+	}
+
+	// Validate the complete budgeted vector before selecting a prefix. A bad
+	// suffix must not be hidden merely because an earlier position crossed the
+	// threshold: malformed model output makes the whole confidence receipt
+	// untrusted, so the scalar governor remains authoritative.
+	for position := 0; position < limit; position++ {
+		prediction := predicted[position]
+		if !finiteProbability(prediction) || prediction == 0 {
+			return fallback("invalid predicted acceptance")
+		}
+
+		sample := observed[position]
+		if sample.Position != position || sample.Proposed <= 0 || sample.Accepted < 0 || sample.Accepted > sample.Proposed || sample.Rate == nil {
+			return fallback("invalid acceptance profile")
+		}
+		rate := *sample.Rate
+		empiricalRate := float64(sample.Accepted) / float64(sample.Proposed)
+		if !finiteProbability(rate) || math.Abs(rate-empiricalRate) > 1e-12 {
+			return fallback("acceptance rate does not match counters")
+		}
+		if math.Abs(prediction-empiricalRate) > calibrationErrorBound {
+			return fallback("confidence is not calibrated")
+		}
+	}
+
+	cumulative := 1.0
+	depth := 0
+	for position := 0; position < limit; position++ {
+		conservative := predicted[position] - calibrationErrorBound
+		if conservative <= 0 {
+			break
+		}
+		cumulative *= conservative
+		if cumulative < g.MinCumulativeAcceptance {
+			break
+		}
+		depth = position + 1
+	}
+
+	return SpecDepthConfidenceDecision{DraftDepth: depth, UsedConfidence: true, Reason: "calibrated confidence prefix"}
+}
+
+func finiteProbability(value float64) bool {
+	return !math.IsNaN(value) && !math.IsInf(value, 0) && value >= 0 && value <= 1
+}

--- a/internal/polymodel/specdepthconfidence_test.go
+++ b/internal/polymodel/specdepthconfidence_test.go
@@ -1,0 +1,97 @@
+package polymodel
+
+import (
+	"math"
+	"testing"
+)
+
+func TestSpecDepthConfidenceGateSelectsCalibratedPrefix(t *testing.T) {
+	gate := SpecDepthConfidenceGate{Enabled: true, MinCumulativeAcceptance: 0.60}
+	predicted := []float64{0.96, 0.92, 0.86, 0.50, 0.40}
+	profile := acceptanceProfileForTest(100, 95, 90, 84, 48, 39)
+
+	decision := gate.DraftDepth(predicted, profile, 0.021, 5, 5)
+	if decision.DraftDepth != 3 || !decision.UsedConfidence {
+		t.Fatalf("decision = %+v, want calibrated depth 3", decision)
+	}
+}
+
+func TestSpecDepthConfidenceGateMiscalibrationFallsBack(t *testing.T) {
+	gate := SpecDepthConfidenceGate{Enabled: true, MinCumulativeAcceptance: 0.70}
+	predicted := []float64{0.98, 0.95, 0.90, 0.85}
+	profile := acceptanceProfileForTest(100, 97, 93, 40, 35)
+
+	decision := gate.DraftDepth(predicted, profile, 0.03, 4, 4)
+	if decision.DraftDepth != 4 || decision.UsedConfidence {
+		t.Fatalf("decision = %+v, want scalar-governor fallback depth 4", decision)
+	}
+}
+
+func TestSpecDepthConfidenceGateRejectsZeroAndNaNConfidence(t *testing.T) {
+	gate := SpecDepthConfidenceGate{Enabled: true, MinCumulativeAcceptance: 0.50}
+	profile := acceptanceProfileForTest(10, 9, 8)
+
+	for name, predicted := range map[string][]float64{
+		"zero": {0.9, 0},
+		"NaN":  {0.9, math.NaN()},
+	} {
+		t.Run(name, func(t *testing.T) {
+			decision := gate.DraftDepth(predicted, profile, 0.20, 2, 2)
+			if decision.DraftDepth != 2 || decision.UsedConfidence {
+				t.Fatalf("decision = %+v, want fallback depth 2", decision)
+			}
+		})
+	}
+}
+
+func TestSpecDepthConfidenceGateDefaultOffAndVerifyBudget(t *testing.T) {
+	predicted := []float64{0.99, 0.99, 0.99}
+	profile := acceptanceProfileForTest(100, 99, 99, 99)
+
+	if decision := (SpecDepthConfidenceGate{}).DraftDepth(predicted, profile, 0, 3, 2); decision.DraftDepth != 2 || decision.UsedConfidence {
+		t.Fatalf("zero-value decision = %+v, want unchanged fallback", decision)
+	}
+
+	gate := SpecDepthConfidenceGate{Enabled: true, MinCumulativeAcceptance: 0.90}
+	if decision := gate.DraftDepth(predicted, profile, 0, 2, 3); decision.DraftDepth != 2 || !decision.UsedConfidence {
+		t.Fatalf("budgeted decision = %+v, want confidence depth capped at 2", decision)
+	}
+}
+
+func TestSpecDepthConfidenceGateNeverExpandsScalarDepth(t *testing.T) {
+	gate := SpecDepthConfidenceGate{Enabled: true, MinCumulativeAcceptance: 0.50}
+	predicted := []float64{0.99, 0.99, 0.99}
+	profile := acceptanceProfileForTest(100, 99, 99, 99)
+
+	for _, fallback := range []int{0, 2} {
+		decision := gate.DraftDepth(predicted, profile, 0, 3, fallback)
+		if decision.DraftDepth != fallback {
+			t.Fatalf("fallback %d: decision = %+v, confidence must only shorten scalar depth", fallback, decision)
+		}
+	}
+}
+
+func TestSpecDepthConfidenceGateConsumesAcceptancePositionCounters(t *testing.T) {
+	rate := 0.8
+	profile := []AcceptancePosition{{Position: 0, Proposed: 10, Accepted: 8, Rate: &rate}}
+	decision := (SpecDepthConfidenceGate{Enabled: true, MinCumulativeAcceptance: 0.75}).DraftDepth(
+		[]float64{0.8}, profile, 0, 1, 1,
+	)
+	if decision.DraftDepth != 1 || !decision.UsedConfidence {
+		t.Fatalf("decision = %+v, want #8258 counter-compatible depth 1", decision)
+	}
+}
+
+func acceptanceProfileForTest(proposed int, accepted ...int) []AcceptancePosition {
+	profile := make([]AcceptancePosition, len(accepted))
+	for position, count := range accepted {
+		rate := float64(count) / float64(proposed)
+		profile[position] = AcceptancePosition{
+			Position: position,
+			Proposed: proposed,
+			Accepted: count,
+			Rate:     &rate,
+		}
+	}
+	return profile
+}


### PR DESCRIPTION
Closes #8938.

Independent witness:
- go test ./internal/model ./internal/polymodel -run 'SpecDepth|Confidence|Calibration' -count=1 -timeout=60s
- git diff HEAD^..HEAD --check

The fak-native speculative path uses confidence-derived depth only with valid calibration, falls back otherwise, and carries the decision reason through both model and polymodel layers.