### PR TITLE
docs(studymonitor): record Ruflo inventory #8931

### DIFF
--- a/docs/research/inventory/ruvnet-ruflo.json
+++ b/docs/research/inventory/ruvnet-ruflo.json
@@ -111,12 +111,13 @@
     },
     {
       "class": "open_closed_issues_prs_discussions",
-      "status": "partial",
+      "status": "external_required",
       "evidence": [
-        ".github/ISSUE_TEMPLATE/rollback-incident.md",
-        ".github/issues/alpha-89-telemetry-implementation.md"
+        "https://github.com/ruvnet/ruflo/issues?q=created%3A%3C%3D2026-08-14T15%3A39%3A43Z",
+        "https://github.com/ruvnet/ruflo/pulls?q=created%3A%3C%3D2026-08-14T15%3A39%3A43Z",
+        "https://github.com/ruvnet/ruflo/discussions"
       ],
-      "note": "local templates found; open/closed issue, PR, and discussion history still require GitHub or forge read-back"
+      "note": "GitHub API read-back at the pinned commit timestamp found 1,613 issues (556 open, 1,057 closed), 1,291 pull requests (261 open, 1,030 closed), and all 86 discussions (84 open, 2 closed; 3 answered). Counts exclude items created after 2026-08-14T15:39:43Z."
     },
     {
       "class": "roadmap_todos",
@@ -150,12 +151,19 @@
     {
       "class": "fak_selfquery_witness",
       "status": "external_required",
-      "note": "process artifact created by the study pass, not by the foreign repository tree"
+      "evidence": [
+        "fak help --all (routing, memory, hooks, skills, orchestration, telemetry)",
+        "rg -n -i <candidate-axis> README.md docs internal cmd examples"
+      ],
+      "note": "Queried fak first across adoption, performance, security, reliability, architecture/orchestration, and operations; the candidate matrix records the closest owned surface and avoids filing duplicate capabilities."
     },
     {
       "class": "candidate_matrix",
       "status": "external_required",
-      "note": "process artifact created by the study pass, not by the foreign repository tree"
+      "evidence": [
+        "docs/research/inventory/ruvnet-ruflo.json#non_tree_study.candidate_matrix"
+      ],
+      "note": "Four source-backed candidates were compared against fak-native surfaces; all were rejected or already owned, so no borrow survived."
     },
     {
       "class": "completeness_critic",
@@ -165,7 +173,10 @@
     {
       "class": "issue_tracking",
       "status": "external_required",
-      "note": "process artifact created by the study pass, not by the foreign repository tree"
+      "evidence": [
+        "https://github.com/anthony-chaudhary/fak/issues/8931"
+      ],
+      "note": "Issue #8931 tracks this inventory completion. Candidate adjudication produced no surviving borrow, so no additional implementation issue was filed."
     }
   ],
   "subsystems": [
@@ -801,5 +812,110 @@
   "skipped_dirs": [
     ".git"
   ],
-  "completeness_critic": "local tree inventory walked every non-skipped regular file and grouped immediate subsystems; skipped dependency/cache/control directories: .git; still requires non-tree study artifacts: fak_selfquery_witness, candidate_matrix, issue_tracking"
+  "completeness_critic": "exhaustive local tree map plus pinned-timestamp GitHub issue, pull-request, and complete discussion read-back; fak self-query, candidate adjudication, and issue tracking are recorded under non_tree_study; skipped dependency/cache/control directories: .git",
+  "non_tree_study": {
+    "observed_at": "2026-08-25",
+    "source_cutoff": {
+      "revision": "4dcff483482cee316f47552a961bcbaadc89f378",
+      "commit_timestamp": "2026-08-14T15:39:43Z"
+    },
+    "github_surface": {
+      "issues": {
+        "total": 1613,
+        "open": 556,
+        "closed": 1057
+      },
+      "pull_requests": {
+        "total": 1291,
+        "open": 261,
+        "closed": 1030
+      },
+      "discussions": {
+        "total": 86,
+        "open": 84,
+        "closed": 2,
+        "answered": 3
+      },
+      "method": "GitHub REST issues endpoint paged to exhaustion (issues and pull requests split by pull_request presence), plus GraphQL discussions(first:100); retained records created no later than the pinned commit timestamp."
+    },
+    "self_query_axes": [
+      {
+        "axis": "adoption",
+        "fak_surface": "managed harness integrations, MCP, skills, and setup/doctor surfaces",
+        "verdict": "owned"
+      },
+      {
+        "axis": "performance",
+        "fak_surface": "native routing, shared setup/cache, context memory, benchmarks, and SOTA checks",
+        "verdict": "owned"
+      },
+      {
+        "axis": "security",
+        "fak_surface": "default-deny policy/adjudication, guard hooks, capability floors, and security scorecards",
+        "verdict": "owned"
+      },
+      {
+        "axis": "reliability",
+        "fak_surface": "DOS leases, goal gates, independent witnesses, watchdogs, and recovery surfaces",
+        "verdict": "owned"
+      },
+      {
+        "axis": "architecture_orchestration",
+        "fak_surface": "ultracode/task orchestration, lanes, messaging, reconciliation, and trajectory control",
+        "verdict": "owned"
+      },
+      {
+        "axis": "operations",
+        "fak_surface": "telemetry, health/doctor, study monitoring, ledgers, and observable outcomes",
+        "verdict": "owned"
+      }
+    ],
+    "candidate_matrix": [
+      {
+        "candidate": "power-of-two-choices mesh load balancing",
+        "source": [
+          "https://github.com/ruvnet/ruflo/issues/3026",
+          "https://github.com/ruvnet/ruflo/pull/3027"
+        ],
+        "alternative": "fak native routing and orchestration scheduler",
+        "disposition": "reject",
+        "reason": "Ruflo evaluated and rejected its own experiment at the pinned revision; no validated gain or transferable witness survives."
+      },
+      {
+        "candidate": "evaluation bridge for memory retrieval fusion",
+        "source": [
+          "https://github.com/ruvnet/ruflo/issues/3019",
+          "https://github.com/ruvnet/ruflo/pull/3020"
+        ],
+        "alternative": "fak memory/context benchmarks and claim gates",
+        "disposition": "stay_minimal",
+        "reason": "The source is a Ruflo-specific BM25/semantic benchmark bridge, not evidence of a better fak-native memory primitive."
+      },
+      {
+        "candidate": "persisted swarm-health reporting",
+        "source": [
+          "https://github.com/ruvnet/ruflo/pull/3017"
+        ],
+        "alternative": "fak DOS liveness, productivity, lease, and ultracode status witnesses",
+        "disposition": "already_owned",
+        "reason": "fak already exposes stronger witnessed scheduler health rather than a self-reported swarm status."
+      },
+      {
+        "candidate": "doctor checks for runtime/environment drift",
+        "source": [
+          "https://github.com/ruvnet/ruflo/issues/3022",
+          "https://github.com/ruvnet/ruflo/issues/3023",
+          "https://github.com/ruvnet/ruflo/pull/3028"
+        ],
+        "alternative": "fak doctor/setup/preflight and deterministic gates",
+        "disposition": "already_owned",
+        "reason": "The fixes are Ruflo dependency and environment details; the reusable diagnostic pattern is already native to fak."
+      }
+    ],
+    "issue_tracking": {
+      "study_issue": "https://github.com/anthony-chaudhary/fak/issues/8931",
+      "filed_borrows": [],
+      "reason": "No candidate survived source validation and fak self-query as a distinct, evidence-backed borrow."
+    }
+  }
 }

--- a/docs/research/monitored-repositories.json
+++ b/docs/research/monitored-repositories.json
@@ -23,14 +23,55 @@
           "runtime_source",
           "tests_fixtures",
           "history_changelog_releases",
+          "open_closed_issues_prs_discussions",
           "roadmap_todos",
           "license_provenance",
-          "completeness_critic"
+          "fak_selfquery_witness",
+          "candidate_matrix",
+          "completeness_critic",
+          "issue_tracking"
         ],
         "subsystem_count": 18,
-        "candidate_count": 0,
+        "candidate_count": 4,
         "filed_issue_count": 0,
-        "completeness_critic": "local tree inventory walked every non-skipped regular file and grouped immediate subsystems; skipped dependency/cache/control directories: .git; still requires non-tree study artifacts: fak_selfquery_witness, candidate_matrix, issue_tracking"
+        "completeness_critic": "exhaustive local tree map plus pinned-timestamp GitHub issue, pull-request, and complete discussion read-back; fak self-query, candidate adjudication, and issue tracking are recorded under non_tree_study; skipped dependency/cache/control directories: .git",
+        "source_evidence": [
+          {
+            "class": "open_closed_issues_prs_discussions",
+            "evidence": [
+              "gh api --paginate --slurp repos/ruvnet/ruflo/issues?state=all&per_page=100&sort=created&direction=asc",
+              "gh pr list --repo ruvnet/ruflo --state all --limit 1000 --json number,title,state,createdAt,closedAt,mergedAt,labels,url",
+              "gh api graphql repository(owner:ruvnet,name:ruflo) discussions(first:100)"
+            ],
+            "note": "Paged GitHub read-back through the pinned commit timestamp: 1,613 issues, 1,291 pull requests, and all 86 discussions."
+          },
+          {
+            "class": "fak_selfquery_witness",
+            "evidence": [
+              "fak capabilities \"power of two choices mesh load balancing scheduler routing\"",
+              "fak capabilities \"memory retrieval BM25 semantic fusion evaluation benchmark\"",
+              "fak capabilities \"persisted swarm health liveness lease worker status telemetry\"",
+              "fak capabilities \"doctor environment drift runtime dependency health preflight\""
+            ],
+            "note": "Candidate-specific fak queries returned native routing, fleet-health, and capability-floor surfaces; the retrieval-fusion query returned no exact capability and was adjudicated stay-minimal rather than inventing a gap."
+          },
+          {
+            "class": "candidate_matrix",
+            "evidence": [
+              "docs/research/inventory/ruvnet-ruflo.json#candidate-matrix"
+            ]
+          },
+          {
+            "class": "issue_tracking",
+            "evidence": [
+              "https://github.com/anthony-chaudhary/fak/issues/8931"
+            ],
+            "note": "All candidates were rejected, stay-minimal, or already owned; no borrow issue survived."
+          }
+        ],
+        "issue_refs": [
+          "#8931"
+        ]
       }
     },
     {


### PR DESCRIPTION
Closes #8931.

Independent witness:
- go test ./internal/studymonitor -count=1 -timeout=60s
- git diff HEAD^..HEAD --check

The Ruflo registry row now carries the required non-tree source-class inventory and a durable inventory artifact rather than a tree-only study.