### PR TITLE
feat(process): implement witness-first issue and worker packets #8764

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -38,6 +38,96 @@ body:
         P4 Operations: preserved - reason
     validations:
       required: true
+  - type: markdown
+    attributes:
+      value: |
+        ### Witness-first contract
+
+        For substantive implementation, select the failure context and name the evidence chain
+        before dispatch: envelope -> baseline artifact -> one lever -> candidate artifact -> promotion
+        gate -> durable witness. The adapter points to existing project proof primitives; it does not
+        impose performance fields on unrelated work. Missing fields warn by default and fail closed
+        only on proof-enforced lanes. Read-only triage, trivial changes, urgent safety/outage work,
+        and unavailable external systems may use the documented exception field.
+  - type: dropdown
+    id: witness-context
+    attributes:
+      label: Witness context adapter
+      description: Select the artifact class that matches the failure; choose Exception only for a documented exception below.
+      options:
+        - Logic/correctness - failing behavior repro to focused test to regression test
+        - TUI/visual - captured render to render assertion to render-witness test/screenshot
+        - Security/policy - preflight or red-team receipt to policy/attestation gate to policy fixture
+        - Reliability/operations - incident or soak artifact to end-to-end SLO to fault/soak witness
+        - Cost/token - net-true usage receipt to quality-constrained cost gate to usage regression
+        - Native performance - native benchmark receipt to matched-envelope gate to benchmark regression
+        - Documented exception
+    validations:
+      required: true
+  - type: textarea
+    id: witness-envelope
+    attributes:
+      label: Context / envelope
+      description: Pin only the inputs, environment, policy, load, accounting, quality, or hardware axes relevant to the selected adapter.
+      placeholder: "Example: parser input and deterministic Go environment; or native engine/model/hardware/workload/quality envelope."
+    validations:
+      required: false
+  - type: input
+    id: baseline-artifact
+    attributes:
+      label: Baseline artifact
+      description: Existing failure artifact requested by the selected adapter.
+      placeholder: "Example: failing test case, captured render, preflight receipt, soak artifact, usage receipt, or native benchmark receipt."
+    validations:
+      required: false
+  - type: input
+    id: declared-lever
+    attributes:
+      label: One declared lever
+      description: The single controlled change under test; additional levers require another candidate cycle.
+      placeholder: "Example: Change only the token boundary."
+    validations:
+      required: false
+  - type: input
+    id: candidate-artifact
+    attributes:
+      label: Candidate artifact
+      description: The comparable post-change artifact requested by the selected adapter.
+      placeholder: "Example: passing repro, corrected render, candidate receipt, or matched benchmark."
+    validations:
+      required: false
+  - type: input
+    id: promotion-gate
+    attributes:
+      label: Promotion gate
+      description: Falsifiable command/threshold; include end-to-end costs for performance, cost, and reliability work.
+      placeholder: "Example: go test ./internal/parser; or quality holds and net billed tokens fall."
+    validations:
+      required: false
+  - type: input
+    id: durable-witness
+    attributes:
+      label: Durable regression witness
+      description: Existing project witness primitive that prevents recurrence.
+      placeholder: "Example: regression test, render witness, policy fixture, fault test, usage fixture, or benchmark receipt check."
+    validations:
+      required: false
+  - type: textarea
+    id: rejected-levers
+    attributes:
+      label: Rejected levers / falsifying results
+      description: Record each attempted lever, its artifact, and falsifier so later workers do not repeat it.
+      placeholder: "Example: retry interval - soak-17.json - p99 recovery regressed."
+    validations:
+      required: false
+  - type: textarea
+    id: witness-exception
+    attributes:
+      label: Witness exception
+      description: Required only when Documented exception is selected; name read-only triage, trivial change, urgent safety/outage response, or unavailable external system and explain why.
+      placeholder: "Example: Read-only triage; no implementation dispatch occurs."
+    validations:
+      required: false
   - type: input
     id: version
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -51,6 +51,96 @@ body:
       placeholder: "Today: …\nBetter because: …\nWitness: …"
     validations:
       required: true
+  - type: markdown
+    attributes:
+      value: |
+        ### Witness-first contract
+
+        For substantive implementation, select the failure context and name the evidence chain
+        before dispatch: envelope -> baseline artifact -> one lever -> candidate artifact -> promotion
+        gate -> durable witness. The adapter points to existing project proof primitives; it does not
+        impose performance fields on unrelated work. Missing fields warn by default and fail closed
+        only on proof-enforced lanes. Read-only triage, trivial changes, urgent safety/outage work,
+        and unavailable external systems may use the documented exception field.
+  - type: dropdown
+    id: witness-context
+    attributes:
+      label: Witness context adapter
+      description: Select the artifact class that matches the failure; choose Exception only for a documented exception below.
+      options:
+        - Logic/correctness - failing behavior repro to focused test to regression test
+        - TUI/visual - captured render to render assertion to render-witness test/screenshot
+        - Security/policy - preflight or red-team receipt to policy/attestation gate to policy fixture
+        - Reliability/operations - incident or soak artifact to end-to-end SLO to fault/soak witness
+        - Cost/token - net-true usage receipt to quality-constrained cost gate to usage regression
+        - Native performance - native benchmark receipt to matched-envelope gate to benchmark regression
+        - Documented exception
+    validations:
+      required: true
+  - type: textarea
+    id: witness-envelope
+    attributes:
+      label: Context / envelope
+      description: Pin only the inputs, environment, policy, load, accounting, quality, or hardware axes relevant to the selected adapter.
+      placeholder: "Example: parser input and deterministic Go environment; or native engine/model/hardware/workload/quality envelope."
+    validations:
+      required: false
+  - type: input
+    id: baseline-artifact
+    attributes:
+      label: Baseline artifact
+      description: Existing failure artifact requested by the selected adapter.
+      placeholder: "Example: failing test case, captured render, preflight receipt, soak artifact, usage receipt, or native benchmark receipt."
+    validations:
+      required: false
+  - type: input
+    id: declared-lever
+    attributes:
+      label: One declared lever
+      description: The single controlled change under test; additional levers require another candidate cycle.
+      placeholder: "Example: Change only the token boundary."
+    validations:
+      required: false
+  - type: input
+    id: candidate-artifact
+    attributes:
+      label: Candidate artifact
+      description: The comparable post-change artifact requested by the selected adapter.
+      placeholder: "Example: passing repro, corrected render, candidate receipt, or matched benchmark."
+    validations:
+      required: false
+  - type: input
+    id: promotion-gate
+    attributes:
+      label: Promotion gate
+      description: Falsifiable command/threshold; include end-to-end costs for performance, cost, and reliability work.
+      placeholder: "Example: go test ./internal/parser; or quality holds and net billed tokens fall."
+    validations:
+      required: false
+  - type: input
+    id: durable-witness
+    attributes:
+      label: Durable regression witness
+      description: Existing project witness primitive that prevents recurrence.
+      placeholder: "Example: regression test, render witness, policy fixture, fault test, usage fixture, or benchmark receipt check."
+    validations:
+      required: false
+  - type: textarea
+    id: rejected-levers
+    attributes:
+      label: Rejected levers / falsifying results
+      description: Record each attempted lever, its artifact, and falsifier so later workers do not repeat it.
+      placeholder: "Example: retry interval - soak-17.json - p99 recovery regressed."
+    validations:
+      required: false
+  - type: textarea
+    id: witness-exception
+    attributes:
+      label: Witness exception
+      description: Required only when Documented exception is selected; name read-only triage, trivial change, urgent safety/outage response, or unavailable external system and explain why.
+      placeholder: "Example: Read-only triage; no implementation dispatch occurs."
+    validations:
+      required: false
   - type: textarea
     id: proposal
     attributes:

--- a/.github/ISSUE_TEMPLATE/worker-ready-issue.yml
+++ b/.github/ISSUE_TEMPLATE/worker-ready-issue.yml
@@ -183,6 +183,96 @@ body:
       placeholder: "Example: The producer skips unscoped candidates and reports ISSUE_SCOPE_INCOMPLETE."
     validations:
       required: true
+  - type: markdown
+    attributes:
+      value: |
+        ### Witness-first contract
+
+        For substantive implementation, select the failure context and name the evidence chain
+        before dispatch: envelope -> baseline artifact -> one lever -> candidate artifact -> promotion
+        gate -> durable witness. The adapter points to existing project proof primitives; it does not
+        impose performance fields on unrelated work. Missing fields warn by default and fail closed
+        only on proof-enforced lanes. Read-only triage, trivial changes, urgent safety/outage work,
+        and unavailable external systems may use the documented exception field.
+  - type: dropdown
+    id: witness-context
+    attributes:
+      label: Witness context adapter
+      description: Select the artifact class that matches the failure; choose Exception only for a documented exception below.
+      options:
+        - Logic/correctness - failing behavior repro to focused test to regression test
+        - TUI/visual - captured render to render assertion to render-witness test/screenshot
+        - Security/policy - preflight or red-team receipt to policy/attestation gate to policy fixture
+        - Reliability/operations - incident or soak artifact to end-to-end SLO to fault/soak witness
+        - Cost/token - net-true usage receipt to quality-constrained cost gate to usage regression
+        - Native performance - native benchmark receipt to matched-envelope gate to benchmark regression
+        - Documented exception
+    validations:
+      required: true
+  - type: textarea
+    id: witness-envelope
+    attributes:
+      label: Context / envelope
+      description: Pin only the inputs, environment, policy, load, accounting, quality, or hardware axes relevant to the selected adapter.
+      placeholder: "Example: parser input and deterministic Go environment; or native engine/model/hardware/workload/quality envelope."
+    validations:
+      required: false
+  - type: input
+    id: baseline-artifact
+    attributes:
+      label: Baseline artifact
+      description: Existing failure artifact requested by the selected adapter.
+      placeholder: "Example: failing test case, captured render, preflight receipt, soak artifact, usage receipt, or native benchmark receipt."
+    validations:
+      required: false
+  - type: input
+    id: declared-lever
+    attributes:
+      label: One declared lever
+      description: The single controlled change under test; additional levers require another candidate cycle.
+      placeholder: "Example: Change only the token boundary."
+    validations:
+      required: false
+  - type: input
+    id: candidate-artifact
+    attributes:
+      label: Candidate artifact
+      description: The comparable post-change artifact requested by the selected adapter.
+      placeholder: "Example: passing repro, corrected render, candidate receipt, or matched benchmark."
+    validations:
+      required: false
+  - type: input
+    id: promotion-gate
+    attributes:
+      label: Promotion gate
+      description: Falsifiable command/threshold; include end-to-end costs for performance, cost, and reliability work.
+      placeholder: "Example: go test ./internal/parser; or quality holds and net billed tokens fall."
+    validations:
+      required: false
+  - type: input
+    id: durable-witness
+    attributes:
+      label: Durable regression witness
+      description: Existing project witness primitive that prevents recurrence.
+      placeholder: "Example: regression test, render witness, policy fixture, fault test, usage fixture, or benchmark receipt check."
+    validations:
+      required: false
+  - type: textarea
+    id: rejected-levers
+    attributes:
+      label: Rejected levers / falsifying results
+      description: Record each attempted lever, its artifact, and falsifier so later workers do not repeat it.
+      placeholder: "Example: retry interval - soak-17.json - p99 recovery regressed."
+    validations:
+      required: false
+  - type: textarea
+    id: witness-exception
+    attributes:
+      label: Witness exception
+      description: Required only when Documented exception is selected; name read-only triage, trivial change, urgent safety/outage response, or unavailable external system and explain why.
+      placeholder: "Example: Read-only triage; no implementation dispatch occurs."
+    validations:
+      required: false
   - type: input
     id: witness
     attributes:

--- a/internal/architest/issue_template_test.go
+++ b/internal/architest/issue_template_test.go
@@ -440,7 +440,7 @@ func formIDs(body string) []string {
 
 func TestHumanIssueTemplatesPromptForCanonicalProblemFrame(t *testing.T) {
 	root := filepath.Dir(internalDir(t))
-	workerReadyIDs := []string{"parent-context", "generation", "problem_frame", "current-state", "why-next", "working-spine", "priority-context", "work-unit", "expected-steps", "assumptions", "confusion-risks", "coordination-notes", "trigger", "batch-policy", "in-scope", "out-of-scope", "done-condition", "witness", "acceptance-gate", "lane", "path-hints", "hot-tree-owning-lanes", "hot-tree-contention-check", "hot-tree-partition", "hot-tree-commit-recipe", "boundary-notes", "closure-binding", "final-checks"}
+	workerReadyIDs := []string{"parent-context", "generation", "problem_frame", "current-state", "why-next", "working-spine", "priority-context", "work-unit", "expected-steps", "assumptions", "confusion-risks", "coordination-notes", "trigger", "batch-policy", "in-scope", "out-of-scope", "done-condition", "witness-context", "witness-envelope", "baseline-artifact", "declared-lever", "candidate-artifact", "promotion-gate", "durable-witness", "rejected-levers", "witness-exception", "witness", "acceptance-gate", "lane", "path-hints", "hot-tree-owning-lanes", "hot-tree-contention-check", "hot-tree-partition", "hot-tree-commit-recipe", "boundary-notes", "closure-binding", "final-checks"}
 	for _, name := range []string{"feature-request.yml", "bug-report.yml", "worker-ready-issue.yml"} {
 		data, err := os.ReadFile(filepath.Join(root, ".github", "ISSUE_TEMPLATE", name))
 		if err != nil {

--- a/internal/orchestration/orchestration.go
+++ b/internal/orchestration/orchestration.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/anthony-chaudhary/fak/internal/witnessprocess"
 )
 
 const SchemaVersion = "fak-orchestration-plan/1"
@@ -84,18 +86,19 @@ type FastPins struct {
 }
 
 type TaskSpec struct {
-	Schema       string        `json:"schema"`
-	ID           string        `json:"id"`
-	WorkClass    WorkClass     `json:"work_class,omitempty"`
-	Attended     *bool         `json:"attended,omitempty"`
-	MaxWorkers   *int          `json:"max_workers,omitempty"`
-	ExactWorkers *int          `json:"exact_workers,omitempty"`
-	Width        *WidthRequest `json:"width,omitempty"`
-	MaxTokens    *int64        `json:"max_tokens,omitempty"`
-	EngineRef    string        `json:"engine_ref,omitempty"`
-	FastIntent   *FastIntent   `json:"fast_intent,omitempty"`
-	Pins         FastPins      `json:"pins,omitempty"`
-	ClaudeSpeed  bool          `json:"claude_speed,omitempty"`
+	Schema       string                `json:"schema"`
+	ID           string                `json:"id"`
+	WorkClass    WorkClass             `json:"work_class,omitempty"`
+	Attended     *bool                 `json:"attended,omitempty"`
+	MaxWorkers   *int                  `json:"max_workers,omitempty"`
+	ExactWorkers *int                  `json:"exact_workers,omitempty"`
+	Width        *WidthRequest         `json:"width,omitempty"`
+	MaxTokens    *int64                `json:"max_tokens,omitempty"`
+	EngineRef    string                `json:"engine_ref,omitempty"`
+	FastIntent   *FastIntent           `json:"fast_intent,omitempty"`
+	Pins         FastPins              `json:"pins,omitempty"`
+	ClaudeSpeed  bool                  `json:"claude_speed,omitempty"`
+	WitnessFirst *witnessprocess.Block `json:"witness_first,omitempty"`
 }
 
 type ChildAccessMode string
@@ -262,6 +265,7 @@ type WorkflowPlan struct {
 	Explanation  []string           `json:"explanation"`
 	Fast         *FastExecutionPlan `json:"fast,omitempty"`
 	Width        *WidthSelection    `json:"width,omitempty"`
+	Warnings     []string           `json:"warnings,omitempty"`
 }
 
 type Resolution struct {
@@ -371,6 +375,14 @@ func ParseResolution(data []byte) (Resolution, error) {
 }
 
 func Resolve(req OrchestrationProfile, task TaskSpec, caps HarnessCapabilities) (Resolution, error) {
+	var witnessWarnings []string
+	if task.WitnessFirst != nil {
+		var err error
+		witnessWarnings, err = task.WitnessFirst.Validate()
+		if err != nil {
+			return Resolution{}, err
+		}
+	}
 	if req.Name == "" {
 		req.Name = ProfileAuto
 	}
@@ -508,7 +520,7 @@ func Resolve(req OrchestrationProfile, task TaskSpec, caps HarnessCapabilities) 
 	for _, d := range deg {
 		explain = append(explain, "degraded: "+d.Reason)
 	}
-	plan := WorkflowPlan{Schema: SchemaVersion, Profile: resolvedProfile, TaskID: task.ID, WorkClass: task.WorkClass, Roles: roles, DAG: dag, Budget: Budget{workers, tokens}, Leases: LeasePolicy{"taskmgr", multi}, Witness: WitnessPolicy{witness, witness}, Reconcile: ReconcilePolicy{multi, "effect-readback"}, Interaction: InteractionPolicy{attended, multi, multi}, EngineRef: engine, SOLRoute: solRoute, Degradations: deg, Explanation: explain, Width: width}
+	plan := WorkflowPlan{Schema: SchemaVersion, Profile: resolvedProfile, TaskID: task.ID, WorkClass: task.WorkClass, Roles: roles, DAG: dag, Budget: Budget{workers, tokens}, Leases: LeasePolicy{"taskmgr", multi}, Witness: WitnessPolicy{witness, witness}, Reconcile: ReconcilePolicy{multi, "effect-readback"}, Interaction: InteractionPolicy{attended, multi, multi}, EngineRef: engine, SOLRoute: solRoute, Degradations: deg, Explanation: explain, Width: width, Warnings: witnessWarnings}
 	if resolvedProfile == ProfileFast && task.FastIntent != nil {
 		fast, fastProv, err := resolveFast(task, caps, workers, tokens)
 		if err != nil {

--- a/internal/orchestration/tasktext_test.go
+++ b/internal/orchestration/tasktext_test.go
@@ -1,6 +1,10 @@
 package orchestration
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/anthony-chaudhary/fak/internal/witnessprocess"
+)
 
 func TestTaskFromTextClassifiesWorkShape(t *testing.T) {
 	tests := []struct {
@@ -39,5 +43,21 @@ func TestTaskFromTextRejectsEmptyAndDoesNotRetainPrompt(t *testing.T) {
 	}
 	if task.ID == "Implement Secret_Widget and verify it" || len(task.ID) != len("task-")+16 {
 		t.Fatalf("task id %q is not a bounded digest", task.ID)
+	}
+}
+
+func TestResolveWitnessFirstWarnsOrEnforcesBeforeDispatch(t *testing.T) {
+	incomplete := &witnessprocess.Block{Context: witnessprocess.Logic, Envelope: "fixed input", Lever: "one parser change", CandidateArtifact: "candidate", DurableWitness: "test"}
+	task := TaskSpec{Schema: "fak-orchestration-task/1", ID: "task-witness", WorkClass: WorkGrind, WitnessFirst: incomplete}
+	got, err := Resolve(OrchestrationProfile{Name: ProfileUltracode}, task, HarnessCapabilities{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Resolved.Warnings) != 1 {
+		t.Fatalf("warnings=%v", got.Resolved.Warnings)
+	}
+	incomplete.Policy = witnessprocess.Enforce
+	if _, err := Resolve(OrchestrationProfile{Name: ProfileUltracode}, task, HarnessCapabilities{}); err == nil {
+		t.Fatal("enforced lane accepted incomplete witness block")
 	}
 }

--- a/internal/taskmgr/taskmgr.go
+++ b/internal/taskmgr/taskmgr.go
@@ -9,6 +9,8 @@ import (
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/anthony-chaudhary/fak/internal/witnessprocess"
 )
 
 const SchemaSnapshot = "fak.task-manager-snapshot.v1"
@@ -75,13 +77,14 @@ func WithOriginWitness(w Witness) Option {
 }
 
 type TaskSpec struct {
-	TaskID       string            `json:"task_id"`
-	Title        string            `json:"title,omitempty"`
-	Total        float64           `json:"total,omitempty"`
-	Unit         string            `json:"unit,omitempty"`
-	Labels       map[string]string `json:"labels,omitempty"`
-	EvidenceRefs []EvidenceRef     `json:"evidence_refs,omitempty"`
-	QualitySLO   *QualitySLO       `json:"quality_slo,omitempty"`
+	TaskID       string                `json:"task_id"`
+	Title        string                `json:"title,omitempty"`
+	Total        float64               `json:"total,omitempty"`
+	Unit         string                `json:"unit,omitempty"`
+	Labels       map[string]string     `json:"labels,omitempty"`
+	EvidenceRefs []EvidenceRef         `json:"evidence_refs,omitempty"`
+	QualitySLO   *QualitySLO           `json:"quality_slo,omitempty"`
+	WitnessFirst *witnessprocess.Block `json:"witness_first,omitempty"`
 }
 
 type StepSpec struct {
@@ -693,6 +696,11 @@ func (m *Manager) sampleAt(now time.Time) ResourceSample {
 }
 
 func validateTaskSpec(spec TaskSpec) error {
+	if spec.WitnessFirst != nil {
+		if _, err := spec.WitnessFirst.Validate(); err != nil {
+			return err
+		}
+	}
 	if spec.TaskID == "" {
 		return errors.New("taskmgr: task id is required")
 	}
@@ -840,6 +848,11 @@ func unixNanoOrZero(t time.Time) int64 {
 }
 
 func cloneTaskSpec(spec TaskSpec) TaskSpec {
+	if spec.WitnessFirst != nil {
+		clone := *spec.WitnessFirst
+		clone.NegativeResults = append([]witnessprocess.NegativeResult(nil), spec.WitnessFirst.NegativeResults...)
+		spec.WitnessFirst = &clone
+	}
 	spec.Labels = cloneLabels(spec.Labels)
 	spec.EvidenceRefs = cloneEvidenceRefs(spec.EvidenceRefs)
 	spec.QualitySLO = cloneQualitySLO(spec.QualitySLO)

--- a/internal/taskmgr/taskmgr_test.go
+++ b/internal/taskmgr/taskmgr_test.go
@@ -3,6 +3,8 @@ package taskmgr
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/anthony-chaudhary/fak/internal/witnessprocess"
 	"time"
 )
 
@@ -255,5 +257,18 @@ func fakeSampler(base time.Time) Sampler {
 			SysBytes:       uint64(4000 + elapsed*100),
 			Goroutines:     5 + int(elapsed),
 		}
+	}
+}
+
+func TestStartTaskCarriesWitnessFirstWorkerPacket(t *testing.T) {
+	manager := NewManager()
+	block := &witnessprocess.Block{Context: witnessprocess.Logic, Envelope: "fixed input", BaselineArtifact: "failing test", Lever: "one parser change", CandidateArtifact: "passing test", PromotionGate: "go test", DurableWitness: "regression test", Policy: witnessprocess.Enforce}
+	if _, err := manager.StartTask(TaskSpec{TaskID: "task_witness_packet", WitnessFirst: block}); err != nil {
+		t.Fatal(err)
+	}
+	incomplete := *block
+	incomplete.BaselineArtifact = ""
+	if _, err := manager.StartTask(TaskSpec{TaskID: "task_witness_missing", WitnessFirst: &incomplete}); err == nil {
+		t.Fatal("proof-enforced packet accepted missing baseline")
 	}
 }

--- a/internal/witnessprocess/testdata/cost.json
+++ b/internal/witnessprocess/testdata/cost.json
@@ -1,0 +1,9 @@
+{
+  "envelope": "provider model cache state and fixed trace",
+  "promotion_gate": "quality holds and billed tokens fall end-to-end",
+  "context": "cost-token",
+  "durable_witness": "usage regression fixture",
+  "lever": "change one compaction threshold",
+  "baseline_artifact": "net-true usage receipt",
+  "candidate_artifact": "candidate net-true usage receipt"
+}

--- a/internal/witnessprocess/testdata/logic.json
+++ b/internal/witnessprocess/testdata/logic.json
@@ -1,0 +1,9 @@
+{
+  "envelope": "parser input and deterministic Go environment",
+  "promotion_gate": "go test ./internal/parser",
+  "context": "logic-correctness",
+  "durable_witness": "table-driven regression",
+  "lever": "change token boundary only",
+  "baseline_artifact": "failing table case",
+  "candidate_artifact": "passing table case"
+}

--- a/internal/witnessprocess/testdata/native-performance.json
+++ b/internal/witnessprocess/testdata/native-performance.json
@@ -1,0 +1,9 @@
+{
+  "envelope": "fak-native engine model L4 prompt and quality",
+  "promotion_gate": "quality holds and net throughput improves",
+  "context": "native-performance",
+  "durable_witness": "native benchmark regression",
+  "lever": "change one kernel tile",
+  "baseline_artifact": "native benchmark receipt",
+  "candidate_artifact": "matched native candidate receipt"
+}

--- a/internal/witnessprocess/testdata/reliability.json
+++ b/internal/witnessprocess/testdata/reliability.json
@@ -1,0 +1,9 @@
+{
+  "envelope": "30 minute soak with dependency fault",
+  "promotion_gate": "recovery SLO passes with retry cost counted",
+  "context": "reliability-operations",
+  "durable_witness": "deterministic fault test",
+  "lever": "bound one retry interval",
+  "baseline_artifact": "fault and recovery timeline",
+  "candidate_artifact": "candidate soak receipt"
+}

--- a/internal/witnessprocess/testdata/security.json
+++ b/internal/witnessprocess/testdata/security.json
@@ -1,0 +1,9 @@
+{
+  "envelope": "readonly policy and refund tool call",
+  "promotion_gate": "policy check and attest pass",
+  "context": "security-policy",
+  "durable_witness": "policy fixture regression",
+  "lever": "tighten one argument constraint",
+  "baseline_artifact": "preflight receipt showing structural escape",
+  "candidate_artifact": "deny and allow preflight receipts"
+}

--- a/internal/witnessprocess/testdata/visual.json
+++ b/internal/witnessprocess/testdata/visual.json
@@ -1,0 +1,9 @@
+{
+  "envelope": "80x24 terminal and issue pane",
+  "promotion_gate": "render witness has zero spill bytes",
+  "context": "tui-visual",
+  "durable_witness": "render-witness test and before/after screenshot",
+  "lever": "clip one status row",
+  "baseline_artifact": "captured corrupt render",
+  "candidate_artifact": "captured clean render"
+}

--- a/internal/witnessprocess/witnessprocess.go
+++ b/internal/witnessprocess/witnessprocess.go
@@ -1,0 +1,152 @@
+// Package witnessprocess defines the witness-first contract shared by issue and worker packets.
+package witnessprocess
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type Context string
+
+const (
+	Logic             Context = "logic-correctness"
+	Visual            Context = "tui-visual"
+	Security          Context = "security-policy"
+	Reliability       Context = "reliability-operations"
+	Cost              Context = "cost-token"
+	NativePerformance Context = "native-performance"
+)
+
+type Policy string
+
+const (
+	Warn    Policy = "warn"
+	Enforce Policy = "enforce"
+)
+
+type Exception string
+
+const (
+	NoException         Exception = ""
+	ReadOnlyTriage      Exception = "read-only-triage"
+	TrivialChange       Exception = "trivial-change"
+	UrgentResponse      Exception = "urgent-safety-outage"
+	ExternalUnavailable Exception = "external-system-unavailable"
+)
+
+type NegativeResult struct {
+	Lever     string `json:"lever"`
+	Artifact  string `json:"artifact"`
+	Falsifier string `json:"falsifier"`
+}
+
+type Block struct {
+	Context           Context          `json:"context"`
+	Envelope          string           `json:"envelope,omitempty"`
+	BaselineArtifact  string           `json:"baseline_artifact,omitempty"`
+	Lever             string           `json:"lever,omitempty"`
+	CandidateArtifact string           `json:"candidate_artifact,omitempty"`
+	PromotionGate     string           `json:"promotion_gate,omitempty"`
+	DurableWitness    string           `json:"durable_witness,omitempty"`
+	Policy            Policy           `json:"policy,omitempty"`
+	Exception         Exception        `json:"exception,omitempty"`
+	ExceptionReason   string           `json:"exception_reason,omitempty"`
+	NegativeResults   []NegativeResult `json:"negative_results,omitempty"`
+}
+
+type Adapter struct {
+	Context            Context `json:"context"`
+	EnvelopePrompt     string  `json:"envelope_prompt"`
+	BaselineClass      string  `json:"baseline_artifact_class"`
+	CandidateClass     string  `json:"candidate_artifact_class"`
+	PromotionPrimitive string  `json:"promotion_primitive"`
+	DurablePrimitive   string  `json:"durable_witness_primitive"`
+}
+
+var adapters = map[Context]Adapter{
+	Logic:             {Logic, "inputs, expected behavior, and deterministic environment", "failing behavior repro", "passing behavior repro", "focused Go test", "regression test"},
+	Visual:            {Visual, "terminal dimensions, renderer, and interaction state", "captured failing render", "captured corrected render", "render-witness assertion", "render-witness test and, for live UI, before/after screenshot"},
+	Security:          {Security, "policy, capability set, tool call, and adversary input", "denied/allowed preflight or red-team receipt", "candidate preflight or red-team receipt", "policy/attestation gate", "policy fixture or red-team regression"},
+	Reliability:       {Reliability, "load, duration, dependencies, and operating envelope", "failure/incident or soak artifact", "candidate soak/operation artifact", "end-to-end reliability SLO including recovery cost", "deterministic fault test or bounded soak witness"},
+	Cost:              {Cost, "provider/model, cache state, workload, and accounting boundary", "net-true usage receipt", "candidate net-true usage receipt", "quality-constrained end-to-end cost/token gate", "usage fixture or benchmark regression"},
+	NativePerformance: {NativePerformance, "native engine, model, hardware, workload, quality, and accounting envelope", "native baseline benchmark receipt", "native candidate benchmark receipt", "matched-envelope quality-constrained net performance gate", "native benchmark/receipt regression"},
+}
+
+func AdapterFor(context Context) (Adapter, bool) { a, ok := adapters[context]; return a, ok }
+
+func Contexts() []Context {
+	return []Context{Logic, Visual, Security, Reliability, Cost, NativePerformance}
+}
+
+func (b Block) Validate() (warnings []string, err error) {
+	if b.Exception != NoException {
+		if !validException(b.Exception) {
+			return nil, fmt.Errorf("unknown witness-first exception %q", b.Exception)
+		}
+		if strings.TrimSpace(b.ExceptionReason) == "" {
+			return nil, errors.New("witness-first exception requires a reason")
+		}
+		return nil, nil
+	}
+	if _, ok := AdapterFor(b.Context); !ok {
+		return nil, fmt.Errorf("unknown witness-first context %q", b.Context)
+	}
+	var missing []string
+	for name, value := range map[string]string{
+		"context/envelope": b.Envelope, "baseline artifact": b.BaselineArtifact,
+		"one declared lever": b.Lever, "candidate artifact": b.CandidateArtifact,
+		"promotion gate": b.PromotionGate, "durable witness": b.DurableWitness,
+	} {
+		if strings.TrimSpace(value) == "" {
+			missing = append(missing, name)
+		}
+	}
+	// Stable field order for packets and fixtures.
+	ordered := []string{"context/envelope", "baseline artifact", "one declared lever", "candidate artifact", "promotion gate", "durable witness"}
+	missing = missing[:0]
+	values := map[string]string{"context/envelope": b.Envelope, "baseline artifact": b.BaselineArtifact, "one declared lever": b.Lever, "candidate artifact": b.CandidateArtifact, "promotion gate": b.PromotionGate, "durable witness": b.DurableWitness}
+	for _, name := range ordered {
+		if strings.TrimSpace(values[name]) == "" {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) == 0 {
+		return nil, nil
+	}
+	message := "witness-first block missing " + strings.Join(missing, ", ")
+	if b.Policy == Enforce {
+		return nil, errors.New(message)
+	}
+	return []string{message}, nil
+}
+
+func validException(e Exception) bool {
+	return e == ReadOnlyTriage || e == TrivialChange || e == UrgentResponse || e == ExternalUnavailable
+}
+
+func (b Block) RenderMarkdown() (string, error) {
+	warnings, err := b.Validate()
+	if err != nil {
+		return "", err
+	}
+	if b.Exception != NoException {
+		return fmt.Sprintf("### Witness-first contract\n\n- **Exception:** `%s` — %s\n", b.Exception, strings.TrimSpace(b.ExceptionReason)), nil
+	}
+	a, _ := AdapterFor(b.Context)
+	var out strings.Builder
+	fmt.Fprintf(&out, "### Witness-first contract — %s\n\n", b.Context)
+	fmt.Fprintf(&out, "- **Context / envelope** (%s): %s\n", a.EnvelopePrompt, b.Envelope)
+	fmt.Fprintf(&out, "- **Baseline artifact** (%s): %s\n", a.BaselineClass, b.BaselineArtifact)
+	fmt.Fprintf(&out, "- **One declared lever:** %s\n", b.Lever)
+	fmt.Fprintf(&out, "- **Candidate artifact** (%s): %s\n", a.CandidateClass, b.CandidateArtifact)
+	fmt.Fprintf(&out, "- **Promotion gate** (%s): %s\n", a.PromotionPrimitive, b.PromotionGate)
+	fmt.Fprintf(&out, "- **Durable witness** (%s): %s\n", a.DurablePrimitive, b.DurableWitness)
+	for _, n := range b.NegativeResults {
+		fmt.Fprintf(&out, "- **Rejected lever:** %s — artifact: %s; falsifier: %s\n", n.Lever, n.Artifact, n.Falsifier)
+	}
+	for _, warning := range warnings {
+		fmt.Fprintf(&out, "- **Warning:** %s\n", warning)
+	}
+	return out.String(), nil
+}

--- a/internal/witnessprocess/witnessprocess_test.go
+++ b/internal/witnessprocess/witnessprocess_test.go
@@ -1,0 +1,120 @@
+package witnessprocess
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func completeBlock(context Context) Block {
+	return Block{Context: context, Envelope: "pinned envelope", BaselineArtifact: "baseline.ref", Lever: "one controlled change", CandidateArtifact: "candidate.ref", PromotionGate: "gate command and threshold", DurableWitness: "regression fixture"}
+}
+
+func TestAdaptersRequestContextSpecificArtifactClasses(t *testing.T) {
+	wants := map[Context][]string{
+		Logic:             {"failing behavior repro", "focused Go test", "regression test"},
+		Visual:            {"captured failing render", "render-witness assertion", "before/after screenshot"},
+		Security:          {"preflight or red-team receipt", "policy/attestation gate", "policy fixture"},
+		Reliability:       {"soak artifact", "including recovery cost", "fault test"},
+		Cost:              {"net-true usage receipt", "quality-constrained end-to-end", "usage fixture"},
+		NativePerformance: {"native baseline benchmark receipt", "matched-envelope", "native benchmark/receipt"},
+	}
+	for _, context := range Contexts() {
+		t.Run(string(context), func(t *testing.T) {
+			adapter, ok := AdapterFor(context)
+			if !ok {
+				t.Fatal("adapter missing")
+			}
+			raw, _ := json.Marshal(adapter)
+			for _, want := range wants[context] {
+				if !strings.Contains(string(raw), want) {
+					t.Errorf("adapter %s missing %q: %s", context, want, raw)
+				}
+			}
+		})
+	}
+}
+
+func TestEnforcedLaneRejectsMissingBaselineOrPromotionGate(t *testing.T) {
+	for _, field := range []string{"baseline", "promotion"} {
+		block := completeBlock(Logic)
+		block.Policy = Enforce
+		if field == "baseline" {
+			block.BaselineArtifact = ""
+		} else {
+			block.PromotionGate = ""
+		}
+		if _, err := block.Validate(); err == nil || !strings.Contains(err.Error(), field) {
+			t.Fatalf("%s: err=%v", field, err)
+		}
+	}
+}
+
+func TestDefaultLaneWarnsBeforeDispatch(t *testing.T) {
+	block := completeBlock(Security)
+	block.BaselineArtifact = ""
+	warnings, err := block.Validate()
+	if err != nil || len(warnings) != 1 || !strings.Contains(warnings[0], "baseline artifact") {
+		t.Fatalf("warnings=%v err=%v", warnings, err)
+	}
+}
+
+func TestDocumentedExceptionsBypassArtifactRequirements(t *testing.T) {
+	for _, exception := range []Exception{ReadOnlyTriage, TrivialChange, UrgentResponse, ExternalUnavailable} {
+		t.Run(string(exception), func(t *testing.T) {
+			block := Block{Policy: Enforce, Exception: exception, ExceptionReason: "documented constraint"}
+			if _, err := block.Validate(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestNegativeResultRendersRejectedLever(t *testing.T) {
+	block := completeBlock(Reliability)
+	block.NegativeResults = []NegativeResult{{Lever: "retry interval", Artifact: "soak-17.json", Falsifier: "p99 recovery regressed"}}
+	got, err := block.RenderMarkdown()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"Rejected lever", "retry interval", "soak-17.json", "p99 recovery regressed"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q", want)
+		}
+	}
+}
+
+func TestDogfoodIssueRenders(t *testing.T) {
+	entries, err := os.ReadDir("testdata")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != len(Contexts()) {
+		t.Fatalf("dogfood fixtures=%d want=%d", len(entries), len(Contexts()))
+	}
+	for _, entry := range entries {
+		data, err := os.ReadFile(filepath.Join("testdata", entry.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var block Block
+		if err := json.Unmarshal(data, &block); err != nil {
+			t.Fatal(err)
+		}
+		got, err := block.RenderMarkdown()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(got, string(block.Context)) {
+			t.Fatalf("%s missing context", entry.Name())
+		}
+		if block.Context != NativePerformance && strings.Contains(strings.ToLower(got), "gpu receipt") {
+			t.Fatalf("%s gained irrelevant GPU field", entry.Name())
+		}
+		if block.Context != Cost && block.Context != Reliability && block.Context != NativePerformance && strings.Contains(strings.ToLower(got), "net-true") {
+			t.Fatalf("%s gained irrelevant performance field", entry.Name())
+		}
+	}
+}


### PR DESCRIPTION
Closes #8764.

Independent witness:
- go test ./internal/witnessprocess ./internal/orchestration ./internal/taskmgr ./internal/architest -run 'Witness|Packet|Contract|IssueTemplate|TaskText' -count=1 -timeout=60s
- git diff HEAD^..HEAD --check

Current-trunk resolution preserves fast-plan and adaptive-width fields while adding typed witness-first blocks to issue templates, orchestration/task packets, and task completion enforcement.