### PR TITLE
feat(fastintent): implement portable latency receipt #8959

### DIFF
--- a/internal/architest/architest_test.go
+++ b/internal/architest/architest_test.go
@@ -482,6 +482,7 @@ var tier = map[string]int{
 	"portability":         1, // personal-continuity discovery/export/apply/switch/rollback leaf; stdlib-only, imports nothing internal, off the hot path.
 	"ociartifact":         2, // activation-neutral OCI collection transport and MCP metadata bridge
 	"portabilityswitch":   2, // context-switch transaction coordinator; composes lifecycle/processforest authorities, off the hot path.
+	"fastintent":          3, // joins tier-2 orchestration, provider-tier, and benchmark receipts into one portable replay; off the serving hot path.
 	"orchestration":       2, // pure portable workflow-plan/profile resolution contract; stdlib-only, no provider adapters, off the hot path.
 	"ultracodebench":      2, // pure paired-run fold and verdict contract; stdlib-only, off the serving hot path.
 	"devexmeter":          1, // pure dev-ex friction meter + RSI close gate; stdlib-only, off the hot path.

--- a/internal/fastintent/fastintent.go
+++ b/internal/fastintent/fastintent.go
@@ -1,0 +1,73 @@
+// Package fastintent joins the latency-intent plan, provider readback, and
+// quality-constrained evaluator into one replayable receipt.
+package fastintent
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	"github.com/anthony-chaudhary/fak/internal/modelroute"
+	"github.com/anthony-chaudhary/fak/internal/orchestration"
+	"github.com/anthony-chaudhary/fak/internal/ultracodebench"
+)
+
+const Schema = "fak-fast-intent-replay/1"
+
+type ProviderRealization struct {
+	Provider string                        `json:"provider"`
+	Receipt  modelroute.ServiceTierReceipt `json:"receipt"`
+}
+
+type ReplayBundle struct {
+	Schema         string                           `json:"schema"`
+	Plan           orchestration.FastExecutionPlan  `json:"plan"`
+	Providers      []ProviderRealization            `json:"providers"`
+	Evaluation     ultracodebench.FastProfileReport `json:"evaluation"`
+	Verdict        string                           `json:"verdict"`
+	EvidenceDigest string                           `json:"evidence_digest"`
+}
+
+// Join accepts only realized provider outcomes and a quality-constrained paired
+// evaluation. It never upgrades an abstention or hides a tier downgrade.
+func Join(plan orchestration.FastExecutionPlan, providers []ProviderRealization, evaluation ultracodebench.FastProfileReport) (ReplayBundle, error) {
+	r := ReplayBundle{Schema: Schema, Plan: plan, Providers: append([]ProviderRealization(nil), providers...), Evaluation: evaluation, Verdict: evaluation.Verdict}
+	if plan.Schema != orchestration.FastIntentSchemaVersion || plan.Requested.QualityFloor == "" {
+		return r, fmt.Errorf("fast intent: valid plan and quality floor required")
+	}
+	if len(providers) < 2 {
+		return r, fmt.Errorf("fast intent: at least two provider realizations required")
+	}
+	seen := map[string]bool{}
+	for _, p := range providers {
+		if p.Provider == "" || seen[p.Provider] {
+			return r, fmt.Errorf("fast intent: providers must be named and unique")
+		}
+		seen[p.Provider] = true
+		q := p.Receipt
+		if q.Realized == modelroute.ServiceModeUnknown {
+			return r, fmt.Errorf("fast intent: %s has no realized tier", p.Provider)
+		}
+		if q.Requested != q.Realized && q.DowngradeReason == "" {
+			return r, fmt.Errorf("fast intent: %s silently downgraded", p.Provider)
+		}
+	}
+	if evaluation.Schema != ultracodebench.FastProfileSchema || evaluation.BundleDigest == "" {
+		return r, fmt.Errorf("fast intent: replayable quality evaluation required")
+	}
+	switch evaluation.Verdict {
+	case "GAIN", "NO_GAIN", "ABSTAIN":
+	default:
+		return r, fmt.Errorf("fast intent: invalid evaluator verdict %q", evaluation.Verdict)
+	}
+	canonical := r
+	canonical.EvidenceDigest = ""
+	b, err := json.Marshal(canonical)
+	if err != nil {
+		return r, err
+	}
+	sum := sha256.Sum256(b)
+	r.EvidenceDigest = "sha256:" + hex.EncodeToString(sum[:])
+	return r, nil
+}

--- a/internal/fastintent/fastintent_test.go
+++ b/internal/fastintent/fastintent_test.go
@@ -1,0 +1,90 @@
+package fastintent
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/anthony-chaudhary/fak/internal/modelroute"
+	"github.com/anthony-chaudhary/fak/internal/orchestration"
+	"github.com/anthony-chaudhary/fak/internal/ultracodebench"
+)
+
+func fixture(t *testing.T) (orchestration.FastExecutionPlan, []ProviderRealization, ultracodebench.FastProfileReport) {
+	t.Helper()
+	var plan orchestration.FastExecutionPlan
+	b, err := os.ReadFile("../orchestration/testdata/fast-claude.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var task orchestration.TaskSpec
+	if err := json.Unmarshal(b, &task); err != nil {
+		t.Fatal(err)
+	}
+	res, err := orchestration.Resolve(orchestration.OrchestrationProfile{Name: orchestration.ProfileFast}, task, orchestration.HarnessCapabilities{Concurrency: orchestration.SupportNative, TaskMessaging: orchestration.SupportNative, Cancellation: orchestration.SupportNative, Leases: orchestration.SupportNative, IndependentWitness: orchestration.SupportNative, ClaudeSpeed: orchestration.SupportNative})
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan = *res.Resolved.Fast
+
+	mk := func(provider string, realized modelroute.ServiceMode, rewarm int64) ProviderRealization {
+		c, _ := modelroute.LookupProviderContract(provider)
+		_, r, err := modelroute.BindServiceTier(c, modelroute.ServiceTierRequest{Mode: modelroute.ServiceModeFast, Policy: modelroute.ServiceAllowDeclaredDowngrade})
+		if err != nil {
+			t.Fatal(err)
+		}
+		r, err = modelroute.RealizeServiceTier(r, realized, rewarm)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return ProviderRealization{Provider: provider, Receipt: r}
+	}
+	raw, err := os.ReadFile("../ultracodebench/testdata/issue8963-fast-profile-replay.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var input ultracodebench.FastProfileBundle
+	if err := json.Unmarshal(raw, &input); err != nil {
+		t.Fatal(err)
+	}
+	return plan, []ProviderRealization{mk("openai", modelroute.ServiceModeFast, 0), mk("anthropic", modelroute.ServiceModeStandard, 73)}, ultracodebench.EvaluateFastProfile(input)
+}
+
+func TestJoinDeterministicPortableReceipt(t *testing.T) {
+	plan, providers, evaluation := fixture(t)
+	a, err := Join(plan, providers, evaluation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := Join(plan, providers, evaluation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.EvidenceDigest != b.EvidenceDigest || a.EvidenceDigest == "" {
+		t.Fatalf("digests %q %q", a.EvidenceDigest, b.EvidenceDigest)
+	}
+	if a.Verdict != evaluation.Verdict || len(a.Providers) != 2 {
+		t.Fatalf("receipt %+v", a)
+	}
+	if a.Providers[1].Receipt.DowngradeReason == "" || !a.Providers[1].Receipt.CacheInvalidated {
+		t.Fatalf("downgrade hidden: %+v", a.Providers[1])
+	}
+}
+
+func TestJoinRejectsMissingQualityAndSilentFallback(t *testing.T) {
+	plan, providers, evaluation := fixture(t)
+	plan.Requested.QualityFloor = ""
+	if _, err := Join(plan, providers, evaluation); err == nil {
+		t.Fatal("missing quality accepted")
+	}
+	plan, providers, evaluation = fixture(t)
+	providers[1].Receipt.DowngradeReason = ""
+	if _, err := Join(plan, providers, evaluation); err == nil {
+		t.Fatal("silent fallback accepted")
+	}
+	plan, providers, evaluation = fixture(t)
+	evaluation.BundleDigest = ""
+	if _, err := Join(plan, providers, evaluation); err == nil {
+		t.Fatal("unreplayable evaluation accepted")
+	}
+}


### PR DESCRIPTION
Closes #8959.\n\nJoins the shipped fast execution plan, OpenAI/Anthropic-shaped requested-versus-realized service-tier receipts, and the paired quality-constrained evaluator into one deterministic replay receipt. Refuses missing quality floors, unrealized tiers, silent downgrades, and unreplayable evaluator evidence.\n\nEvidence: ak validate --mine internal/fastintent/fastintent.go internal/fastintent/fastintent_test.go internal/architest/architest_test.go passed build, vet, and affected tests; focused package tests passed for orchestration, modelroute, ultracodebench, fastintent, and the architest tier declaration.