### PR TITLE
feat(trajectory): add bounded unknown exemplars (#9563)

### DIFF
--- a/internal/trajectory/audit.go
+++ b/internal/trajectory/audit.go
@@ -97,30 +97,33 @@ type AuditDenominatorRow struct {
 
 // AuditTranscriptRow is one queryable, content-free transcript rollup.
 type AuditTranscriptRow struct {
-	Schema               string                 `json:"schema"`
-	Kind                 string                 `json:"kind"`
-	Source               string                 `json:"source"`
-	TranscriptID         string                 `json:"session_id"`
-	SourcePath           string                 `json:"source_path"`
-	Models               []string               `json:"models"`
-	BuildIdentities      []AuditBuildIdentity   `json:"build_identities"`
-	Tokens               AuditTokens            `json:"tokens"`
-	ToolCalls            int                    `json:"tool_calls"`
-	ToolErrors           int                    `json:"tool_errors"`
-	Distribution         []AuditDistributionRow `json:"distribution,omitempty"`
-	ToolDistribution     []AuditDistributionRow `json:"tool_distribution,omitempty"`
-	ToolResults          []AuditToolResultRow   `json:"tool_results,omitempty"`
-	StorageDistribution  []AuditStorageRow      `json:"storage_distribution,omitempty"`
-	RepeatedFailures     int                    `json:"repeated_failures"`
-	ExpectedWaitTimeouts int                    `json:"expected_wait_timeouts"`
-	MutationChurn        int                    `json:"mutation_churn"`
-	MutationChurnEvents  []QwenMutationChurn    `json:"mutation_churn_events,omitempty"`
-	HookP95MS            *int64                 `json:"hook_p95_ms"`
-	UsageRecords         int                    `json:"usage_records"`
-	SourcePaths          []string               `json:"source_paths,omitempty"`
+	Schema               string                        `json:"schema"`
+	Kind                 string                        `json:"kind"`
+	Source               string                        `json:"source"`
+	TranscriptID         string                        `json:"session_id"`
+	SourcePath           string                        `json:"source_path"`
+	Models               []string                      `json:"models"`
+	BuildIdentities      []AuditBuildIdentity          `json:"build_identities"`
+	Tokens               AuditTokens                   `json:"tokens"`
+	ToolCalls            int                           `json:"tool_calls"`
+	ToolErrors           int                           `json:"tool_errors"`
+	Distribution         []AuditDistributionRow        `json:"distribution,omitempty"`
+	ToolDistribution     []AuditDistributionRow        `json:"tool_distribution,omitempty"`
+	ToolResults          []AuditToolResultRow          `json:"tool_results,omitempty"`
+	StorageDistribution  []AuditStorageRow             `json:"storage_distribution,omitempty"`
+	UnknownExemplars     AuditUnknownExemplarReservoir `json:"unknown_exemplars"`
+	RepeatedFailures     int                           `json:"repeated_failures"`
+	ExpectedWaitTimeouts int                           `json:"expected_wait_timeouts"`
+	MutationChurn        int                           `json:"mutation_churn"`
+	MutationChurnEvents  []QwenMutationChurn           `json:"mutation_churn_events,omitempty"`
+	HookP95MS            *int64                        `json:"hook_p95_ms"`
+	UsageRecords         int                           `json:"usage_records"`
+	SourcePaths          []string                      `json:"source_paths,omitempty"`
 	usageByID            map[string]AuditTokens
 	failureCounts        map[string]int
 	schemaShapes         map[string]auditShapeSet
+	fragmentDigest       string
+	fragmentDigests      map[string]struct{}
 }
 
 // AuditBottleneckRow ranks sessions by exact accounted tokens. DominantBucket
@@ -140,49 +143,50 @@ type AuditBottleneckRow struct {
 
 // AuditSummaryRow is the machine-wide exact rollup and baseline input.
 type AuditSummaryRow struct {
-	Schema                              string                 `json:"schema"`
-	Kind                                string                 `json:"kind"`
-	Sources                             int                    `json:"sources"`
-	Transcripts                         int                    `json:"sessions"`
-	RawFragments                        int                    `json:"raw_fragments"`
-	CanonicalTranscripts                int                    `json:"canonical_transcripts"`
-	FilesDiscovered                     int                    `json:"files_discovered"`
-	FilesScanned                        int                    `json:"files_scanned"`
-	FixtureFilesExcluded                int                    `json:"fixture_files_excluded"`
-	FilesMatched                        int                    `json:"files_matched,omitempty"`
-	Records                             int                    `json:"records"`
-	UsageRecordsExact                   int                    `json:"usage_records_exact"`
-	RefusedRecords                      int                    `json:"refused_records"`
-	Tokens                              AuditTokens            `json:"tokens"`
-	InputOutputRatio                    *float64               `json:"input_output_ratio"`
-	PromptWriteFraction                 *float64               `json:"prompt_write_fraction"`
-	RepeatedFailures                    int                    `json:"repeated_failures"`
-	RepeatedFailuresPerSession          *float64               `json:"repeated_failures_per_session"`
-	RepeatedFailureSemantics            string                 `json:"repeated_failure_semantics"`
-	RepeatedFailureNormalization        string                 `json:"repeated_failure_normalization"`
-	ExpectedWaitTimeouts                int                    `json:"expected_wait_timeouts"`
-	MutationChurn                       int                    `json:"mutation_churn"`
-	HookP95MS                           *int64                 `json:"hook_p95_ms"`
-	DistinctTranscripts                 int                    `json:"distinct_transcripts"`
-	DuplicateFragments                  int                    `json:"duplicate_fragments"`
-	EmptyUsageFiles                     int                    `json:"empty_usage_files"`
-	ToolCalls                           int                    `json:"tool_calls"`
-	ToolErrors                          int                    `json:"tool_errors"`
-	DistributionUnit                    string                 `json:"distribution_unit"`
-	DistributionProvenance              string                 `json:"distribution_provenance"`
-	Distribution                        []AuditDistributionRow `json:"distribution,omitempty"`
-	ToolDistribution                    []AuditDistributionRow `json:"tool_distribution,omitempty"`
-	ToolResults                         []AuditToolResultRow   `json:"tool_results,omitempty"`
-	StorageUnit                         string                 `json:"storage_unit"`
-	StorageDistribution                 []AuditStorageRow      `json:"storage_distribution,omitempty"`
-	ToolErrorFraction                   *float64               `json:"tool_error_fraction"`
-	TopTenTokenFraction                 *float64               `json:"top_ten_token_fraction"`
-	QwenTopContributor                  *string                `json:"qwen_top_contributor"`
-	QwenTopContributorTokens            *int64                 `json:"qwen_top_contributor_tokens"`
-	QwenTotalTokens                     *int64                 `json:"qwen_total_tokens"`
-	QwenTopContributorTokenFraction     *float64               `json:"qwen_top_contributor_token_fraction"`
-	QwenTokenConcentrationThreshold     float64                `json:"qwen_token_concentration_threshold"`
-	QwenTopContributorTokenConcentrated *bool                  `json:"qwen_top_contributor_token_concentrated"`
+	Schema                              string                        `json:"schema"`
+	Kind                                string                        `json:"kind"`
+	Sources                             int                           `json:"sources"`
+	Transcripts                         int                           `json:"sessions"`
+	RawFragments                        int                           `json:"raw_fragments"`
+	CanonicalTranscripts                int                           `json:"canonical_transcripts"`
+	FilesDiscovered                     int                           `json:"files_discovered"`
+	FilesScanned                        int                           `json:"files_scanned"`
+	FixtureFilesExcluded                int                           `json:"fixture_files_excluded"`
+	FilesMatched                        int                           `json:"files_matched,omitempty"`
+	Records                             int                           `json:"records"`
+	UsageRecordsExact                   int                           `json:"usage_records_exact"`
+	RefusedRecords                      int                           `json:"refused_records"`
+	Tokens                              AuditTokens                   `json:"tokens"`
+	InputOutputRatio                    *float64                      `json:"input_output_ratio"`
+	PromptWriteFraction                 *float64                      `json:"prompt_write_fraction"`
+	RepeatedFailures                    int                           `json:"repeated_failures"`
+	RepeatedFailuresPerSession          *float64                      `json:"repeated_failures_per_session"`
+	RepeatedFailureSemantics            string                        `json:"repeated_failure_semantics"`
+	RepeatedFailureNormalization        string                        `json:"repeated_failure_normalization"`
+	ExpectedWaitTimeouts                int                           `json:"expected_wait_timeouts"`
+	MutationChurn                       int                           `json:"mutation_churn"`
+	HookP95MS                           *int64                        `json:"hook_p95_ms"`
+	DistinctTranscripts                 int                           `json:"distinct_transcripts"`
+	DuplicateFragments                  int                           `json:"duplicate_fragments"`
+	EmptyUsageFiles                     int                           `json:"empty_usage_files"`
+	ToolCalls                           int                           `json:"tool_calls"`
+	ToolErrors                          int                           `json:"tool_errors"`
+	DistributionUnit                    string                        `json:"distribution_unit"`
+	DistributionProvenance              string                        `json:"distribution_provenance"`
+	Distribution                        []AuditDistributionRow        `json:"distribution,omitempty"`
+	ToolDistribution                    []AuditDistributionRow        `json:"tool_distribution,omitempty"`
+	ToolResults                         []AuditToolResultRow          `json:"tool_results,omitempty"`
+	StorageUnit                         string                        `json:"storage_unit"`
+	StorageDistribution                 []AuditStorageRow             `json:"storage_distribution,omitempty"`
+	UnknownExemplars                    AuditUnknownExemplarReservoir `json:"unknown_exemplars"`
+	ToolErrorFraction                   *float64                      `json:"tool_error_fraction"`
+	TopTenTokenFraction                 *float64                      `json:"top_ten_token_fraction"`
+	QwenTopContributor                  *string                       `json:"qwen_top_contributor"`
+	QwenTopContributorTokens            *int64                        `json:"qwen_top_contributor_tokens"`
+	QwenTotalTokens                     *int64                        `json:"qwen_total_tokens"`
+	QwenTopContributorTokenFraction     *float64                      `json:"qwen_top_contributor_token_fraction"`
+	QwenTokenConcentrationThreshold     float64                       `json:"qwen_token_concentration_threshold"`
+	QwenTopContributorTokenConcentrated *bool                         `json:"qwen_top_contributor_token_concentrated"`
 }
 
 // AuditDeltaRow compares one higher-is-worse metric with a prior summary.
@@ -408,6 +412,11 @@ func auditSource(source AuditSource, opts AuditOptions) (AuditDenominatorRow, []
 	var refusals []AuditRefusalRow
 	var hookDurations []int64
 	var toolErrorEvents []QwenToolErrorEvent
+	// Canonical merging still receives every row so duplicate-usage conflicts
+	// remain visible. These file-derived side channels have no canonical row
+	// representation, so deduplicate them here by the same transcript identity
+	// and exact fragment digest used by canonicalAuditTranscripts.
+	sideChannelFragments := map[string]struct{}{}
 	for _, path := range files {
 		if opts.Since > 0 {
 			stat, statErr := os.Stat(path)
@@ -444,8 +453,16 @@ func auditSource(source AuditSource, opts AuditOptions) (AuditDenominatorRow, []
 		denominator.FilesScanned++
 		transcripts = append(transcripts, row)
 		refusals = append(refusals, fileRefusals...)
-		hookDurations = append(hookDurations, fileHooks...)
-		toolErrorEvents = append(toolErrorEvents, fileToolErrors...)
+		sideChannelKey := row.TranscriptID + "\x00" + row.fragmentDigest
+		_, duplicateFragment := sideChannelFragments[sideChannelKey]
+		duplicateFragment = duplicateFragment && row.fragmentDigest != ""
+		if !duplicateFragment {
+			hookDurations = append(hookDurations, fileHooks...)
+			toolErrorEvents = append(toolErrorEvents, fileToolErrors...)
+			if row.fragmentDigest != "" {
+				sideChannelFragments[sideChannelKey] = struct{}{}
+			}
+		}
 	}
 	return denominator, transcripts, refusals, hookDurations, toolErrorEvents, nil
 }
@@ -515,6 +532,7 @@ func summarizeAudit(denominators []AuditDenominatorRow, transcripts []AuditTrans
 	toolTotals := map[string]*AuditDistributionRow{}
 	var toolResultGroups [][]AuditToolResultRow
 	storageTotals := map[string]*AuditStorageRow{}
+	exemplars := newDefaultAuditUnknownExemplarReservoir()
 	for _, transcript := range transcripts {
 		summary.Tokens.add(transcript.Tokens)
 		summary.RepeatedFailures += transcript.RepeatedFailures
@@ -522,6 +540,7 @@ func summarizeAudit(denominators []AuditDenominatorRow, transcripts []AuditTrans
 		summary.MutationChurn += transcript.MutationChurn
 		summary.ToolCalls += transcript.ToolCalls
 		summary.ToolErrors += transcript.ToolErrors
+		exemplars.merge(transcript.UnknownExemplars)
 		for _, r := range transcript.Distribution {
 			categoryTotals[r.Name] += r.Bytes
 		}
@@ -598,6 +617,8 @@ func summarizeAudit(denominators []AuditDenominatorRow, transcripts []AuditTrans
 	summary.ToolResults = mergeAuditToolResultRows(toolResultGroups...)
 	summary.StorageUnit = AuditStorageUnit
 	summary.StorageDistribution = storageDistributionRows(storageTotals)
+	summary.UnknownExemplars = exemplars.snapshot()
+	linkAuditUnknownExemplars(summary.Distribution, summary.StorageDistribution, summary.UnknownExemplars.Exemplars)
 	summary.DistinctTranscripts = len(transcriptIDs)
 	summary.DuplicateFragments = summary.Transcripts - summary.DistinctTranscripts
 	if summary.ToolCalls > 0 {

--- a/internal/trajectory/audit_canonical.go
+++ b/internal/trajectory/audit_canonical.go
@@ -18,11 +18,27 @@ func canonicalAuditTranscripts(raw []AuditTranscriptRow) ([]AuditTranscriptRow, 
 			copy.ToolResults = append([]AuditToolResultRow(nil), row.ToolResults...)
 			copy.usageByID = cloneAuditUsage(row.usageByID)
 			copy.failureCounts = cloneAuditFailureCounts(row.failureCounts)
+			copy.fragmentDigests = map[string]struct{}{}
+			if row.fragmentDigest != "" {
+				copy.fragmentDigests[row.fragmentDigest] = struct{}{}
+			}
 			byID[key] = &copy
 			continue
 		}
 		rollup.SourcePaths = append(rollup.SourcePaths, row.SourcePath)
 		rollup.Models = appendUniqueStrings(rollup.Models, row.Models...)
+		_, duplicateFragment := rollup.fragmentDigests[row.fragmentDigest]
+		duplicateFragment = duplicateFragment && row.fragmentDigest != ""
+		if !duplicateFragment {
+			rollup.Distribution = mergeAuditDistributionRows(rollup.Distribution, row.Distribution)
+			rollup.ToolDistribution = mergeAuditDistributionRows(rollup.ToolDistribution, row.ToolDistribution)
+			rollup.StorageDistribution = mergeAuditStorageRows(rollup.StorageDistribution, row.StorageDistribution)
+			rollup.UnknownExemplars = mergeAuditUnknownExemplarReservoirs(rollup.UnknownExemplars, row.UnknownExemplars)
+			linkAuditUnknownExemplars(rollup.Distribution, rollup.StorageDistribution, rollup.UnknownExemplars.Exemplars)
+			if row.fragmentDigest != "" {
+				rollup.fragmentDigests[row.fragmentDigest] = struct{}{}
+			}
+		}
 		if row.Source == AuditSourceClaude {
 			for id, usage := range row.usageByID {
 				if previous, exists := rollup.usageByID[id]; exists {
@@ -40,6 +56,9 @@ func canonicalAuditTranscripts(raw []AuditTranscriptRow) ([]AuditTranscriptRow, 
 			// provenance, not additive usage.
 		} else {
 			refusals = append(refusals, newAuditRefusal(row.Source, row.SourcePath, 0, "codex_fragment_usage_mismatch", "duplicate session id carries different cumulative usage"))
+		}
+		if duplicateFragment {
+			continue
 		}
 		rollup.ToolCalls += row.ToolCalls
 		rollup.ToolErrors += row.ToolErrors

--- a/internal/trajectory/audit_distribution.go
+++ b/internal/trajectory/audit_distribution.go
@@ -11,10 +11,11 @@ const AuditDistributionUnit = "utf8_content_bytes"
 const AuditStorageUnit = "utf8_serialized_bytes"
 
 type AuditDistributionRow struct {
-	Name  string  `json:"name"`
-	Bytes int64   `json:"bytes"`
-	Share float64 `json:"share"`
-	Calls int     `json:"calls,omitempty"`
+	Name        string   `json:"name"`
+	Bytes       int64    `json:"bytes"`
+	Share       float64  `json:"share"`
+	Calls       int      `json:"calls,omitempty"`
+	ExemplarIDs []string `json:"exemplar_ids,omitempty"`
 }
 type AuditToolResultRow struct {
 	Name           string `json:"name"`
@@ -38,11 +39,12 @@ type AuditToolResultRow struct {
 	ChannelUnknown int    `json:"channel_unknown,omitempty"`
 }
 type AuditStorageRow struct {
-	Source  string  `json:"source"`
-	Subtype string  `json:"subtype"`
-	Bytes   int64   `json:"bytes"`
-	Share   float64 `json:"share"`
-	Records int     `json:"records"`
+	Source      string   `json:"source"`
+	Subtype     string   `json:"subtype"`
+	Bytes       int64    `json:"bytes"`
+	Share       float64  `json:"share"`
+	Records     int      `json:"records"`
+	ExemplarIDs []string `json:"exemplar_ids,omitempty"`
 }
 type auditDistribution struct {
 	categories     map[string]int64
@@ -53,6 +55,7 @@ type auditDistribution struct {
 	resultCalls    map[string]auditResultCall
 	pendingResults map[string][]auditToolResult
 	storage        map[string]*AuditStorageRow
+	exemplars      *auditUnknownExemplarReservoir
 }
 
 type auditResultCall struct {
@@ -112,6 +115,7 @@ func newAuditDistribution() auditDistribution {
 		categories: map[string]int64{}, tools: map[string]*AuditDistributionRow{}, results: map[string]*AuditToolResultRow{},
 		callTools: map[string]string{}, pending: map[string]int64{}, resultCalls: map[string]auditResultCall{},
 		pendingResults: map[string][]auditToolResult{}, storage: map[string]*AuditStorageRow{},
+		exemplars: newDefaultAuditUnknownExemplarReservoir(),
 	}
 }
 
@@ -126,12 +130,25 @@ func (d *auditDistribution) observe(source string, line []byte) {
 		payload = root["message"]
 	}
 	d.observeToolResult(source, typ, payload)
+	persistedSource := auditUnknownSourceLabel(source)
 	for _, event := range classifyDistributionEvents(source, typ, payload, root) {
+		subtype := event.subtype
+		if event.visibility == "unresolved" {
+			// Unknown discriminator values are payload even when they resemble
+			// harmless identifiers. Persist only a known structural prefix plus
+			// an opaque stable hash of the classifier's ephemeral raw subtype.
+			subtype = auditOpaqueUnknownSubtype(source, typ, event.subtype)
+			visibility, aggregate, observedBytes := "visible_unknown", event.category, int64(len(event.content))
+			if !event.visible {
+				visibility, aggregate, observedBytes = "storage_unknown", subtype, int64(len(line))
+			}
+			d.exemplars.observe(persistedSource, subtype, visibility, aggregate, line, observedBytes)
+		}
 		if !event.visible {
-			key := source + "\x00" + event.subtype
+			key := persistedSource + "\x00" + subtype
 			row := d.storage[key]
 			if row == nil {
-				row = &AuditStorageRow{Source: source, Subtype: event.subtype}
+				row = &AuditStorageRow{Source: persistedSource, Subtype: subtype}
 				d.storage[key] = row
 			}
 			row.Bytes += int64(len(line))
@@ -139,6 +156,15 @@ func (d *auditDistribution) observe(source string, line []byte) {
 			continue
 		}
 		d.observeVisible(event.category, event.tool, event.id, int64(len(event.content)))
+	}
+}
+
+func auditUnknownSourceLabel(source string) string {
+	switch source {
+	case AuditSourceClaude, AuditSourceCodex:
+		return source
+	default:
+		return "source/" + auditUnknownDiscriminatorSuffix([]string{"source\x00" + source})
 	}
 }
 
@@ -171,6 +197,69 @@ func (d *auditDistribution) observeVisible(cat, tool, id string, weight int64) {
 			}
 		}
 	}
+}
+
+func (d *auditDistribution) distributionRows() []AuditDistributionRow {
+	rows := distributionRows(d.categories)
+	exemplars := d.exemplars.snapshot().Exemplars
+	for i := range rows {
+		name := rows[i].Name
+		rows[i].ExemplarIDs = auditExemplarIDs(exemplars, func(exemplar AuditUnknownExemplar) bool {
+			return exemplar.Visibility == "visible_unknown" && exemplar.Aggregate == name
+		})
+	}
+	return rows
+}
+
+func (d *auditDistribution) storageRows() []AuditStorageRow {
+	rows := storageDistributionRows(d.storage)
+	exemplars := d.exemplars.snapshot().Exemplars
+	for i := range rows {
+		source, subtype := rows[i].Source, rows[i].Subtype
+		rows[i].ExemplarIDs = auditExemplarIDs(exemplars, func(exemplar AuditUnknownExemplar) bool {
+			return exemplar.Visibility == "storage_unknown" && exemplar.Source == auditScrubExemplarLabel(source) && exemplar.Subtype == auditScrubExemplarLabel(subtype)
+		})
+	}
+	return rows
+}
+
+func auditKnownClaudeAttachmentSubtype(subtype string) bool {
+	if subtype == "deferred_tools_delta" {
+		return true
+	}
+	if !strings.HasPrefix(subtype, "hook_") || len(subtype) > 64 || len(subtype) == len("hook_") {
+		return false
+	}
+	for _, char := range subtype[len("hook_"):] {
+		if (char < 'a' || char > 'z') && (char < '0' || char > '9') && char != '_' {
+			return false
+		}
+	}
+	return true
+}
+
+func auditOpaqueUnknownSubtype(source, typ, rawSubtype string) string {
+	prefix := "record"
+	switch source {
+	case AuditSourceCodex:
+		switch typ {
+		case "response_item":
+			prefix = "response_item"
+		case "event_msg":
+			prefix = "event_msg"
+			if strings.HasPrefix(rawSubtype, "event_msg/item_started/") {
+				prefix = "event_msg/item_started"
+			} else if strings.HasPrefix(rawSubtype, "event_msg/item_completed/") {
+				prefix = "event_msg/item_completed"
+			}
+		}
+	case AuditSourceClaude:
+		switch typ {
+		case "assistant", "attachment", "user":
+			prefix = typ
+		}
+	}
+	return prefix + "/" + auditUnknownDiscriminatorSuffix([]string{"subtype\x00" + rawSubtype})
 }
 
 // observeToolResult deliberately uses only the harness-native call/result IDs:
@@ -530,11 +619,26 @@ func classifyDistributionEvents(source, typ string, payload json.RawMessage, roo
 				return []auditClassifiedEvent{auditVisibleEvent("reasoning", "", "", joinRaw(p["summary"], p["content"]), sub, "inferred_model_visible", "known_response_item_content")}
 			case "message":
 				role := rawString(p["role"])
-				c := "assistant_message"
-				if role == "user" {
+				c := "visible_unknown"
+				knownRole := true
+				switch role {
+				case "user":
 					c = "user_message"
+				case "assistant":
+					c = "assistant_message"
+				default:
+					knownRole = false
 				}
-				return classifyCodexMessageContent(c, sub, p["content"])
+				events := classifyCodexMessageContent(c, sub, p["content"])
+				if !knownRole {
+					for i := range events {
+						events[i].category = "visible_unknown"
+						events[i].visibility = "unresolved"
+						events[i].visibilityReason = "unknown_message_role"
+						events[i].subtype += "/role/" + role
+					}
+				}
+				return events
 			}
 		}
 		if typ == "event_msg" {
@@ -553,7 +657,12 @@ func classifyDistributionEvents(source, typ string, payload json.RawMessage, roo
 			if pt == "item_completed" || pt == "item_started" {
 				var item map[string]json.RawMessage
 				_ = json.Unmarshal(p["item"], &item)
-				return []auditClassifiedEvent{auditStorageEvent("event_msg/"+pt+"/"+firstNonempty(rawString(item["type"]), "unknown_item"), "explicit_storage_only", "known_event_mirror")}
+				itemType := rawString(item["type"])
+				subtype := "event_msg/" + pt + "/" + firstNonempty(itemType, "unknown_item")
+				if itemType != "CommandExecution" {
+					return []auditClassifiedEvent{auditStorageEvent(subtype, "unresolved", "unknown_event_item_subtype")}
+				}
+				return []auditClassifiedEvent{auditStorageEvent(subtype, "explicit_storage_only", "known_event_mirror")}
 			}
 			return []auditClassifiedEvent{auditStorageEvent("event_msg/"+pt, "explicit_storage_only", "known_event_envelope")}
 		}
@@ -572,7 +681,12 @@ func classifyDistributionEvents(source, typ string, payload json.RawMessage, roo
 	if typ == "attachment" {
 		var a map[string]json.RawMessage
 		_ = json.Unmarshal(root["attachment"], &a)
-		return []auditClassifiedEvent{auditStorageEvent("attachment/"+firstNonempty(rawString(a["type"]), "unknown"), "explicit_storage_only", "known_attachment_envelope")}
+		attachmentType := rawString(a["type"])
+		subtype := "attachment/" + firstNonempty(attachmentType, "unknown")
+		if !auditKnownClaudeAttachmentSubtype(attachmentType) {
+			return []auditClassifiedEvent{auditStorageEvent(subtype, "unresolved", "unknown_attachment_subtype")}
+		}
+		return []auditClassifiedEvent{auditStorageEvent(subtype, "explicit_storage_only", "known_attachment_envelope")}
 	}
 	if _, supported := auditClaudeRowSubtypes[typ]; !supported {
 		return []auditClassifiedEvent{auditStorageEvent(firstNonempty(typ, "unknown"), "unresolved", "unknown_row_subtype")}

--- a/internal/trajectory/audit_distribution_test.go
+++ b/internal/trajectory/audit_distribution_test.go
@@ -85,6 +85,21 @@ func TestClaudeAttachmentIsTypedStorage(t *testing.T) {
 	if len(rows) != 1 || rows[0].Subtype != "attachment/deferred_tools_delta" || rows[0].Records != 1 {
 		t.Fatalf("rows=%+v", rows)
 	}
+	if got := d.exemplars.snapshot(); got.Retained != 0 {
+		t.Fatalf("known attachment subtypes entered unknown reservoir: %+v", got)
+	}
+}
+
+func TestClaudeValidatedHookAttachmentIsTypedStorage(t *testing.T) {
+	d := newAuditDistribution()
+	d.observe("claude", []byte(`{"type":"attachment","attachment":{"type":"hook_success","durationMs":12}}`))
+	rows := storageDistributionRows(d.storage)
+	if len(rows) != 1 || rows[0].Subtype != "attachment/hook_success" || rows[0].Records != 1 {
+		t.Fatalf("rows=%+v", rows)
+	}
+	if got := d.exemplars.snapshot(); got.Retained != 0 {
+		t.Fatalf("known hook subtype entered unknown reservoir: %+v", got)
+	}
 }
 
 func TestAuditToolResultsCodexExecOutcomesAndDirectIDs(t *testing.T) {

--- a/internal/trajectory/audit_exemplar.go
+++ b/internal/trajectory/audit_exemplar.go
@@ -1,0 +1,350 @@
+package trajectory
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	// AuditUnknownExemplarMaxCount and AuditUnknownExemplarMaxBytes bound each
+	// persisted reservoir. The byte bound covers the exact JSON encoding of the
+	// exemplar array, including delimiters, rather than an approximate payload sum.
+	AuditUnknownExemplarMaxCount = 32
+	AuditUnknownExemplarMaxBytes = 16 * 1024
+
+	auditUnknownExemplarStructureMaxBytes = 1024
+)
+
+// AuditUnknownExemplar is a content-free shape retained for an event whose
+// subtype or visibility could not be classified. Structure contains JSON field
+// names and JSON types only. Scalar values are discarded before ShapeHash, ID,
+// or any persisted field is produced.
+type AuditUnknownExemplar struct {
+	ID            string `json:"id"`
+	Source        string `json:"source"`
+	Subtype       string `json:"subtype"`
+	Visibility    string `json:"visibility"`
+	Aggregate     string `json:"aggregate"`
+	ShapeHash     string `json:"shape_hash"`
+	Structure     string `json:"structure"`
+	Observations  int    `json:"observations"`
+	ObservedBytes int64  `json:"observed_bytes"`
+}
+
+// AuditUnknownExemplarReservoir describes both the fixed production limits and
+// the retained set. DroppedObservations includes observations whose shapes were
+// evicted or could not fit; it keeps the cap honest without an unbounded side map.
+type AuditUnknownExemplarReservoir struct {
+	CardinalityLimit    int                    `json:"cardinality_limit"`
+	ByteLimit           int                    `json:"byte_limit"`
+	Retained            int                    `json:"retained"`
+	StoredBytes         int                    `json:"stored_bytes"`
+	DroppedObservations int                    `json:"dropped_observations"`
+	Exemplars           []AuditUnknownExemplar `json:"exemplars,omitempty"`
+}
+
+type auditUnknownExemplarReservoir struct {
+	maxCount          int
+	maxBytes          int
+	totalObservations int
+	byID              map[string]AuditUnknownExemplar
+}
+
+func newDefaultAuditUnknownExemplarReservoir() *auditUnknownExemplarReservoir {
+	return newAuditUnknownExemplarReservoir(AuditUnknownExemplarMaxCount, AuditUnknownExemplarMaxBytes)
+}
+
+func newAuditUnknownExemplarReservoir(maxCount, maxBytes int) *auditUnknownExemplarReservoir {
+	if maxCount < 0 {
+		maxCount = 0
+	}
+	if maxBytes < 2 { // [] is the smallest exact JSON array encoding.
+		maxBytes = 2
+	}
+	return &auditUnknownExemplarReservoir{maxCount: maxCount, maxBytes: maxBytes, byID: map[string]AuditUnknownExemplar{}}
+}
+
+func (r *auditUnknownExemplarReservoir) observe(source, subtype, visibility, aggregate string, line []byte, observedBytes int64) {
+	structure, shapeHash := auditStructuralShape(line)
+	scrubbedSource, scrubbedSubtype := auditScrubExemplarLabel(source), auditScrubExemplarLabel(subtype)
+	auditExemplarShape := auditScrubExemplarLabel(aggregate)
+	identity := sha256.Sum256([]byte(strings.Join([]string{scrubbedSource, scrubbedSubtype, visibility, auditExemplarShape, shapeHash}, "\x00")))
+	id := "ex-" + hex.EncodeToString(identity[:8])
+	r.totalObservations++
+	if previous, ok := r.byID[id]; ok {
+		previous.Observations++
+		previous.ObservedBytes += observedBytes
+		r.byID[id] = previous
+		r.rebalance()
+		return
+	}
+	r.byID[id] = AuditUnknownExemplar{
+		ID: id, Source: scrubbedSource, Subtype: scrubbedSubtype,
+		Visibility: visibility, Aggregate: auditExemplarShape, ShapeHash: shapeHash, Structure: auditBoundStructure(structure, shapeHash),
+		Observations: 1, ObservedBytes: observedBytes,
+	}
+	r.rebalance()
+}
+
+func (r *auditUnknownExemplarReservoir) merge(snapshot AuditUnknownExemplarReservoir) {
+	r.totalObservations += snapshot.DroppedObservations
+	for _, exemplar := range snapshot.Exemplars {
+		if exemplar.Observations < 1 {
+			exemplar.Observations = 1
+		}
+		r.totalObservations += exemplar.Observations
+		if previous, ok := r.byID[exemplar.ID]; ok {
+			previous.Observations += exemplar.Observations
+			previous.ObservedBytes += exemplar.ObservedBytes
+			r.byID[exemplar.ID] = previous
+		} else {
+			r.byID[exemplar.ID] = exemplar
+		}
+		r.rebalance()
+	}
+}
+
+func (r *auditUnknownExemplarReservoir) rebalance() {
+	rows := r.sorted()
+	kept := make(map[string]AuditUnknownExemplar, min(len(rows), r.maxCount))
+	selected := make([]AuditUnknownExemplar, 0, min(len(rows), r.maxCount))
+	for _, row := range rows {
+		if len(selected) >= r.maxCount {
+			break
+		}
+		candidate := append(append([]AuditUnknownExemplar(nil), selected...), row)
+		if auditSerializedExemplarBytes(candidate) > r.maxBytes {
+			continue
+		}
+		selected = candidate
+		kept[row.ID] = row
+	}
+	r.byID = kept
+}
+
+func (r *auditUnknownExemplarReservoir) sorted() []AuditUnknownExemplar {
+	rows := make([]AuditUnknownExemplar, 0, len(r.byID))
+	for _, row := range r.byID {
+		rows = append(rows, row)
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].ID < rows[j].ID })
+	return rows
+}
+
+func (r *auditUnknownExemplarReservoir) snapshot() AuditUnknownExemplarReservoir {
+	rows := r.sorted()
+	retainedObservations := 0
+	for _, row := range rows {
+		retainedObservations += row.Observations
+	}
+	return AuditUnknownExemplarReservoir{
+		CardinalityLimit: r.maxCount, ByteLimit: r.maxBytes, Retained: len(rows),
+		StoredBytes:         auditSerializedExemplarBytes(rows),
+		DroppedObservations: max(0, r.totalObservations-retainedObservations), Exemplars: rows,
+	}
+}
+
+func auditSerializedExemplarBytes(rows []AuditUnknownExemplar) int {
+	encoded, _ := json.Marshal(rows)
+	return len(encoded)
+}
+
+func auditStructuralShape(line []byte) (string, string) {
+	var value any
+	decoder := json.NewDecoder(strings.NewReader(string(line)))
+	decoder.UseNumber()
+	if err := decoder.Decode(&value); err != nil {
+		value = map[string]any{"malformed": nil}
+	}
+	var out strings.Builder
+	auditWriteStructuralShape(&out, value)
+	structure := out.String()
+	digest := sha256.Sum256([]byte(structure))
+	return structure, hex.EncodeToString(digest[:])
+}
+
+func auditWriteStructuralShape(out *strings.Builder, value any) {
+	switch typed := value.(type) {
+	case map[string]any:
+		keys := make([]string, 0, len(typed))
+		for key := range typed {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		out.WriteString("object{")
+		for i, key := range keys {
+			if i > 0 {
+				out.WriteByte(',')
+			}
+			out.WriteString(strconv.Quote(auditScrubStructuralField(key)))
+			out.WriteByte(':')
+			auditWriteStructuralShape(out, typed[key])
+		}
+		out.WriteByte('}')
+	case []any:
+		shapes := make(map[string]struct{})
+		for _, item := range typed {
+			var itemShape strings.Builder
+			auditWriteStructuralShape(&itemShape, item)
+			shapes[itemShape.String()] = struct{}{}
+		}
+		items := make([]string, 0, len(shapes))
+		for shape := range shapes {
+			items = append(items, shape)
+		}
+		sort.Strings(items)
+		out.WriteString("array<")
+		out.WriteString(strings.Join(items, "|"))
+		out.WriteByte('>')
+	case string:
+		out.WriteString("string")
+	case json.Number, float64:
+		out.WriteString("number")
+	case bool:
+		out.WriteString("boolean")
+	case nil:
+		out.WriteString("null")
+	default:
+		out.WriteString("unknown")
+	}
+}
+
+func auditScrubStructuralField(field string) string {
+	field = strings.ToValidUTF8(field, "�")
+	lower := strings.ToLower(field)
+	secretShaped := strings.HasPrefix(lower, "sk-") || strings.HasPrefix(lower, "ghp_") ||
+		strings.HasPrefix(lower, "github_pat_") || strings.HasPrefix(field, "AKIA") ||
+		strings.HasPrefix(lower, "bearer ") || strings.Contains(field, "\\") || strings.Contains(field, "/") ||
+		strings.Contains(field, "@") || len(field) > 64
+	if !secretShaped {
+		return field
+	}
+	digest := sha256.Sum256([]byte(field))
+	return "field#" + hex.EncodeToString(digest[:6])
+}
+
+func auditScrubExemplarLabel(label string) string {
+	label = strings.ToValidUTF8(label, "�")
+	if strings.HasPrefix(label, "/") {
+		return auditScrubStructuralField(label)
+	}
+	parts := strings.Split(label, "/")
+	for i, part := range parts {
+		parts[i] = auditScrubStructuralField(part)
+	}
+	return strings.Join(parts, "/")
+}
+
+func auditUnknownDiscriminatorSuffix(values []string) string {
+	hashes := make([]string, 0, len(values))
+	seen := map[string]bool{}
+	for _, value := range values {
+		digest := sha256.Sum256([]byte(value))
+		hash := hex.EncodeToString(digest[:6])
+		if !seen[hash] {
+			hashes = append(hashes, hash)
+			seen[hash] = true
+		}
+	}
+	if len(hashes) == 0 {
+		return ""
+	}
+	sort.Strings(hashes)
+	return "discriminator#" + strings.Join(hashes, ".")
+}
+
+func auditBoundStructure(structure, shapeHash string) string {
+	if len(structure) <= auditUnknownExemplarStructureMaxBytes {
+		return structure
+	}
+	suffix := "…#" + shapeHash[:12]
+	limit := auditUnknownExemplarStructureMaxBytes - len(suffix)
+	if limit <= 0 {
+		return suffix
+	}
+	cut := limit
+	for cut > 0 && !utf8.ValidString(structure[:cut]) {
+		cut--
+	}
+	return structure[:cut] + suffix
+}
+
+func hasExemplarID(rows []AuditUnknownExemplar, id string) bool {
+	for _, row := range rows {
+		if row.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func auditExemplarIDs(rows []AuditUnknownExemplar, match func(AuditUnknownExemplar) bool) []string {
+	ids := make([]string, 0)
+	for _, row := range rows {
+		if match(row) {
+			ids = append(ids, row.ID)
+		}
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func linkAuditUnknownExemplars(distribution []AuditDistributionRow, storage []AuditStorageRow, exemplars []AuditUnknownExemplar) {
+	for i := range distribution {
+		name := distribution[i].Name
+		distribution[i].ExemplarIDs = auditExemplarIDs(exemplars, func(exemplar AuditUnknownExemplar) bool {
+			return exemplar.Visibility == "visible_unknown" && exemplar.Aggregate == name
+		})
+	}
+	for i := range storage {
+		source, subtype := storage[i].Source, storage[i].Subtype
+		storage[i].ExemplarIDs = auditExemplarIDs(exemplars, func(exemplar AuditUnknownExemplar) bool {
+			return exemplar.Visibility == "storage_unknown" && exemplar.Source == auditScrubExemplarLabel(source) && exemplar.Subtype == auditScrubExemplarLabel(subtype)
+		})
+	}
+}
+
+func mergeAuditUnknownExemplarReservoirs(left, right AuditUnknownExemplarReservoir) AuditUnknownExemplarReservoir {
+	reservoir := newDefaultAuditUnknownExemplarReservoir()
+	reservoir.merge(left)
+	reservoir.merge(right)
+	return reservoir.snapshot()
+}
+
+func mergeAuditDistributionRows(groups ...[]AuditDistributionRow) []AuditDistributionRow {
+	byteTotals := map[string]int64{}
+	callTotals := map[string]int{}
+	for _, group := range groups {
+		for _, row := range group {
+			byteTotals[row.Name] += row.Bytes
+			callTotals[row.Name] += row.Calls
+		}
+	}
+	rows := distributionRows(byteTotals)
+	for i := range rows {
+		rows[i].Calls = callTotals[rows[i].Name]
+	}
+	return rows
+}
+
+func mergeAuditStorageRows(groups ...[]AuditStorageRow) []AuditStorageRow {
+	totals := map[string]*AuditStorageRow{}
+	for _, group := range groups {
+		for _, row := range group {
+			key := row.Source + "\x00" + row.Subtype
+			total := totals[key]
+			if total == nil {
+				total = &AuditStorageRow{Source: row.Source, Subtype: row.Subtype}
+				totals[key] = total
+			}
+			total.Bytes += row.Bytes
+			total.Records += row.Records
+		}
+	}
+	return storageDistributionRows(totals)
+}

--- a/internal/trajectory/audit_exemplar_test.go
+++ b/internal/trajectory/audit_exemplar_test.go
@@ -1,0 +1,472 @@
+package trajectory
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAuditUnknownExemplarsCoalesceLinkAndRedact(t *testing.T) {
+	const secret = "sk-ant-api03-DO-NOT-PERSIST"
+	const sensitiveType = "customer-project-blue"
+	d := newAuditDistribution()
+	visible := []byte(`{"type":"response_item","payload":{"type":"` + sensitiveType + `","secret":"` + secret + `","items":[{"value":"first"}]}}`)
+	visibleRepeat := []byte(`{"type":"response_item","payload":{"type":"` + sensitiveType + `","secret":"different-secret","items":[{"value":"second"}]}}`)
+	storage := []byte(`{"type":"` + secret + `","payload":{"password":"` + secret + `","enabled":true}}`)
+	d.observe(AuditSourceCodex, visible)
+	d.observe(AuditSourceCodex, visibleRepeat)
+	d.observe(AuditSourceCodex, storage)
+
+	exemplars := d.exemplars.snapshot()
+	if len(exemplars.Exemplars) != 2 {
+		t.Fatalf("exemplars = %+v, want one coalesced visible shape and one storage shape", exemplars)
+	}
+	if exemplars.CardinalityLimit != AuditUnknownExemplarMaxCount || exemplars.ByteLimit != AuditUnknownExemplarMaxBytes {
+		t.Fatalf("limits = %d/%d", exemplars.CardinalityLimit, exemplars.ByteLimit)
+	}
+	if got := exemplarByVisibility(t, exemplars.Exemplars, "visible_unknown"); got.Observations != 2 {
+		t.Fatalf("visible observations = %d, want 2", got.Observations)
+	} else if !strings.Contains(got.Structure, "secret\":string") {
+		t.Fatalf("visible structure does not retain field name/type: %+v", got)
+	}
+	for _, exemplar := range exemplars.Exemplars {
+		if exemplar.ID == "" || exemplar.ShapeHash == "" || !strings.Contains(exemplar.Structure, ":string") {
+			t.Fatalf("structural exemplar is not classifiable: %+v", exemplar)
+		}
+	}
+
+	distribution := d.distributionRows()
+	visibleRow := distributionRowByName(t, distribution, "visible_unknown")
+	if len(visibleRow.ExemplarIDs) != 1 || visibleRow.ExemplarIDs[0] != exemplarByVisibility(t, exemplars.Exemplars, "visible_unknown").ID {
+		t.Fatalf("visible exemplar links = %v", visibleRow.ExemplarIDs)
+	}
+	storageRows := d.storageRows()
+	if len(storageRows) != 1 || len(storageRows[0].ExemplarIDs) != 1 || storageRows[0].ExemplarIDs[0] != exemplarByVisibility(t, exemplars.Exemplars, "storage_unknown").ID {
+		t.Fatalf("storage exemplar links = %+v", storageRows)
+	}
+
+	result := AuditResult{Summary: AuditSummaryRow{
+		Schema: AuditSchema, Kind: "summary", Distribution: distribution,
+		StorageDistribution: storageRows, UnknownExemplars: exemplars,
+	}}
+	var jsonl, markdown bytes.Buffer
+	if err := WriteAuditJSONL(&jsonl, result); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteAuditMarkdown(&markdown, result); err != nil {
+		t.Fatal(err)
+	}
+	for name, persisted := range map[string]string{"jsonl": jsonl.String(), "markdown": markdown.String()} {
+		if strings.Contains(persisted, secret) || strings.Contains(persisted, sensitiveType) || strings.Contains(persisted, "different-secret") || strings.Contains(persisted, "first") || strings.Contains(persisted, "second") {
+			t.Fatalf("%s leaked payload content: %s", name, persisted)
+		}
+		for _, exemplar := range exemplars.Exemplars {
+			if !strings.Contains(persisted, exemplar.ID) {
+				t.Fatalf("%s does not link exemplar %s: %s", name, exemplar.ID, persisted)
+			}
+		}
+	}
+}
+
+func TestAuditUnknownExemplarReservoirHasIndependentCardinalityAndByteBounds(t *testing.T) {
+	t.Run("cardinality", func(t *testing.T) {
+		r := newAuditUnknownExemplarReservoir(3, 1<<20)
+		for i := 0; i < 50; i++ {
+			line := []byte(fmt.Sprintf(`{"type":"future","payload":{"field_%02d":true}}`, i))
+			r.observe(AuditSourceCodex, "future", "storage_unknown", "future", line, int64(len(line)))
+		}
+		got := r.snapshot()
+		if len(got.Exemplars) != 3 || got.Retained != 3 || got.DroppedObservations == 0 {
+			t.Fatalf("cardinality reservoir = %+v", got)
+		}
+		assertSerializedExemplarBound(t, got)
+	})
+
+	t.Run("serialized bytes", func(t *testing.T) {
+		const byteLimit = 900
+		r := newAuditUnknownExemplarReservoir(100, byteLimit)
+		for i := 0; i < 50; i++ {
+			line := []byte(fmt.Sprintf(`{"type":"future","payload":{"field_%02d_%s":true}}`, i, strings.Repeat("x", 100)))
+			r.observe(AuditSourceCodex, "future", "storage_unknown", "future", line, int64(len(line)))
+		}
+		got := r.snapshot()
+		if len(got.Exemplars) >= 50 || got.StoredBytes > byteLimit || got.DroppedObservations == 0 {
+			t.Fatalf("byte reservoir = %+v", got)
+		}
+		assertSerializedExemplarBound(t, got)
+	})
+}
+
+func TestAuditUnknownExemplarIdentityIncludesClassificationCase(t *testing.T) {
+	r := newAuditUnknownExemplarReservoir(10, 1<<20)
+	line := []byte(`{"type":"future","payload":{"value":"discarded"}}`)
+	r.observe(AuditSourceCodex, "future/a", "visible_unknown", "visible_unknown", line, 10)
+	r.observe(AuditSourceCodex, "future/b", "visible_unknown", "visible_unknown", line, 10)
+	r.observe(AuditSourceCodex, "future/a", "storage_unknown", "future/a", line, 10)
+	got := r.snapshot()
+	if len(got.Exemplars) != 3 {
+		t.Fatalf("classification cases coalesced: %+v", got.Exemplars)
+	}
+	wantShape := got.Exemplars[0].ShapeHash
+	ids := map[string]bool{}
+	for _, exemplar := range got.Exemplars {
+		if exemplar.ShapeHash != wantShape {
+			t.Fatalf("identical JSON shape has different shape hashes: %+v", got.Exemplars)
+		}
+		if ids[exemplar.ID] {
+			t.Fatalf("classification cases share ID %q: %+v", exemplar.ID, got.Exemplars)
+		}
+		ids[exemplar.ID] = true
+	}
+}
+
+func TestAuditUnknownExemplarsCoverClaudeSubtypeAndVisibilityCases(t *testing.T) {
+	d := newAuditDistribution()
+	d.observe(AuditSourceClaude, []byte(`{"type":"assistant","message":{"content":[{"type":"customer_alpha","private":"discard-me"}]}}`))
+	d.observe(AuditSourceClaude, []byte(`{"type":"assistant","message":{"content":[{"type":"customer_beta","private":"discard-me"}]}}`))
+	d.observe(AuditSourceClaude, []byte(`{"type":"attachment","attachment":{"type":"future_attachment","private":"discard-me"}}`))
+
+	got := d.exemplars.snapshot()
+	if len(got.Exemplars) != 3 {
+		t.Fatalf("Claude unknown cases = %+v", got.Exemplars)
+	}
+	visible := distributionRowByName(t, d.distributionRows(), "visible_unknown")
+	if len(visible.ExemplarIDs) != 2 {
+		t.Fatalf("Claude unknown block links = %v", visible.ExemplarIDs)
+	}
+	storage := d.storageRows()
+	if len(storage) != 1 || !strings.HasPrefix(storage[0].Subtype, "attachment/discriminator#") || len(storage[0].ExemplarIDs) != 1 {
+		t.Fatalf("Claude unknown attachment links = %+v", storage)
+	}
+	encoded, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(encoded, []byte("discard-me")) || bytes.Contains(encoded, []byte("customer_alpha")) || bytes.Contains(encoded, []byte("customer_beta")) || bytes.Contains(encoded, []byte("future_attachment")) {
+		t.Fatalf("Claude exemplar retained payload: %s", encoded)
+	}
+	visibleExemplars := make([]AuditUnknownExemplar, 0, 2)
+	for _, exemplar := range got.Exemplars {
+		if exemplar.Visibility == "visible_unknown" {
+			visibleExemplars = append(visibleExemplars, exemplar)
+		}
+	}
+	if len(visibleExemplars) != 2 || visibleExemplars[0].ID == visibleExemplars[1].ID || visibleExemplars[0].ShapeHash != visibleExemplars[1].ShapeHash {
+		t.Fatalf("Claude discriminator hashes did not distinguish identical structures: %+v", visibleExemplars)
+	}
+}
+
+func TestAuditUnknownExemplarsCoverNestedCodexSubtypes(t *testing.T) {
+	d := newAuditDistribution()
+	d.observe(AuditSourceCodex, []byte(`{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"customer_alpha","text":"discard-one"}]}}`))
+	d.observe(AuditSourceCodex, []byte(`{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"customer_beta","text":"discard-two"}]}}`))
+	d.observe(AuditSourceCodex, []byte(`{"type":"event_msg","payload":{"type":"item_started","item":{"type":"project_alpha","state":"private"}}}`))
+	d.observe(AuditSourceCodex, []byte(`{"type":"event_msg","payload":{"type":"item_started","item":{"type":"project_beta","state":"private"}}}`))
+
+	got := d.exemplars.snapshot()
+	if len(got.Exemplars) != 4 {
+		t.Fatalf("nested Codex unknown cases = %+v", got.Exemplars)
+	}
+	visible := distributionRowByName(t, d.distributionRows(), "visible_unknown")
+	if len(visible.ExemplarIDs) != 2 {
+		t.Fatalf("nested Codex content links = %v", visible.ExemplarIDs)
+	}
+	storage := d.storageRows()
+	if len(storage) != 2 {
+		t.Fatalf("nested Codex item rows = %+v", storage)
+	}
+	encoded, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"customer_alpha", "customer_beta", "project_alpha", "project_beta", "discard-one", "discard-two", "private"} {
+		if bytes.Contains(encoded, []byte(forbidden)) {
+			t.Fatalf("nested discriminator/payload %q leaked: %s", forbidden, encoded)
+		}
+	}
+}
+
+func TestAuditUnknownExemplarCanonicalDuplicateFragmentDoesNotInflate(t *testing.T) {
+	d := newAuditDistribution()
+	d.observe(AuditSourceCodex, []byte(`{"type":"future","payload":{"value":"discarded"}}`))
+	d.observe(AuditSourceCodex, []byte(`{"type":"response_item","payload":{"type":"future_visible","value":"discarded"}}`))
+	row := AuditTranscriptRow{
+		Schema: AuditSchema, Kind: "session", Source: AuditSourceCodex, TranscriptID: "duplicate-session",
+		SourcePath: "one.jsonl", Distribution: d.distributionRows(),
+		ToolDistribution:    []AuditDistributionRow{{Name: "exec_command", Bytes: 17, Share: 1, Calls: 1}},
+		ToolResults:         []AuditToolResultRow{{Name: "exec_command", Subtype: "command", Bytes: 23, Results: 1, Success: 1}},
+		StorageDistribution: d.storageRows(),
+		UnknownExemplars:    d.exemplars.snapshot(), fragmentDigest: "same-content-digest",
+		ToolCalls: 3, ToolErrors: 2, RepeatedFailures: 4, ExpectedWaitTimeouts: 5, MutationChurn: 6,
+	}
+	duplicate := row
+	duplicate.SourcePath = "two.jsonl"
+	canonical, refusals := canonicalAuditTranscripts([]AuditTranscriptRow{row, duplicate})
+	if len(refusals) != 0 || len(canonical) != 1 {
+		t.Fatalf("canonical = %+v, refusals = %+v", canonical, refusals)
+	}
+	got := canonical[0]
+	if len(got.StorageDistribution) != 1 || got.StorageDistribution[0].Records != 1 || got.StorageDistribution[0].Bytes != row.StorageDistribution[0].Bytes {
+		t.Fatalf("duplicate fragment inflated storage: %+v", got.StorageDistribution)
+	}
+	if len(got.Distribution) != 1 || got.Distribution[0].Bytes != row.Distribution[0].Bytes {
+		t.Fatalf("duplicate fragment inflated visible distribution: %+v", got.Distribution)
+	}
+	if len(got.ToolDistribution) != 1 || got.ToolDistribution[0].Bytes != row.ToolDistribution[0].Bytes || got.ToolDistribution[0].Calls != row.ToolDistribution[0].Calls {
+		t.Fatalf("duplicate fragment inflated tool distribution: %+v", got.ToolDistribution)
+	}
+	if len(got.ToolResults) != 1 || got.ToolResults[0] != row.ToolResults[0] {
+		t.Fatalf("duplicate fragment inflated tool-result projection: %+v", got.ToolResults)
+	}
+	if len(got.UnknownExemplars.Exemplars) != 2 {
+		t.Fatalf("duplicate fragment inflated exemplars: %+v", got.UnknownExemplars)
+	}
+	for i, exemplar := range got.UnknownExemplars.Exemplars {
+		if exemplar.Observations != 1 || exemplar.ObservedBytes != row.UnknownExemplars.Exemplars[i].ObservedBytes {
+			t.Fatalf("duplicate fragment inflated exemplar %d: %+v", i, got.UnknownExemplars)
+		}
+	}
+	if got.ToolCalls != row.ToolCalls || got.ToolErrors != row.ToolErrors || got.RepeatedFailures != row.RepeatedFailures || got.ExpectedWaitTimeouts != row.ExpectedWaitTimeouts || got.MutationChurn != row.MutationChurn {
+		t.Fatalf("duplicate fragment inflated derived metrics: got=%+v want=%+v", got, row)
+	}
+}
+
+func TestAuditCanonicalDistinctFragmentsMergeToolDistributionCallsAndBytes(t *testing.T) {
+	first := AuditTranscriptRow{
+		Schema: AuditSchema, Kind: "session", Source: AuditSourceCodex, TranscriptID: "split-session",
+		SourcePath: "one.jsonl", fragmentDigest: "first-fragment",
+		ToolDistribution: []AuditDistributionRow{
+			{Name: "exec_command", Bytes: 10, Calls: 1},
+			{Name: "read_file", Bytes: 5, Calls: 2},
+		},
+	}
+	second := AuditTranscriptRow{
+		Schema: AuditSchema, Kind: "session", Source: AuditSourceCodex, TranscriptID: "split-session",
+		SourcePath: "two.jsonl", fragmentDigest: "second-fragment",
+		ToolDistribution: []AuditDistributionRow{
+			{Name: "exec_command", Bytes: 20, Calls: 3},
+			{Name: "write_file", Bytes: 7, Calls: 1},
+		},
+	}
+
+	canonical, refusals := canonicalAuditTranscripts([]AuditTranscriptRow{first, second})
+	if len(refusals) != 0 || len(canonical) != 1 {
+		t.Fatalf("canonical = %+v, refusals = %+v", canonical, refusals)
+	}
+	rows := canonical[0].ToolDistribution
+	for name, want := range map[string]struct {
+		bytes int64
+		calls int
+	}{
+		"exec_command": {bytes: 30, calls: 4},
+		"read_file":    {bytes: 5, calls: 2},
+		"write_file":   {bytes: 7, calls: 1},
+	} {
+		got := distributionRowByName(t, rows, name)
+		if got.Bytes != want.bytes || got.Calls != want.calls {
+			t.Fatalf("%s merged row = %+v, want bytes=%d calls=%d", name, got, want.bytes, want.calls)
+		}
+	}
+}
+
+func TestRunAuditDuplicateFilesDoNotWeightHookOrToolErrorSideChannels(t *testing.T) {
+	root := t.TempDir()
+	lowHooksAndErrors := make([]string, 0, 14)
+	for i := 0; i < 10; i++ {
+		lowHooksAndErrors = append(lowHooksAndErrors, `{"sessionId":"duplicate-session","type":"attachment","attachment":{"type":"hook_success","durationMs":10}}`)
+	}
+	lowHooksAndErrors = append(lowHooksAndErrors,
+		`{"sessionId":"duplicate-session","type":"assistant","message":{"id":"usage-one","usage":{"input_tokens":10,"output_tokens":0},"content":[{"type":"tool_use","id":"edit-one","name":"edit_file","input":{"path":"fixture.go"}}]}}`,
+		`{"sessionId":"duplicate-session","type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"edit-one","is_error":true,"content":"permission denied"}]}}`,
+		`{"sessionId":"duplicate-session","type":"assistant","message":{"id":"usage-two","usage":{"input_tokens":10,"output_tokens":0},"content":[{"type":"tool_use","id":"edit-two","name":"edit_file","input":{"path":"fixture.go"}}]}}`,
+		`{"sessionId":"duplicate-session","type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"edit-two","is_error":true,"content":"permission denied"}]}}`,
+	)
+	lowFragment := []byte(strings.Join(lowHooksAndErrors, "\n") + "\n")
+	highFragment := []byte(`{"sessionId":"duplicate-session","type":"attachment","attachment":{"type":"hook_success","durationMs":100}}` + "\n")
+	for name, content := range map[string][]byte{
+		"a-low.jsonl":      lowFragment,
+		"b-low-copy.jsonl": lowFragment,
+		"c-high.jsonl":     highFragment,
+	} {
+		if err := os.WriteFile(filepath.Join(root, name), content, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	result, err := RunAudit(AuditOptions{Sources: []AuditSource{{Name: AuditSourceClaude, Root: root, RootLabel: "duplicate-fixture"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Summary.HookP95MS == nil || *result.Summary.HookP95MS != 100 {
+		t.Fatalf("duplicate low-hook fragment weighted p95: %v, want 100", result.Summary.HookP95MS)
+	}
+	if len(result.ToolErrorFamilies) != 1 {
+		t.Fatalf("tool-error families = %+v, want one", result.ToolErrorFamilies)
+	}
+	family := result.ToolErrorFamilies[0]
+	if family.Family != "permission" || family.Count != 2 || family.Tokens != 0 || family.RepeatedFailures != 1 || family.MutationChurn != 1 {
+		t.Fatalf("duplicate fragment inflated tool-error family totals: %+v", family)
+	}
+	if result.Summary.ToolErrors != 2 || result.Summary.MutationChurn != 1 || result.Summary.RepeatedFailures != 1 {
+		t.Fatalf("canonical summary was inflated: errors=%d churn=%d repeats=%d", result.Summary.ToolErrors, result.Summary.MutationChurn, result.Summary.RepeatedFailures)
+	}
+}
+
+func TestAuditUnknownCodexMessageRoleIsOpaqueAndLinked(t *testing.T) {
+	const privateRole = "customer-project-blue"
+	d := newAuditDistribution()
+	d.observe(AuditSourceCodex, []byte(`{"type":"response_item","payload":{"type":"message","role":"`+privateRole+`","content":[{"type":"input_text","text":"discard-me"}]}}`))
+	rows := d.distributionRows()
+	unknown := distributionRowByName(t, rows, "visible_unknown")
+	if len(unknown.ExemplarIDs) != 1 {
+		t.Fatalf("unknown role exemplar links = %v", unknown.ExemplarIDs)
+	}
+	got := d.exemplars.snapshot()
+	encoded, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(encoded, []byte(privateRole)) || bytes.Contains(encoded, []byte("discard-me")) {
+		t.Fatalf("unknown role leaked into exemplar: %s", encoded)
+	}
+	if len(got.Exemplars) != 1 || !strings.HasPrefix(got.Exemplars[0].Subtype, "response_item/discriminator#") {
+		t.Fatalf("unknown role subtype = %+v", got.Exemplars)
+	}
+}
+
+func TestAuditUnknownSourceIsOpaqueAndLinked(t *testing.T) {
+	const privateSource = "customer-project-source"
+	d := newAuditDistribution()
+	d.observe(privateSource, []byte(`{"type":"future","payload":{"value":"discard-me"}}`))
+	storage := d.storageRows()
+	if len(storage) != 1 || strings.Contains(storage[0].Source, privateSource) || !strings.HasPrefix(storage[0].Source, "source/discriminator#") || len(storage[0].ExemplarIDs) != 1 {
+		t.Fatalf("unknown source row = %+v", storage)
+	}
+	encoded, err := json.Marshal(struct {
+		Storage   []AuditStorageRow             `json:"storage"`
+		Exemplars AuditUnknownExemplarReservoir `json:"exemplars"`
+	}{storage, d.exemplars.snapshot()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(encoded, []byte(privateSource)) || bytes.Contains(encoded, []byte("discard-me")) {
+		t.Fatalf("unknown source leaked into persisted projection: %s", encoded)
+	}
+}
+
+func TestAuditConformanceFutureDiscriminatorsRemainEphemeral(t *testing.T) {
+	d := newAuditDistribution()
+	d.observe(AuditSourceCodex, []byte(`{"type":"event_msg","payload":{"type":"future_event_v99","private":"discard-event"}}`))
+	d.observe(AuditSourceCodex, []byte(`{"type":"future_row_v99","payload":{"private":"discard-row"}}`))
+
+	storage := d.storageRows()
+	wantSubtypes := map[string]bool{
+		"event_msg/discriminator#8dde2a3a3ed8": false,
+		"record/discriminator#9e88b29883a2":    false,
+	}
+	for _, row := range storage {
+		if _, ok := wantSubtypes[row.Subtype]; !ok {
+			t.Fatalf("unexpected persisted subtype: %+v", row)
+		}
+		wantSubtypes[row.Subtype] = true
+	}
+	for subtype, seen := range wantSubtypes {
+		if !seen {
+			t.Fatalf("missing persisted subtype %q in %+v", subtype, storage)
+		}
+	}
+
+	result := AuditResult{Summary: AuditSummaryRow{
+		Schema: AuditSchema, Kind: "summary", StorageDistribution: storage,
+		UnknownExemplars: d.exemplars.snapshot(),
+	}}
+	var jsonl, markdown bytes.Buffer
+	if err := WriteAuditJSONL(&jsonl, result); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteAuditMarkdown(&markdown, result); err != nil {
+		t.Fatal(err)
+	}
+	for name, persisted := range map[string]string{"storage JSON": string(mustJSON(storage)), "JSONL": jsonl.String(), "Markdown": markdown.String()} {
+		for _, forbidden := range []string{"future_event_v99", "future_row_v99", "discard-event", "discard-row"} {
+			if strings.Contains(persisted, forbidden) {
+				t.Fatalf("%s persisted raw future discriminator/payload %q: %s", name, forbidden, persisted)
+			}
+		}
+	}
+}
+
+func TestAuditUnknownExemplarSummaryAndCanonicalMergesStayBounded(t *testing.T) {
+	rows := make([]AuditTranscriptRow, 0, AuditUnknownExemplarMaxCount*3)
+	for i := 0; i < AuditUnknownExemplarMaxCount*3; i++ {
+		d := newAuditDistribution()
+		line := []byte(fmt.Sprintf(`{"type":"future","payload":{"shape_%03d":"secret-%03d"}}`, i, i))
+		d.observe(AuditSourceCodex, line)
+		rows = append(rows, AuditTranscriptRow{
+			Schema: AuditSchema, Kind: "session", Source: AuditSourceCodex,
+			TranscriptID: "same-session", SourcePath: fmt.Sprintf("fragment-%03d.jsonl", i),
+			Distribution: d.distributionRows(), StorageDistribution: d.storageRows(), UnknownExemplars: d.exemplars.snapshot(),
+		})
+	}
+
+	canonical, refusals := canonicalAuditTranscripts(rows)
+	if len(refusals) != 0 || len(canonical) != 1 {
+		t.Fatalf("canonical = %d, refusals = %+v", len(canonical), refusals)
+	}
+	assertSerializedExemplarBound(t, canonical[0].UnknownExemplars)
+	if canonical[0].UnknownExemplars.Retained > AuditUnknownExemplarMaxCount {
+		t.Fatalf("canonical reservoir re-expanded: %+v", canonical[0].UnknownExemplars)
+	}
+	summary := summarizeAudit(nil, canonical, nil)
+	assertSerializedExemplarBound(t, summary.UnknownExemplars)
+	if summary.UnknownExemplars.Retained > AuditUnknownExemplarMaxCount {
+		t.Fatalf("summary reservoir re-expanded: %+v", summary.UnknownExemplars)
+	}
+	for _, row := range summary.StorageDistribution {
+		for _, id := range row.ExemplarIDs {
+			if !hasExemplarID(summary.UnknownExemplars.Exemplars, id) {
+				t.Fatalf("summary row links evicted exemplar %q: %+v", id, row)
+			}
+		}
+	}
+}
+
+func assertSerializedExemplarBound(t *testing.T, got AuditUnknownExemplarReservoir) {
+	t.Helper()
+	encoded, err := json.Marshal(got.Exemplars)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(encoded) != got.StoredBytes {
+		t.Fatalf("stored_bytes = %d, serialized exemplars = %d", got.StoredBytes, len(encoded))
+	}
+	if len(encoded) > got.ByteLimit {
+		t.Fatalf("serialized exemplars = %d, byte limit = %d", len(encoded), got.ByteLimit)
+	}
+}
+
+func exemplarByVisibility(t *testing.T, rows []AuditUnknownExemplar, visibility string) AuditUnknownExemplar {
+	t.Helper()
+	for _, row := range rows {
+		if row.Visibility == visibility {
+			return row
+		}
+	}
+	t.Fatalf("missing %s exemplar in %+v", visibility, rows)
+	return AuditUnknownExemplar{}
+}
+
+func distributionRowByName(t *testing.T, rows []AuditDistributionRow, name string) AuditDistributionRow {
+	t.Helper()
+	for _, row := range rows {
+		if row.Name == name {
+			return row
+		}
+	}
+	t.Fatalf("missing %s distribution row in %+v", name, rows)
+	return AuditDistributionRow{}
+}

--- a/internal/trajectory/audit_parse.go
+++ b/internal/trajectory/audit_parse.go
@@ -3,6 +3,8 @@ package trajectory
 import (
 	"bufio"
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -84,6 +86,7 @@ func parseAuditFile(source, path, rel string, denominator *AuditDenominatorRow) 
 		schemaShapes:    map[string]auditShapeSet{},
 	}
 	var refusals []AuditRefusalRow
+	fragmentHasher := sha256.New()
 	scanner := bufio.NewScanner(file)
 	scanner.Buffer(make([]byte, 64*1024), auditMaxLineBytes)
 	lineNumber := 0
@@ -93,6 +96,8 @@ func parseAuditFile(source, path, rel string, denominator *AuditDenominatorRow) 
 		if len(line) == 0 {
 			continue
 		}
+		_, _ = fragmentHasher.Write(line)
+		_, _ = fragmentHasher.Write([]byte{'\n'})
 		denominator.Records++
 		state.distribution.observe(source, line)
 		var record map[string]any
@@ -159,10 +164,12 @@ func parseAuditFile(source, path, rel string, denominator *AuditDenominatorRow) 
 	}
 	applyQwenToolErrorAttribution(state.toolErrorEvents, state.toolErrorAttributions, state.mutationCounts)
 	state.row.HookP95MS = auditPercentile(state.hookDurations, 95)
-	state.row.Distribution = distributionRows(state.distribution.categories)
+	state.row.Distribution = state.distribution.distributionRows()
 	state.row.ToolDistribution = toolDistributionRows(state.distribution.tools)
 	state.row.ToolResults = state.distribution.toolResultRows()
-	state.row.StorageDistribution = storageDistributionRows(state.distribution.storage)
+	state.row.StorageDistribution = state.distribution.storageRows()
+	state.row.UnknownExemplars = state.distribution.exemplars.snapshot()
+	state.row.fragmentDigest = hex.EncodeToString(fragmentHasher.Sum(nil))
 	if source == AuditSourceCodex && state.codexRawTotal != nil {
 		state.row.UsageRecords++
 		denominator.UsageRecordsApplied++

--- a/internal/trajectory/audit_render.go
+++ b/internal/trajectory/audit_render.go
@@ -46,15 +46,15 @@ func WriteAuditMarkdown(w io.Writer, result AuditResult) error {
 		}
 	}
 	if len(summary.StorageDistribution) > 0 {
-		out.WriteString("\n## Transcript storage and telemetry overhead\n\n| Source | Subtype | Records | Serialized UTF-8 bytes | Source share |\n|---|---|---:|---:|---:|\n")
+		out.WriteString("\n## Transcript storage and telemetry overhead\n\n| Source | Subtype | Records | Serialized UTF-8 bytes | Source share | Unknown exemplar IDs |\n|---|---|---:|---:|---:|---|\n")
 		for _, r := range summary.StorageDistribution {
-			fmt.Fprintf(&out, "| `%s` | `%s` | %d | %d | %.1f%% |\n", r.Source, r.Subtype, r.Records, r.Bytes, r.Share*100)
+			fmt.Fprintf(&out, "| `%s` | `%s` | %d | %d | %.1f%% | %s |\n", r.Source, r.Subtype, r.Records, r.Bytes, r.Share*100, auditExemplarIDLinks(r.ExemplarIDs))
 		}
 	}
 	if len(summary.Distribution) > 0 {
-		out.WriteString("\n## Token destination distribution\n\n| Category | UTF-8 bytes | Share |\n|---|---:|---:|\n")
+		out.WriteString("\n## Token destination distribution\n\n| Category | UTF-8 bytes | Share | Unknown exemplar IDs |\n|---|---:|---:|---|\n")
 		for _, r := range summary.Distribution {
-			fmt.Fprintf(&out, "| `%s` | %d | %.1f%% |\n", r.Name, r.Bytes, r.Share*100)
+			fmt.Fprintf(&out, "| `%s` | %d | %.1f%% | %s |\n", r.Name, r.Bytes, r.Share*100, auditExemplarIDLinks(r.ExemplarIDs))
 		}
 	}
 	if len(summary.ToolDistribution) > 0 {
@@ -71,6 +71,19 @@ func WriteAuditMarkdown(w io.Writer, result AuditResult) error {
 				escapeAuditMarkdown(r.Name), escapeAuditMarkdown(r.Subtype), r.Results, r.Success, r.Errors, r.Timeouts, r.Truncated, r.Unknown, r.Unmatched,
 				r.ExitZero, r.ExitNonzero, r.Results-r.ExitKnown, r.DurationKnown, r.DurationMS,
 				r.Stdout, r.Stderr, r.CombinedOutput, r.ChannelUnknown, r.Bytes)
+		}
+	}
+	if summary.UnknownExemplars.Retained > 0 || summary.UnknownExemplars.DroppedObservations > 0 {
+		reservoir := summary.UnknownExemplars
+		out.WriteString("\n## Unknown event structural exemplars\n\n")
+		fmt.Fprintf(&out, "Retained %d content-free shapes (%d serialized bytes) within fixed limits of %d shapes / %d bytes; dropped observations: %d. Structures contain scrubbed field names and JSON types only; scalar payload values are discarded before hashing and persistence.\n\n",
+			reservoir.Retained, reservoir.StoredBytes, reservoir.CardinalityLimit, reservoir.ByteLimit, reservoir.DroppedObservations)
+		out.WriteString("| ID | Source/subtype | Visibility → aggregate | Observations | Observed bytes | Shape hash | Structure |\n")
+		out.WriteString("|---|---|---|---:|---:|---|---|\n")
+		for _, exemplar := range reservoir.Exemplars {
+			fmt.Fprintf(&out, "| `%s` | `%s` / `%s` | `%s` → `%s` | %d | %d | `%s` | `%s` |\n",
+				exemplar.ID, exemplar.Source, exemplar.Subtype, exemplar.Visibility, exemplar.Aggregate,
+				exemplar.Observations, exemplar.ObservedBytes, exemplar.ShapeHash, escapeAuditMarkdown(exemplar.Structure))
 		}
 	}
 	if summary.QwenTopContributorTokenFraction == nil {
@@ -263,4 +276,15 @@ func auditDeltaComparedRegression(row AuditDeltaRow) bool {
 
 func escapeAuditMarkdown(value string) string {
 	return strings.ReplaceAll(value, "|", "\\|")
+}
+
+func auditExemplarIDLinks(ids []string) string {
+	if len(ids) == 0 {
+		return "—"
+	}
+	quoted := make([]string, len(ids))
+	for i, id := range ids {
+		quoted[i] = "`" + id + "`"
+	}
+	return strings.Join(quoted, ", ")
 }

--- a/internal/trajectory/testdata/audit/conformance/expectations.json
+++ b/internal/trajectory/testdata/audit/conformance/expectations.json
@@ -31,7 +31,7 @@
       "expected_storage_rows": [
         {"subtype": "attachment/deferred_tools_delta", "bytes": 123, "records": 1},
         {"subtype": "attachment/hook_completed", "bytes": 109, "records": 1},
-        {"subtype": "future_row_v99", "bytes": 90, "records": 1}
+        {"subtype": "record/discriminator#9e88b29883a2", "bytes": 90, "records": 1}
       ],
       "expected_totals": {
         "records": 13,
@@ -92,12 +92,12 @@
         {"line": 23, "ordinal": 0, "subtype": "response_item/message/future_message_block_v99", "category": "visible_unknown", "content_bytes": 61, "visible": true, "visibility": "unresolved", "visibility_reason": "unknown_message_block_subtype", "decision": "retained_unknown"}
       ],
       "expected_storage_rows": [
-        {"subtype": "event_msg/future_event_v99", "bytes": 75, "records": 1},
+        {"subtype": "event_msg/discriminator#8dde2a3a3ed8", "bytes": 75, "records": 1},
         {"subtype": "event_msg/item_completed/CommandExecution", "bytes": 129, "records": 1},
         {"subtype": "event_msg/item_started/CommandExecution", "bytes": 106, "records": 1},
         {"subtype": "event_msg/task_started", "bytes": 103, "records": 1},
         {"subtype": "event_msg/token_count", "bytes": 191, "records": 1},
-        {"subtype": "future_row_v99", "bytes": 54, "records": 1},
+        {"subtype": "record/discriminator#9e88b29883a2", "bytes": 54, "records": 1},
         {"subtype": "session_meta", "bytes": 110, "records": 1},
         {"subtype": "turn_context", "bytes": 59, "records": 1}
       ],


### PR DESCRIPTION
Implements #9563 with bounded scrubbed structural exemplar reservoirs, coalescing and report links. Focused witness: go test ./internal/trajectory -run 'Exemplar|Distribution|Canonical|Conformance|Attribution' -count=1 (run before unrelated nightly WIP entered shared package).