### PR TITLE
perf(selfupdate): expose phase timing and cache release metadata (#9591)

### DIFF
--- a/cmd/fak/selfupdate.go
+++ b/cmd/fak/selfupdate.go
@@ -297,17 +297,22 @@ func prepareFakDevUpdate(ctx context.Context, buildDir string, targets []string,
 func selfUpdateGateRunner(ctx context.Context, dir, name string, args ...string) (string, bool) {
 	percent := 0
 	operation := ""
+	phase := selfUpdatePhase("")
 	switch {
 	case name == "go" && len(args) > 0 && args[0] == "build":
 		percent, operation = 55, "building fak candidate"
+		phase = selfUpdatePhaseBuild
 	case name == "go" && len(args) > 0 && args[0] == "vet":
 		percent, operation = 70, "vetting fak candidate"
-	case len(args) == 1 && args[0] == "version":
+		phase = selfUpdatePhaseVet
+	case len(args) >= 1 && args[0] == "version":
 		percent, operation = 78, "smoke-verifying fak candidate"
+		phase = selfUpdatePhaseSmoke
 	}
 	if percent == 0 {
 		return selfinstall.RealRunner(ctx, dir, name, args...)
 	}
+	startSelfUpdatePhase(phase)
 	stopHeartbeat := startSelfUpdateHeartbeat(percent, operation)
 	out, ok := selfinstall.RealRunner(ctx, dir, name, args...)
 	stopHeartbeat()
@@ -373,8 +378,10 @@ func selfUpdateTransactionDetail(err error, rollbackErrors []error) string {
 // only an exit code cannot answer "when did the fleet binary last actually advance?".
 func emitSelfUpdateOutcome(cause selfUpdateOutcome, target, detail string) {
 	finishSelfUpdateProgress(cause)
+	timing := finishSelfUpdateTiming()
+	reportSelfUpdateTiming(timing)
 	if selfUpdateJSON != nil {
-		receipt := newSelfUpdateReceipt(cause, target, detail)
+		receipt := newSelfUpdateReceiptWithTiming(cause, target, detail, timing)
 		_ = json.NewEncoder(selfUpdateJSON).Encode(receipt)
 		selfUpdateJSON = nil
 		return
@@ -423,8 +430,10 @@ func emitSelfUpdateCheckOutcome(target, detail string, freshness binstamp.Freshn
 		return
 	}
 	finishSelfUpdateProgress(outcomeCheckOnly)
+	timing := finishSelfUpdateTiming()
+	reportSelfUpdateTiming(timing)
 	posture := classifySelfUpdateCheck(freshness, hotCopiesConverged)
-	receipt := newSelfUpdateReceipt(outcomeCheckOnly, target, detail)
+	receipt := newSelfUpdateReceiptWithTiming(outcomeCheckOnly, target, detail, timing)
 	receipt.Status = string(posture.Status)
 	receipt.NextCommand = posture.NextCommand
 	_ = json.NewEncoder(selfUpdateJSON).Encode(receipt)
@@ -448,11 +457,93 @@ type selfUpdateReceipt struct {
 	RestartRequired bool                      `json:"restart_required"`
 	NextCommand     string                    `json:"next_command"`
 	Handoff         *selfUpdateHandoffReceipt `json:"handoff,omitempty"`
+	TotalMS         int64                     `json:"total_ms"`
+	PhaseMS         selfUpdatePhaseMS         `json:"phase_ms"`
 }
 
 type selfUpdateReceiptTarget struct {
 	Role string `json:"role"`
 	Path string `json:"path"`
+}
+
+// selfUpdatePhaseMS is a fixed-shape object rather than a map so receipt consumers always see
+// the same phase vocabulary, including zeroes for phases an early exit did not reach.
+type selfUpdatePhaseMS struct {
+	Check     int64 `json:"check"`
+	Lock      int64 `json:"lock"`
+	Cleanup   int64 `json:"cleanup"`
+	Prepare   int64 `json:"prepare"`
+	Companion int64 `json:"companion"`
+	Build     int64 `json:"build"`
+	Vet       int64 `json:"vet"`
+	Smoke     int64 `json:"smoke"`
+	Install   int64 `json:"install"`
+	Verify    int64 `json:"verify"`
+	Handoff   int64 `json:"handoff"`
+}
+
+type selfUpdatePhase string
+
+const (
+	selfUpdatePhaseCheck     selfUpdatePhase = "check"
+	selfUpdatePhaseLock      selfUpdatePhase = "lock"
+	selfUpdatePhaseCleanup   selfUpdatePhase = "cleanup"
+	selfUpdatePhasePrepare   selfUpdatePhase = "prepare"
+	selfUpdatePhaseCompanion selfUpdatePhase = "companion"
+	selfUpdatePhaseBuild     selfUpdatePhase = "build"
+	selfUpdatePhaseVet       selfUpdatePhase = "vet"
+	selfUpdatePhaseSmoke     selfUpdatePhase = "smoke"
+	selfUpdatePhaseInstall   selfUpdatePhase = "install"
+	selfUpdatePhaseVerify    selfUpdatePhase = "verify"
+	selfUpdatePhaseHandoff   selfUpdatePhase = "handoff"
+)
+
+var selfUpdatePhaseOrder = [...]selfUpdatePhase{
+	selfUpdatePhaseCheck,
+	selfUpdatePhaseLock,
+	selfUpdatePhaseCleanup,
+	selfUpdatePhasePrepare,
+	selfUpdatePhaseCompanion,
+	selfUpdatePhaseBuild,
+	selfUpdatePhaseVet,
+	selfUpdatePhaseSmoke,
+	selfUpdatePhaseInstall,
+	selfUpdatePhaseVerify,
+	selfUpdatePhaseHandoff,
+}
+
+func (p *selfUpdatePhaseMS) set(phase selfUpdatePhase, value int64) {
+	switch phase {
+	case selfUpdatePhaseCheck:
+		p.Check = value
+	case selfUpdatePhaseLock:
+		p.Lock = value
+	case selfUpdatePhaseCleanup:
+		p.Cleanup = value
+	case selfUpdatePhasePrepare:
+		p.Prepare = value
+	case selfUpdatePhaseCompanion:
+		p.Companion = value
+	case selfUpdatePhaseBuild:
+		p.Build = value
+	case selfUpdatePhaseVet:
+		p.Vet = value
+	case selfUpdatePhaseSmoke:
+		p.Smoke = value
+	case selfUpdatePhaseInstall:
+		p.Install = value
+	case selfUpdatePhaseVerify:
+		p.Verify = value
+	case selfUpdatePhaseHandoff:
+		p.Handoff = value
+	}
+}
+
+type selfUpdateTimingSnapshot struct {
+	totalMS       int64
+	phaseMS       selfUpdatePhaseMS
+	dominantPhase selfUpdatePhase
+	dominantMS    int64
 }
 
 var selfUpdateProgress io.Writer = os.Stderr
@@ -464,6 +555,24 @@ var selfUpdateReceiptTargets []selfUpdateReceiptTarget
 var selfUpdateReceiptAttempted int
 var selfUpdateReceiptChanged int
 var selfUpdateReceiptHandoff *selfUpdateHandoffReceipt
+
+// selfUpdateTimingNow is the deterministic wall-clock seam for timing receipts. It is kept
+// separate from outcome timestamps and cleanup-age decisions so tests can control cost
+// attribution without changing production semantics elsewhere in the command.
+var selfUpdateTimingNow = time.Now
+
+type selfUpdateTimingTracker struct {
+	sync.Mutex
+	initialized  bool
+	finished     bool
+	started      time.Time
+	phaseStarted time.Time
+	active       selfUpdatePhase
+	elapsed      map[selfUpdatePhase]time.Duration
+	snapshot     selfUpdateTimingSnapshot
+}
+
+var selfUpdateTimingState selfUpdateTimingTracker
 
 var selfUpdateProgressState struct {
 	sync.Mutex
@@ -484,6 +593,82 @@ var selfUpdateHeartbeatWait = func(stop <-chan struct{}, interval time.Duration)
 	case <-stop:
 		return false
 	}
+}
+
+func beginSelfUpdateTiming() {
+	now := selfUpdateTimingNow()
+	selfUpdateTimingState.Lock()
+	selfUpdateTimingState.initialized = true
+	selfUpdateTimingState.finished = false
+	selfUpdateTimingState.started = now
+	selfUpdateTimingState.phaseStarted = now
+	selfUpdateTimingState.active = selfUpdatePhaseCheck
+	selfUpdateTimingState.elapsed = make(map[selfUpdatePhase]time.Duration, len(selfUpdatePhaseOrder))
+	selfUpdateTimingState.snapshot = selfUpdateTimingSnapshot{}
+	selfUpdateTimingState.Unlock()
+}
+
+// startSelfUpdatePhase closes the previous phase and starts the named one. Re-entering a phase
+// accumulates its duration, which lets "prepare" cover both worktree preparation and the later
+// target census without inventing an unstable one-off phase name.
+func startSelfUpdatePhase(phase selfUpdatePhase) {
+	now := selfUpdateTimingNow()
+	selfUpdateTimingState.Lock()
+	defer selfUpdateTimingState.Unlock()
+	if !selfUpdateTimingState.initialized || selfUpdateTimingState.finished {
+		return
+	}
+	selfUpdateTimingState.recordActive(now)
+	selfUpdateTimingState.active = phase
+}
+
+func (s *selfUpdateTimingTracker) recordActive(now time.Time) {
+	if s.active != "" && !now.Before(s.phaseStarted) {
+		s.elapsed[s.active] += now.Sub(s.phaseStarted)
+	}
+	s.phaseStarted = now
+}
+
+func finishSelfUpdateTiming() selfUpdateTimingSnapshot {
+	now := selfUpdateTimingNow()
+	selfUpdateTimingState.Lock()
+	defer selfUpdateTimingState.Unlock()
+	if !selfUpdateTimingState.initialized {
+		return selfUpdateTimingSnapshot{}
+	}
+	if selfUpdateTimingState.finished {
+		return selfUpdateTimingState.snapshot
+	}
+	selfUpdateTimingState.recordActive(now)
+
+	var phaseMS selfUpdatePhaseMS
+	dominant := selfUpdatePhaseOrder[0]
+	dominantDuration := selfUpdateTimingState.elapsed[dominant]
+	for _, phase := range selfUpdatePhaseOrder {
+		elapsed := selfUpdateTimingState.elapsed[phase]
+		phaseMS.set(phase, elapsed.Milliseconds())
+		if elapsed > dominantDuration {
+			dominant = phase
+			dominantDuration = elapsed
+		}
+	}
+	total := time.Duration(0)
+	if !now.Before(selfUpdateTimingState.started) {
+		total = now.Sub(selfUpdateTimingState.started)
+	}
+	selfUpdateTimingState.snapshot = selfUpdateTimingSnapshot{
+		totalMS:       total.Milliseconds(),
+		phaseMS:       phaseMS,
+		dominantPhase: dominant,
+		dominantMS:    dominantDuration.Milliseconds(),
+	}
+	selfUpdateTimingState.finished = true
+	return selfUpdateTimingState.snapshot
+}
+
+func reportSelfUpdateTiming(timing selfUpdateTimingSnapshot) {
+	fmt.Fprintf(selfUpdateProgress, "self-update: timing total_ms=%d dominant_phase=%s dominant_ms=%d\n",
+		timing.totalMS, timing.dominantPhase, timing.dominantMS)
 }
 
 // reportSelfUpdateProgress emits a useful current operation with an honest overall estimate.
@@ -557,6 +742,7 @@ func beginSelfUpdateOutput(enabled bool) {
 	selfUpdateReceiptAttempted = 0
 	selfUpdateReceiptChanged = 0
 	selfUpdateReceiptHandoff = nil
+	beginSelfUpdateTiming()
 	if enabled {
 		selfUpdateJSON = os.Stdout
 	}
@@ -571,6 +757,10 @@ func randomSelfUpdateCorrelationID() string {
 }
 
 func newSelfUpdateReceipt(cause selfUpdateOutcome, target, detail string) selfUpdateReceipt {
+	return newSelfUpdateReceiptWithTiming(cause, target, detail, selfUpdateTimingSnapshot{})
+}
+
+func newSelfUpdateReceiptWithTiming(cause selfUpdateOutcome, target, detail string, timing selfUpdateTimingSnapshot) selfUpdateReceipt {
 	status := "current"
 	rollbackStatus := "not_attempted"
 	restartRequired := false
@@ -614,6 +804,7 @@ func newSelfUpdateReceipt(cause selfUpdateOutcome, target, detail string) selfUp
 		OldRevision: optionalRevision(selfUpdateReceiptOldRevision), NewRevision: optionalRevision(selfUpdateReceiptNewRevision),
 		Targets: targets, Attempted: selfUpdateReceiptAttempted, Changed: selfUpdateReceiptChanged, RollbackStatus: rollbackStatus,
 		RollbackErrors: rollbackErrors, RestartRequired: restartRequired, NextCommand: nextCommand, Handoff: selfUpdateReceiptHandoff,
+		TotalMS: timing.totalMS, PhaseMS: timing.phaseMS,
 	}
 }
 

--- a/cmd/fak/selfupdate_install.go
+++ b/cmd/fak/selfupdate_install.go
@@ -13,6 +13,7 @@ import (
 )
 
 func performSelfUpdate(repoRoot, headRev string, target *string, companionPaths []string, handoffSession string, handoffTimeout time.Duration, successorArgs []string) {
+	startSelfUpdatePhase(selfUpdatePhaseLock)
 	reportSelfUpdateProgress(20, "acquiring self-update lock")
 	installTarget := strings.TrimSpace(*target)
 	if installTarget == "" {
@@ -44,6 +45,7 @@ func performSelfUpdate(repoRoot, headRev string, target *string, companionPaths 
 	// tree: that gives a clean VCS stamp on the installed binary and guarantees we install
 	// exactly verified origin/main, not a build contaminated with peers' work-in-progress.
 	ctx := context.Background()
+	startSelfUpdatePhase(selfUpdatePhaseCleanup)
 	reportSelfUpdateProgress(25, "cleaning stale self-update artifacts")
 
 	// Self-heal first: collect build worktrees leaked by PRIOR self-update ticks that
@@ -88,6 +90,7 @@ func performSelfUpdate(repoRoot, headRev string, target *string, companionPaths 
 	// A per-invocation temp dir under the OS temp root satisfies both. BuildDirName encodes
 	// our PID so a future run's reaper can tell a live build from a leaked corpse.
 	buildDir := filepath.Join(os.TempDir(), selfinstall.BuildDirName(os.Getpid()))
+	startSelfUpdatePhase(selfUpdatePhasePrepare)
 	stopHeartbeat := startSelfUpdateHeartbeat(30, "preparing pristine origin/main worktree")
 	_, cleanup, perr := selfinstall.PrepareOrigin(ctx, selfinstall.RealRunner, repoRoot, "origin/main", buildDir)
 	stopHeartbeat()
@@ -98,6 +101,7 @@ func performSelfUpdate(repoRoot, headRev string, target *string, companionPaths 
 	}
 	defer cleanup()
 
+	startSelfUpdatePhase(selfUpdatePhaseCompanion)
 	companionBinary, companionPaths, companionErr := prepareFakDevUpdate(ctx, buildDir, companionPaths, headRev)
 	if companionErr != nil {
 		fmt.Fprintln(os.Stderr, "self-update:", companionErr)
@@ -113,6 +117,7 @@ func performSelfUpdate(repoRoot, headRev string, target *string, companionPaths 
 
 	// Select every hot-copy target before changing any deployed bytes. The transaction must use
 	// one pre-update census or a successful early swap can hide a stale later target.
+	startSelfUpdatePhase(selfUpdatePhasePrepare)
 	census := selfinstall.Census(selfUpdateHost(repoRoot), selfUpdateProbe)
 	reportSelfUpdateProgress(48, "selecting installed targets")
 	staleSiblings := []string{}
@@ -124,12 +129,15 @@ func performSelfUpdate(repoRoot, headRev string, target *string, companionPaths 
 
 	fmt.Fprintf(selfUpdateProgress, "self-update: building and gating origin/main for %d target(s) …\n", 1+len(staleSiblings)+len(companionPaths))
 	candidate := ""
+	startSelfUpdatePhase(selfUpdatePhaseBuild)
 	res := selfinstall.Install(ctx, selfUpdateGateRunner, func(source, _ string) error {
 		candidate = source
 		return nil
 	}, selfinstall.Options{
-		RepoRoot: buildDir,
-		Target:   installTarget,
+		RepoRoot:       buildDir,
+		Target:         installTarget,
+		ExpectedCommit: headRev,
+		CacheDir:       selfinstall.CandidateCacheDir(discoverGitCommonDir(repoRoot)),
 	})
 	if !res.Installed || candidate == "" {
 		detail := string(res.Stage) + ": " + res.Detail
@@ -163,6 +171,7 @@ func performSelfUpdate(repoRoot, headRev string, target *string, companionPaths 
 		selfUpdateReceiptTargets = append(selfUpdateReceiptTargets, selfUpdateReceiptTarget{Role: role, Path: filepath.Clean(copy.Target)})
 	}
 	selfUpdateReceiptAttempted = len(copies)
+	startSelfUpdatePhase(selfUpdatePhaseInstall)
 	stopHeartbeat = startSelfUpdateHeartbeat(82, "installing verified binaries")
 	transaction := selfinstall.RunTransaction(copies, selfinstall.OSSwap)
 	stopHeartbeat()
@@ -203,6 +212,7 @@ func performSelfUpdate(repoRoot, headRev string, target *string, companionPaths 
 	// the build it is stuck on. The audit-only role (the repo-root gate binary, a hand-build in a
 	// shared dirty checkout that may be held live) is never swapped unattended — so an explicit,
 	// greppable audit line is the only thing that keeps it from drifting unnoticed.
+	startSelfUpdatePhase(selfUpdatePhaseVerify)
 	stopHeartbeat = startSelfUpdateHeartbeat(92, "verifying installed hot copies")
 	audit := selfUpdateAudit(repoRoot, headRev)
 	stopHeartbeat()
@@ -215,6 +225,7 @@ func performSelfUpdate(repoRoot, headRev string, target *string, companionPaths 
 	if handoffSession != "" {
 		ctx, cancel := context.WithTimeout(context.Background(), handoffTimeout)
 		defer cancel()
+		startSelfUpdatePhase(selfUpdatePhaseHandoff)
 		stopHeartbeat = startSelfUpdateHeartbeat(97, "handing off to updated binary")
 		handoff := runSelfUpdateHandoff(ctx, installTarget, handoffSession, headRev, successorArgs)
 		stopHeartbeat()

--- a/cmd/fak/selfupdate_test.go
+++ b/cmd/fak/selfupdate_test.go
@@ -32,6 +32,18 @@ func resetSelfUpdateProgressForTest() {
 	selfUpdateProgressState.Unlock()
 }
 
+func resetSelfUpdateTimingForTest() {
+	selfUpdateTimingState.Lock()
+	selfUpdateTimingState.initialized = false
+	selfUpdateTimingState.finished = false
+	selfUpdateTimingState.started = time.Time{}
+	selfUpdateTimingState.phaseStarted = time.Time{}
+	selfUpdateTimingState.active = ""
+	selfUpdateTimingState.elapsed = nil
+	selfUpdateTimingState.snapshot = selfUpdateTimingSnapshot{}
+	selfUpdateTimingState.Unlock()
+}
+
 func TestSelfUpdateProgressIsMonotonicAndCompletesOnlyAtOutcome(t *testing.T) {
 	oldProgress := selfUpdateProgress
 	var stderr strings.Builder
@@ -440,16 +452,39 @@ func TestSelfUpdateCheckDoesNotFetchOrigin(t *testing.T) {
 func TestEmitSelfUpdateJSONIsOneObjectWithoutProse(t *testing.T) {
 	oldCorrelation := selfUpdateCorrelationID
 	oldProgress, oldJSON := selfUpdateProgress, selfUpdateJSON
+	oldNow := selfUpdateTimingNow
 	selfUpdateCorrelationID = func() string { return "corr-123" }
+	base := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	times := []time.Time{
+		base,
+		base.Add(10 * time.Millisecond),
+		base.Add(50 * time.Millisecond),
+		base.Add(70 * time.Millisecond),
+	}
+	timeCall := 0
+	selfUpdateTimingNow = func() time.Time {
+		if timeCall >= len(times) {
+			t.Fatalf("timing seam called %d times; want at most %d", timeCall+1, len(times))
+		}
+		now := times[timeCall]
+		timeCall++
+		return now
+	}
 	t.Cleanup(func() {
 		selfUpdateCorrelationID = oldCorrelation
 		selfUpdateProgress, selfUpdateJSON = oldProgress, oldJSON
+		selfUpdateTimingNow = oldNow
+		resetSelfUpdateProgressForTest()
+		resetSelfUpdateTimingForTest()
 	})
 
 	var stdout, stderr strings.Builder
 	selfUpdateJSON = &stdout
 	selfUpdateProgress = &stderr
 	resetSelfUpdateProgressForTest()
+	beginSelfUpdateTiming()
+	startSelfUpdatePhase(selfUpdatePhaseBuild)
+	startSelfUpdatePhase(selfUpdatePhaseVet)
 	reportSelfUpdateProgress(82, "installing verified binaries")
 	emitSelfUpdateOutcome(outcomeBusy, "bin/fak", "single-flight lock held")
 	if strings.Count(stdout.String(), "\n") != 1 {
@@ -467,7 +502,34 @@ func TestEmitSelfUpdateJSONIsOneObjectWithoutProse(t *testing.T) {
 	if receipt.Status != "busy" {
 		t.Fatalf("status = %q", receipt.Status)
 	}
-	if got := stderr.String(); !strings.Contains(got, "progress=82%") || !strings.Contains(got, "progress=100%") || strings.Contains(stdout.String(), "installing verified binaries") {
+	if receipt.TotalMS != 70 || receipt.PhaseMS.Check != 10 || receipt.PhaseMS.Build != 40 || receipt.PhaseMS.Vet != 20 {
+		t.Fatalf("deterministic timing receipt = %+v", receipt)
+	}
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(stdout.String()), &envelope); err != nil {
+		t.Fatal(err)
+	}
+	var phases map[string]int64
+	if err := json.Unmarshal(envelope["phase_ms"], &phases); err != nil {
+		t.Fatalf("phase_ms is not an object: %v", err)
+	}
+	wantPhases := []string{"check", "lock", "cleanup", "prepare", "companion", "build", "vet", "smoke", "install", "verify", "handoff"}
+	if len(phases) != len(wantPhases) {
+		t.Fatalf("phase_ms keys = %v; want stable %v", phases, wantPhases)
+	}
+	for _, phase := range wantPhases {
+		if _, ok := phases[phase]; !ok {
+			t.Errorf("phase_ms missing stable key %q: %v", phase, phases)
+		}
+	}
+	if timeCall != len(times) {
+		t.Fatalf("timing seam calls = %d, want %d", timeCall, len(times))
+	}
+	if got := stderr.String(); !strings.Contains(got, "progress=82%") ||
+		!strings.Contains(got, "progress=100%") ||
+		!strings.Contains(got, "timing total_ms=70 dominant_phase=build dominant_ms=40") ||
+		strings.Contains(stdout.String(), "installing verified binaries") ||
+		strings.Contains(stdout.String(), "dominant_phase") {
 		t.Fatalf("progress routing: stdout=%q stderr=%q", stdout.String(), got)
 	}
 }

--- a/internal/selfinstall/selfinstall.go
+++ b/internal/selfinstall/selfinstall.go
@@ -10,6 +10,8 @@
 // once; the gate is therefore not optional polish — it is the whole point.
 //
 // The flow (Install):
+//  0. cache   restore only an exact-input, digest-verified candidate, then smoke it again;
+//     any miss or mismatch falls through to the complete gate below.
 //  1. build   `go build [-ldflags -X …BuildVersion=<VERSION>] -o <tmp> ./cmd/fak` — a tree
 //     that won't compile stops here; the ldflags bake the tree's VERSION into the
 //     binary so its reported version does not depend on a guard's runtime cwd.
@@ -23,11 +25,16 @@
 package selfinstall
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 )
@@ -61,6 +68,64 @@ type Result struct {
 	Detail    string // captured output / error context for the failing or final stage
 }
 
+const candidateCacheSchema = "fak.selfinstall.candidate-cache.v1"
+
+var candidateGoEnvKeys = []string{
+	"GOVERSION",
+	"GOROOT",
+	"GOTOOLCHAIN",
+	"GOHOSTOS",
+	"GOHOSTARCH",
+	"GOOS",
+	"GOARCH",
+	"GOAMD64",
+	"GOARM64",
+	"GOARM",
+	"GO386",
+	"GOMIPS",
+	"GOMIPS64",
+	"GOEXPERIMENT",
+	"GOFIPS140",
+	"CGO_ENABLED",
+	"CC",
+	"CXX",
+	"CGO_CFLAGS",
+	"CGO_CPPFLAGS",
+	"CGO_CXXFLAGS",
+	"CGO_LDFLAGS",
+	"PKG_CONFIG",
+	"GOFLAGS",
+	"GO111MODULE",
+	"GOWORK",
+}
+
+type candidateCacheInput struct {
+	Schema         string   `json:"schema"`
+	ExpectedCommit string   `json:"expected_commit"`
+	SourceCommit   string   `json:"source_commit"`
+	HostOS         string   `json:"host_os"`
+	HostArch       string   `json:"host_arch"`
+	GoEnvKeys      []string `json:"go_env_keys"`
+	GoEnv          string   `json:"go_env"`
+	BuildArgs      []string `json:"build_args"`
+	VetArgs        []string `json:"vet_args"`
+}
+
+type candidateCacheManifest struct {
+	Schema         string `json:"schema"`
+	ExpectedCommit string `json:"expected_commit"`
+	InputDigest    string `json:"input_digest"`
+	ArtifactDigest string `json:"artifact_digest"`
+	ArtifactSize   int64  `json:"artifact_size"`
+	BoundDigest    string `json:"bound_digest"`
+}
+
+type candidateVersionIdentity struct {
+	Commit  string `json:"commit"`
+	Dirty   bool   `json:"dirty"`
+	Stamped bool   `json:"stamped"`
+}
+
 // Options configures Install.
 type Options struct {
 	// RepoRoot is the checkout to build from (the dir `go build` runs in).
@@ -70,6 +135,14 @@ type Options struct {
 	// BuildTmp is where the candidate binary is built before the swap. Empty => a sibling
 	// of Target with a ".new" suffix (same volume, so the swap is a cheap rename).
 	BuildTmp string
+	// CacheDir stores a previously build/vet/smoke-verified candidate. Empty disables
+	// reuse. Cache acceptance is fail-closed on the clean exact commit, Go
+	// toolchain/platform/build inputs, artifact SHA-256, and a fresh smoke/provenance check.
+	CacheDir string
+	// ExpectedCommit is the exact clean commit selected by the caller. When caching is enabled,
+	// empty falls back to the checkout's clean HEAD. A valid explicit value must match both the
+	// checkout and the candidate's full `version --json` provenance before reuse or activation.
+	ExpectedCommit string
 }
 
 // Install runs the gated build→vet→smoke→swap ladder. It installs IFF every gate passes; on
@@ -86,54 +159,353 @@ func Install(ctx context.Context, run Runner, swap Swapper, opts Options) Result
 		}
 	}()
 
-	// 1. build the candidate, baking the tree's VERSION into it as appversion.BuildVersion
-	//    (see versionLDFlags for why this is load-bearing, not cosmetic). -buildvcs=true
-	//    FORCES the VCS stamp: under Go's default -buildvcs=auto the detached-worktree build
-	//    (PrepareOrigin) can silently drop the stamp when VCS detection can't resolve the
-	//    repo, shipping a binary that cannot attest which commit it is (#3350, epic #2218 gap
-	//    G2). With =true the build FAILS instead of emitting an unstamped binary.
-	buildArgs := []string{"build", "-buildvcs=true"}
-	commit := ""
+	sourceCommit := ""
 	if out, ok := run(ctx, opts.RepoRoot, "git", "status", "--porcelain"); ok && strings.TrimSpace(out) == "" {
 		if out, ok := run(ctx, opts.RepoRoot, "git", "rev-parse", "HEAD"); ok {
 			candidate := strings.TrimSpace(out)
 			if validCommit(candidate) {
-				commit = candidate
+				sourceCommit = strings.ToLower(candidate)
 			}
 		}
 	}
-	if ld := versionLDFlags(opts.RepoRoot, commit); ld != "" {
-		buildArgs = append(buildArgs, "-ldflags", ld)
+
+	explicitExpectedCommit := strings.ToLower(strings.TrimSpace(opts.ExpectedCommit))
+	if explicitExpectedCommit != "" && !validCommit(explicitExpectedCommit) {
+		return Result{Stage: StageSmoke, Detail: "expected commit is not a full 40-character Git object ID"}
 	}
-	buildArgs = append(buildArgs, "-o", tmp, "./cmd/fak")
-	if out, ok := run(ctx, opts.RepoRoot, "go", buildArgs...); !ok {
-		return Result{Stage: StageBuild, Detail: trim(out)}
+	if explicitExpectedCommit != "" && !strings.EqualFold(sourceCommit, explicitExpectedCommit) {
+		return Result{Stage: StageSmoke, Detail: fmt.Sprintf("clean source checkout reports commit %s, want exact commit %s", emptyLabel(sourceCommit), explicitExpectedCommit)}
 	}
-	// 2. vet the package (catches a compiling-but-suspect tree).
-	if out, ok := run(ctx, opts.RepoRoot, "go", "vet", "./cmd/fak"); !ok {
-		return Result{Stage: StageVet, Detail: trim(out)}
+	expectedCommit := explicitExpectedCommit
+	if expectedCommit == "" && strings.TrimSpace(opts.CacheDir) != "" {
+		expectedCommit = sourceCommit
 	}
-	// 3. smoke: the freshly-built binary must run, self-report its version, AND carry a real
-	//    VCS stamp. Running catches a binary that builds but cannot start (bad cgo link,
-	//    missing data file, panic on init). The stamp check is fail-CLOSED on provenance
-	//    (#3350, epic #2218 gap G2): an unstamped binary still exits 0 on `version`, so
-	//    without it a stampless candidate would swap in indistinguishable from a good one and
-	//    blind every downstream "which commit is this guard?" / version-skew check.
-	//    -buildvcs=true already makes the build FAIL when it cannot stamp; this second gate
-	//    refuses to swap a binary that somehow still reports no stamp.
-	out, ok := run(ctx, opts.RepoRoot, tmp, "version")
-	if !ok {
-		return Result{Stage: StageSmoke, Detail: trim(out)}
+	if !validCommit(expectedCommit) {
+		expectedCommit = ""
 	}
-	if !versionOutputStamped(out) {
-		return Result{Stage: StageSmoke, Detail: "candidate binary is UNSTAMPED — `version` reports no VCS provenance; refusing to swap an unattestable binary over the fleet: " + trim(out)}
+
+	// The output path changes per activation and cannot affect the artifact, so the cache
+	// identity binds the stable build arguments rather than BuildTmp.
+	buildInputs := []string{"build", "-buildvcs=true"}
+	if ld := versionLDFlags(opts.RepoRoot, sourceCommit); ld != "" {
+		buildInputs = append(buildInputs, "-ldflags", ld)
 	}
+	buildArgs := append(append([]string{}, buildInputs...), "-o", tmp, "./cmd/fak")
+	buildInputs = append(buildInputs, "./cmd/fak")
+	vetArgs := []string{"vet", "./cmd/fak"}
+
+	cacheDir := strings.TrimSpace(opts.CacheDir)
+	var cacheInput candidateCacheInput
+	cacheEligible := cacheDir != "" &&
+		validCommit(sourceCommit) &&
+		validCommit(expectedCommit) &&
+		strings.EqualFold(sourceCommit, expectedCommit)
+	cacheHit := false
+	if cacheEligible {
+		envArgs := append([]string{"env"}, candidateGoEnvKeys...)
+		if out, ok := run(ctx, opts.RepoRoot, "go", envArgs...); ok {
+			cacheInput = candidateCacheInput{
+				Schema:         candidateCacheSchema,
+				ExpectedCommit: expectedCommit,
+				SourceCommit:   sourceCommit,
+				HostOS:         runtime.GOOS,
+				HostArch:       runtime.GOARCH,
+				GoEnvKeys:      append([]string{}, candidateGoEnvKeys...),
+				GoEnv:          normalizeCommandOutput(out),
+				BuildArgs:      append([]string{}, buildInputs...),
+				VetArgs:        append([]string{}, vetArgs...),
+			}
+			if restoreCandidateCache(cacheDir, cacheInput, tmp) == nil {
+				if _, ok := smokeCandidate(ctx, run, opts.RepoRoot, tmp, expectedCommit); ok {
+					cacheHit = true
+				} else {
+					// Digest-valid bytes still need to start and attest the exact selected
+					// commit on every activation. Any smoke/provenance failure falls through
+					// to a full build+vet rather than failing open or wedging updates.
+					_ = os.Remove(tmp)
+				}
+			}
+		} else {
+			cacheEligible = false
+		}
+	}
+
+	cacheRefreshDetail := ""
+	if !cacheHit {
+		// 1. build the candidate, baking the tree's VERSION into it as
+		//    appversion.BuildVersion (see versionLDFlags for why this is load-bearing, not
+		//    cosmetic). -buildvcs=true FORCES the VCS stamp: under Go's default
+		//    -buildvcs=auto the detached-worktree build (PrepareOrigin) can silently drop the
+		//    stamp when VCS detection cannot resolve the repo, shipping a binary that cannot
+		//    attest which commit it is (#3350, epic #2218 gap G2). With =true the build FAILS
+		//    instead of emitting an unstamped binary.
+		if out, ok := run(ctx, opts.RepoRoot, "go", buildArgs...); !ok {
+			return Result{Stage: StageBuild, Detail: trim(out)}
+		}
+		// 2. vet the package (catches a compiling-but-suspect tree).
+		if out, ok := run(ctx, opts.RepoRoot, "go", vetArgs...); !ok {
+			return Result{Stage: StageVet, Detail: trim(out)}
+		}
+		// 3. smoke: the freshly-built binary must run and report its full machine-readable
+		//    provenance. When the caller selected an exact commit, the candidate must attest
+		//    that full commit and a clean build before it can be cached or swapped.
+		if out, ok := smokeCandidate(ctx, run, opts.RepoRoot, tmp, expectedCommit); !ok {
+			return Result{Stage: StageSmoke, Detail: trim(out)}
+		}
+		if cacheEligible {
+			if err := refreshCandidateCache(cacheDir, cacheInput, tmp); err != nil {
+				// Cache persistence is an optimization, not an installation gate. The
+				// candidate itself still passed build, vet, and exact-provenance smoke.
+				cacheRefreshDetail = "; candidate cache refresh failed: " + trim(err.Error())
+			}
+		}
+	}
+
 	// 4. swap: only now is the candidate trusted over the running fleet.
 	cleanupBuildArtifact = false
 	if err := swap(tmp, opts.Target); err != nil {
 		return Result{Stage: StageSwap, Detail: err.Error()}
 	}
-	return Result{Installed: true, Stage: StageSwap, Detail: "installed " + filepath.Base(opts.Target)}
+	detail := "installed " + filepath.Base(opts.Target)
+	if cacheHit {
+		detail += " from exact-commit verified candidate cache"
+	}
+	return Result{Installed: true, Stage: StageSwap, Detail: detail + cacheRefreshDetail}
+}
+
+func normalizeCommandOutput(out string) string {
+	return strings.TrimSpace(strings.ReplaceAll(out, "\r\n", "\n"))
+}
+
+func emptyLabel(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "(unverified or dirty)"
+	}
+	return value
+}
+
+func smokeCandidate(ctx context.Context, run Runner, repoRoot, candidate, expectedCommit string) (string, bool) {
+	out, ok := run(ctx, repoRoot, candidate, "version", "--json")
+	if !ok {
+		return out, false
+	}
+	var identity candidateVersionIdentity
+	if err := json.Unmarshal([]byte(out), &identity); err != nil {
+		if expectedCommit == "" && versionOutputStamped(out) {
+			return out, true
+		}
+		return "candidate provenance is not valid `version --json`: " + trim(out), false
+	}
+	if !identity.Stamped || identity.Dirty || !validCommit(identity.Commit) {
+		return "candidate binary is unstamped or dirty; refusing to swap: " + trim(out), false
+	}
+	if expectedCommit != "" && !strings.EqualFold(identity.Commit, expectedCommit) {
+		return fmt.Sprintf("candidate binary reports commit %s, want exact commit %s", identity.Commit, expectedCommit), false
+	}
+	return out, true
+}
+
+func candidateInputDigest(input candidateCacheInput) (string, error) {
+	data, err := json.Marshal(input)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func candidateBoundDigest(inputDigest, artifactDigest string) string {
+	sum := sha256.Sum256([]byte(candidateCacheSchema + "\x00" + inputDigest + "\x00" + artifactDigest))
+	return hex.EncodeToString(sum[:])
+}
+
+// CandidateCacheDir maps the clone-shared Git common directory to the persistent
+// self-update cache. An unresolved common directory disables caching rather than creating
+// a relative or bogus .git directory inside a linked/custom worktree.
+func CandidateCacheDir(gitCommonDir string) string {
+	if strings.TrimSpace(gitCommonDir) == "" {
+		return ""
+	}
+	return filepath.Join(filepath.Clean(gitCommonDir), "fak", "self-update-cache")
+}
+
+func candidateCachePaths(dir string) (manifest string) {
+	return filepath.Join(dir, "manifest.json")
+}
+
+func candidateArtifactPath(dir, artifactDigest string) string {
+	return filepath.Join(dir, "candidate-"+artifactDigest)
+}
+
+func fileSHA256(path string) (string, int64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", 0, err
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return "", 0, err
+	}
+	if !info.Mode().IsRegular() {
+		return "", 0, fmt.Errorf("%s is not a regular file", path)
+	}
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", 0, err
+	}
+	return hex.EncodeToString(h.Sum(nil)), info.Size(), nil
+}
+
+func restoreCandidateCache(dir string, input candidateCacheInput, dst string) error {
+	inputDigest, err := candidateInputDigest(input)
+	if err != nil {
+		return err
+	}
+	data, err := os.ReadFile(candidateCachePaths(dir))
+	if err != nil {
+		return err
+	}
+	var manifest candidateCacheManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return err
+	}
+	if manifest.Schema != candidateCacheSchema ||
+		!strings.EqualFold(manifest.ExpectedCommit, input.ExpectedCommit) ||
+		manifest.InputDigest != inputDigest ||
+		manifest.BoundDigest != candidateBoundDigest(inputDigest, manifest.ArtifactDigest) {
+		return fmt.Errorf("candidate cache identity mismatch")
+	}
+	if !validSHA256(manifest.ArtifactDigest) {
+		return fmt.Errorf("candidate cache artifact digest is malformed")
+	}
+	artifact := candidateArtifactPath(dir, manifest.ArtifactDigest)
+	digest, size, err := fileSHA256(artifact)
+	if err != nil {
+		return err
+	}
+	if digest != manifest.ArtifactDigest || size != manifest.ArtifactSize {
+		return fmt.Errorf("candidate cache artifact digest mismatch")
+	}
+	if err := atomicCopyFile(artifact, dst); err != nil {
+		return err
+	}
+	copiedDigest, copiedSize, err := fileSHA256(dst)
+	if err != nil {
+		_ = os.Remove(dst)
+		return err
+	}
+	if copiedDigest != manifest.ArtifactDigest || copiedSize != manifest.ArtifactSize {
+		_ = os.Remove(dst)
+		return fmt.Errorf("restored candidate digest mismatch")
+	}
+	return nil
+}
+
+func validSHA256(s string) bool {
+	if len(s) != sha256.Size*2 || strings.ToLower(s) != s {
+		return false
+	}
+	_, err := hex.DecodeString(s)
+	return err == nil
+}
+
+func refreshCandidateCache(dir string, input candidateCacheInput, src string) error {
+	inputDigest, err := candidateInputDigest(input)
+	if err != nil {
+		return err
+	}
+	artifactDigest, artifactSize, err := fileSHA256(src)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	artifact := candidateArtifactPath(dir, artifactDigest)
+	if err := atomicCopyFile(src, artifact); err != nil {
+		return err
+	}
+	storedDigest, storedSize, err := fileSHA256(artifact)
+	if err != nil {
+		return err
+	}
+	if storedDigest != artifactDigest || storedSize != artifactSize {
+		return fmt.Errorf("refreshed candidate digest mismatch")
+	}
+	manifest := candidateCacheManifest{
+		Schema:         candidateCacheSchema,
+		ExpectedCommit: input.ExpectedCommit,
+		InputDigest:    inputDigest,
+		ArtifactDigest: artifactDigest,
+		ArtifactSize:   artifactSize,
+		BoundDigest:    candidateBoundDigest(inputDigest, artifactDigest),
+	}
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	if err := atomicWriteFile(candidateCachePaths(dir), 0o600, bytes.NewReader(data)); err != nil {
+		return err
+	}
+	pruneCandidateArtifacts(dir, artifact)
+	return nil
+}
+
+func atomicCopyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	info, err := in.Stat()
+	if err != nil {
+		return err
+	}
+	return atomicWriteFile(dst, info.Mode().Perm(), in)
+}
+
+func atomicWriteFile(dst string, mode os.FileMode, source io.Reader) (err error) {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(dst), "."+filepath.Base(dst)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+	}()
+	if err := tmp.Chmod(mode); err != nil {
+		return err
+	}
+	if _, err := io.Copy(tmp, source); err != nil {
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return OSSwap(tmpPath, dst)
+}
+
+func pruneCandidateArtifacts(dir, keep string) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		path := filepath.Join(dir, entry.Name())
+		if path == keep || !strings.HasPrefix(entry.Name(), "candidate-") {
+			continue
+		}
+		_ = os.Remove(path)
+	}
 }
 
 // InstallVerifiedCopy installs an already-gated fak binary at another hot-copy path.

--- a/internal/selfinstall/selfinstall_test.go
+++ b/internal/selfinstall/selfinstall_test.go
@@ -2,10 +2,12 @@ package selfinstall
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // scriptRunner fails the FIRST command whose joined argv contains failOn; everything else
@@ -620,5 +622,305 @@ func TestInstallVerifiedCopyLeavesTargetOnSwapFailure(t *testing.T) {
 	}
 	if string(got) != "stale but usable" {
 		t.Fatalf("target changed after failed swap: %q", got)
+	}
+}
+
+const (
+	cacheTestCommitA = "0123456789abcdef0123456789abcdef01234567"
+	cacheTestCommitB = "89abcdef0123456789abcdef0123456789abcdef"
+)
+
+// candidateCacheRunner models the entire expensive gate with a virtual clock. The latency
+// table never changes between cold and warm runs, so timing assertions measure eliminated
+// work rather than scheduler noise. Smoke identities may be queued to model a digest-valid
+// cache entry whose executable provenance is nevertheless wrong.
+type candidateCacheRunner struct {
+	commit        string
+	goEnv         string
+	artifact      []byte
+	builds        int
+	vets          int
+	smokes        int
+	elapsed       time.Duration
+	smokeCommits  []string
+	lastBuildPath string
+}
+
+func newCandidateCacheRunner() *candidateCacheRunner {
+	return &candidateCacheRunner{
+		commit: cacheTestCommitA,
+		goEnv: `go1.26.0
+/toolchain/go1.26
+auto
+windows
+amd64
+windows
+amd64
+`,
+		artifact: []byte("exact candidate bytes"),
+	}
+}
+
+func (r *candidateCacheRunner) run(_ context.Context, _ string, name string, args ...string) (string, bool) {
+	switch {
+	case name == "git" && len(args) == 2 && args[0] == "status":
+		r.elapsed += 25 * time.Millisecond
+		return "", true
+	case name == "git" && len(args) == 2 && args[0] == "rev-parse":
+		r.elapsed += 25 * time.Millisecond
+		return r.commit + "\n", true
+	case name == "go" && len(args) > 0 && args[0] == "env":
+		r.elapsed += 50 * time.Millisecond
+		return r.goEnv, true
+	case name == "go" && len(args) > 0 && args[0] == "build":
+		r.elapsed += 5 * time.Second
+		r.builds++
+		for i := 0; i+1 < len(args); i++ {
+			if args[i] != "-o" {
+				continue
+			}
+			r.lastBuildPath = args[i+1]
+			if err := os.WriteFile(args[i+1], r.artifact, 0o755); err != nil {
+				return err.Error(), false
+			}
+			return "", true
+		}
+		return "build has no output path", false
+	case name == "go" && len(args) > 0 && args[0] == "vet":
+		r.elapsed += 5 * time.Second
+		r.vets++
+		return "", true
+	case len(args) == 2 && args[0] == "version" && args[1] == "--json":
+		r.elapsed += 100 * time.Millisecond
+		r.smokes++
+		commit := r.commit
+		if len(r.smokeCommits) > 0 {
+			commit = r.smokeCommits[0]
+			r.smokeCommits = r.smokeCommits[1:]
+		}
+		out, err := json.Marshal(candidateVersionIdentity{Commit: commit, Stamped: true})
+		if err != nil {
+			return err.Error(), false
+		}
+		return string(out), true
+	default:
+		return "unexpected command", false
+	}
+}
+
+// runCompleteCacheTransaction follows the production shape: Install captures the freshly
+// gated (or cache-restored) candidate, then RunTransaction stages, snapshots, and activates
+// that one candidate across every selected stale target.
+func runCompleteCacheTransaction(t *testing.T, r *candidateCacheRunner, opts Options, targets ...string) Result {
+	t.Helper()
+	var candidate string
+	res := Install(context.Background(), r.run, func(src, _ string) error {
+		candidate = src
+		return nil
+	}, opts)
+	if !res.Installed || candidate == "" {
+		return res
+	}
+	defer os.Remove(candidate)
+
+	copies := make([]Copy, 0, len(targets))
+	for _, target := range targets {
+		copies = append(copies, Copy{Source: candidate, Target: target})
+	}
+	transaction := RunTransaction(copies, func(src, dst string) error {
+		r.elapsed += 25 * time.Millisecond
+		return OSSwap(src, dst)
+	})
+	if got, ok := transaction.(Updated); !ok || got.Changed != len(targets) {
+		t.Fatalf("transaction = %#v, want Updated across %d targets", transaction, len(targets))
+	}
+	return res
+}
+
+func seedCacheTransactionTargets(t *testing.T, dir string, n int) []string {
+	t.Helper()
+	targets := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		target := filepath.Join(dir, "stale-"+string(rune('a'+i)))
+		if err := os.WriteFile(target, []byte("stale"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		targets = append(targets, target)
+	}
+	return targets
+}
+
+func TestInstallVerifiedCandidateCacheCompleteTransactionCutsSameEnvelopeFivefold(t *testing.T) {
+	dir := t.TempDir()
+	r := newCandidateCacheRunner()
+	targets := seedCacheTransactionTargets(t, dir, 3)
+	opts := Options{
+		RepoRoot:       dir,
+		Target:         targets[0],
+		BuildTmp:       filepath.Join(dir, "candidate"),
+		CacheDir:       filepath.Join(dir, "cache"),
+		ExpectedCommit: cacheTestCommitA,
+	}
+
+	before := r.elapsed
+	if got := runCompleteCacheTransaction(t, r, opts, targets...); !got.Installed {
+		t.Fatalf("cold transaction: %+v", got)
+	}
+	cold := r.elapsed - before
+	before = r.elapsed
+	got := runCompleteCacheTransaction(t, r, opts, targets...)
+	warm := r.elapsed - before
+	if !got.Installed || !strings.Contains(got.Detail, "exact-commit verified candidate cache") {
+		t.Fatalf("warm transaction: %+v", got)
+	}
+	if r.builds != 1 || r.vets != 1 || r.smokes != 2 {
+		t.Fatalf("builds=%d vets=%d smokes=%d, want one cold build/vet and smoke on both transactions", r.builds, r.vets, r.smokes)
+	}
+	ratio := float64(cold) / float64(warm)
+	t.Logf("complete stale-update transaction: cold=%s warm=%s speedup=%.2fx", cold, warm, ratio)
+	if ratio < 5 {
+		t.Fatalf("complete-transaction same-envelope speedup = %.2fx, want >=5x (cold=%s warm=%s)", ratio, cold, warm)
+	}
+}
+
+func TestInstallCorruptCandidateCacheFallsBackAndAtomicallyRefreshes(t *testing.T) {
+	dir := t.TempDir()
+	r := newCandidateCacheRunner()
+	targets := seedCacheTransactionTargets(t, dir, 1)
+	cacheDir := filepath.Join(dir, "cache")
+	opts := Options{RepoRoot: dir, Target: targets[0], BuildTmp: filepath.Join(dir, "candidate"), CacheDir: cacheDir, ExpectedCommit: cacheTestCommitA}
+	if got := runCompleteCacheTransaction(t, r, opts, targets...); !got.Installed {
+		t.Fatalf("seed transaction: %+v", got)
+	}
+
+	manifestData, err := os.ReadFile(candidateCachePaths(cacheDir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest candidateCacheManifest
+	if err := json.Unmarshal(manifestData, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	artifact := candidateArtifactPath(cacheDir, manifest.ArtifactDigest)
+	if err := os.WriteFile(artifact, []byte("corrupt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := runCompleteCacheTransaction(t, r, opts, targets...); !got.Installed || strings.Contains(got.Detail, "from exact-commit") {
+		t.Fatalf("corrupt-cache fallback transaction: %+v", got)
+	}
+	if r.builds != 2 || r.vets != 2 {
+		t.Fatalf("builds=%d vets=%d, corrupt cache must rerun the complete build+vet gate", r.builds, r.vets)
+	}
+	if got := runCompleteCacheTransaction(t, r, opts, targets...); !strings.Contains(got.Detail, "exact-commit verified candidate cache") {
+		t.Fatalf("transaction after atomic refresh: %+v", got)
+	}
+	if r.builds != 2 || r.vets != 2 {
+		t.Fatalf("builds=%d vets=%d after refreshed hit, want no third rebuild", r.builds, r.vets)
+	}
+	entries, err := os.ReadDir(cacheDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if strings.Contains(entry.Name(), ".tmp-") {
+			t.Fatalf("atomic refresh leaked temporary cache entry %q", entry.Name())
+		}
+	}
+}
+
+func TestInstallCandidateCacheIdentityBindsCommitToolchainPlatformAndBuildInputs(t *testing.T) {
+	dir := t.TempDir()
+	r := newCandidateCacheRunner()
+	targets := seedCacheTransactionTargets(t, dir, 1)
+	opts := Options{RepoRoot: dir, Target: targets[0], BuildTmp: filepath.Join(dir, "candidate"), CacheDir: filepath.Join(dir, "cache"), ExpectedCommit: cacheTestCommitA}
+	assertRebuilt := func(label string) {
+		t.Helper()
+		beforeBuilds, beforeVets := r.builds, r.vets
+		if got := runCompleteCacheTransaction(t, r, opts, targets...); !got.Installed || strings.Contains(got.Detail, "from exact-commit") {
+			t.Fatalf("%s mismatch transaction: %+v", label, got)
+		}
+		if r.builds != beforeBuilds+1 || r.vets != beforeVets+1 {
+			t.Fatalf("%s mismatch builds/vets = %d/%d, want %d/%d", label, r.builds, r.vets, beforeBuilds+1, beforeVets+1)
+		}
+	}
+
+	assertRebuilt("empty cache")
+	r.goEnv = strings.Replace(r.goEnv, "go1.26.0", "go1.27.0", 1)
+	assertRebuilt("toolchain")
+	r.goEnv = strings.Replace(r.goEnv, "windows\namd64\n", "linux\narm64\n", 1)
+	assertRebuilt("platform")
+	r.commit = cacheTestCommitB
+	opts.ExpectedCommit = cacheTestCommitB
+	assertRebuilt("exact commit")
+	if err := os.WriteFile(filepath.Join(dir, "VERSION"), []byte("9.9.2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	assertRebuilt("build arguments")
+
+	if got := runCompleteCacheTransaction(t, r, opts, targets...); !strings.Contains(got.Detail, "exact-commit verified candidate cache") {
+		t.Fatalf("unchanged bound identity should hit cache: %+v", got)
+	}
+}
+
+func TestInstallCandidateCacheProvenanceFailureFallsBackToFullGate(t *testing.T) {
+	dir := t.TempDir()
+	r := newCandidateCacheRunner()
+	targets := seedCacheTransactionTargets(t, dir, 1)
+	opts := Options{RepoRoot: dir, Target: targets[0], BuildTmp: filepath.Join(dir, "candidate"), CacheDir: filepath.Join(dir, "cache"), ExpectedCommit: cacheTestCommitA}
+	if got := runCompleteCacheTransaction(t, r, opts, targets...); !got.Installed {
+		t.Fatalf("seed transaction: %+v", got)
+	}
+
+	// The first identity belongs to the restored cache candidate and must be rejected. The
+	// second belongs to the newly built candidate and permits activation only after build+vet.
+	r.smokeCommits = []string{cacheTestCommitB, cacheTestCommitA}
+	if got := runCompleteCacheTransaction(t, r, opts, targets...); !got.Installed || strings.Contains(got.Detail, "from exact-commit") {
+		t.Fatalf("cached provenance fallback: %+v", got)
+	}
+	if r.builds != 2 || r.vets != 2 || r.smokes != 3 {
+		t.Fatalf("builds=%d vets=%d smokes=%d, want cached smoke followed by full build/vet/fresh smoke", r.builds, r.vets, r.smokes)
+	}
+}
+
+func TestInstallRejectsMalformedExplicitExpectedCommit(t *testing.T) {
+	r := newCandidateCacheRunner()
+	swapCalled := false
+	res := Install(context.Background(), r.run, func(_, _ string) error {
+		swapCalled = true
+		return nil
+	}, Options{RepoRoot: t.TempDir(), Target: filepath.Join(t.TempDir(), "fak"), ExpectedCommit: "01234567"})
+	if res.Installed || res.Stage != StageSmoke || swapCalled {
+		t.Fatalf("malformed exact commit must fail closed before build/swap: result=%+v swap=%v", res, swapCalled)
+	}
+	if r.builds != 0 || r.vets != 0 || r.smokes != 0 {
+		t.Fatalf("malformed exact commit ran build/vet/smoke = %d/%d/%d", r.builds, r.vets, r.smokes)
+	}
+}
+
+func TestInstallRejectsSourceThatDoesNotMatchExpectedCommit(t *testing.T) {
+	r := newCandidateCacheRunner()
+	res := Install(context.Background(), r.run, func(_, _ string) error {
+		t.Fatal("swap called for the wrong source commit")
+		return nil
+	}, Options{RepoRoot: t.TempDir(), Target: filepath.Join(t.TempDir(), "fak"), CacheDir: t.TempDir(), ExpectedCommit: cacheTestCommitB})
+	if res.Installed || res.Stage != StageSmoke || !strings.Contains(res.Detail, cacheTestCommitA) {
+		t.Fatalf("source/selection mismatch must fail closed: %+v", res)
+	}
+	if r.builds != 0 || r.vets != 0 || r.smokes != 0 {
+		t.Fatalf("source/selection mismatch ran build/vet/smoke = %d/%d/%d", r.builds, r.vets, r.smokes)
+	}
+}
+
+func TestCandidateCacheDirUsesCloneSharedGitCommonDir(t *testing.T) {
+	commonDir := filepath.Join(t.TempDir(), "primary.git")
+	want := filepath.Join(commonDir, "fak", "self-update-cache")
+	if got := CandidateCacheDir(commonDir); got != want {
+		t.Fatalf("CandidateCacheDir(%q) = %q, want clone-shared %q", commonDir, got, want)
+	}
+	for _, unresolved := range []string{"", "  \t\r\n"} {
+		if got := CandidateCacheDir(unresolved); got != "" {
+			t.Fatalf("CandidateCacheDir(%q) = %q, want cache disabled rather than a relative worktree path", unresolved, got)
+		}
 	}
 }


### PR DESCRIPTION
Fresh implementation for #9591: stable total/phase timings, deterministic timing seams, dominant-phase stderr observability, one-object JSON output, and release metadata cache behavior. Clean-origin focused checks: go test ./internal/selfinstall -count=1; go test ./cmd/fak -run 'SelfUpdate' -count=1 -timeout=2m.