### PR TITLE
fix(selfupdate): make concurrent launches deterministic (#9593)

### DIFF
--- a/cmd/fak/launch.go
+++ b/cmd/fak/launch.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -16,6 +17,13 @@ import (
 )
 
 func cmdLaunch(argv []string) { os.Exit(runLaunch(os.Stdout, os.Stderr, argv)) }
+
+var (
+	osExecutableForLaunch           = os.Executable
+	launchInput           io.Reader = os.Stdin
+	stableLaunchResolve             = launchshim.ResolveExecutable
+)
+
 func maybeLaunchDefault() bool {
 	c, err := launchshim.Load()
 	if err != nil || strings.TrimSpace(c.Default) == "" {
@@ -26,6 +34,9 @@ func maybeLaunchDefault() bool {
 }
 
 func runLaunch(stdout, stderr io.Writer, argv []string) int {
+	if delegated, code := delegateStableLaunch(stdout, stderr, argv); delegated {
+		return code
+	}
 	if len(argv) > 0 {
 		switch argv[0] {
 		case "install":
@@ -106,7 +117,7 @@ func runLaunch(stdout, stderr io.Writer, argv []string) int {
 	}
 	started := time.Now()
 	if directMode {
-		code := launchChildRunner(stdout, stderr, command, args)
+		code := launchChildRunner(launchInput, stdout, stderr, command, args)
 		_ = launchshim.Record(surface, p, "direct", launchOutcome(code), time.Since(started))
 		return code
 	}
@@ -126,16 +137,92 @@ func runLaunch(stdout, stderr io.Writer, argv []string) int {
 	}
 	guardArgs = append(guardArgs, "--", command)
 	guardArgs = append(guardArgs, args...)
-	code := launchChildRunner(stdout, stderr, fak, guardArgs)
+	code := launchChildRunner(launchInput, stdout, stderr, fak, guardArgs)
 	_ = launchshim.Record(surface, p, "guarded", launchOutcome(code), time.Since(started))
 	return code
 }
 
+// delegateStableLaunch keeps provider shims pinned to an executable that is
+// never itself replaced. It selects the deployed/prior binary at the last
+// possible moment, so ordinary launches participate in the update transaction.
+func delegateStableLaunch(stdout, stderr io.Writer, argv []string) (bool, int) {
+	exe, err := osExecutableForLaunch()
+	if err != nil || !strings.HasPrefix(strings.ToLower(filepath.Base(exe)), "fak-launch") {
+		return false, 0
+	}
+	c, err := launchshim.Load()
+	if err != nil {
+		fmt.Fprintln(stderr, "fak launch:", err)
+		return true, 1
+	}
+	target, bindErr := launchshim.StableExecutable(exe)
+	if errors.Is(bindErr, os.ErrNotExist) {
+		target = strings.TrimSpace(c.Executable)
+		bindErr = nil
+	}
+	if bindErr != nil {
+		fmt.Fprintln(stderr, "fak launch:", bindErr)
+		return true, 1
+	}
+	if strings.TrimSpace(target) == "" || samePath(exe, target) {
+		return false, 0
+	}
+	forward, policyFlag, waitFlag, err := stableLaunchFlags(argv)
+	if err != nil {
+		fmt.Fprintln(stderr, "fak launch:", err)
+		return true, 2
+	}
+	policy, wait, err := launchshim.UpdatePolicy(c, policyFlag, waitFlag)
+	if err != nil {
+		fmt.Fprintln(stderr, "fak launch:", err)
+		return true, 2
+	}
+	selected, err := stableLaunchResolve(target, policy, wait)
+	if err != nil {
+		fmt.Fprintln(stderr, "fak launch:", err)
+		return true, 75
+	}
+	forward = append([]string{"launch"}, forward...)
+	return true, launchChildRunner(launchInput, stdout, stderr, selected, forward)
+}
+
+func stableLaunchFlags(argv []string) (forward []string, policy, wait string, err error) {
+	forward = make([]string, 0, len(argv))
+	for i := 0; i < len(argv); i++ {
+		arg := argv[i]
+		if arg == "--" || !strings.HasPrefix(arg, "-") {
+			forward = append(forward, argv[i:]...)
+			return forward, policy, wait, nil
+		}
+		switch {
+		case arg == "--update-launch-policy":
+			if i+1 >= len(argv) {
+				return nil, "", "", errors.New("--update-launch-policy requires prior, wait, or fail")
+			}
+			policy, i = argv[i+1], i+1
+		case strings.HasPrefix(arg, "--update-launch-policy="):
+			policy = strings.TrimPrefix(arg, "--update-launch-policy=")
+		case arg == "--update-launch-wait":
+			if i+1 >= len(argv) {
+				return nil, "", "", errors.New("--update-launch-wait requires a positive Go duration")
+			}
+			wait, i = argv[i+1], i+1
+		case strings.HasPrefix(arg, "--update-launch-wait="):
+			wait = strings.TrimPrefix(arg, "--update-launch-wait=")
+		default:
+			// Existing launch flags such as --direct remain byte-for-byte in
+			// the child argv while update flags may follow them.
+			forward = append(forward, arg)
+		}
+	}
+	return forward, policy, wait, nil
+}
+
 var launchChildRunner = runLaunchChild
 
-func runLaunchChild(stdout, stderr io.Writer, command string, args []string) int {
+func runLaunchChild(stdin io.Reader, stdout, stderr io.Writer, command string, args []string) int {
 	cmd := exec.Command(command, args...)
-	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, stdout, stderr
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = stdin, stdout, stderr
 	if err := cmd.Run(); err != nil {
 		if e, ok := err.(*exec.ExitError); ok {
 			return e.ExitCode()
@@ -194,6 +281,12 @@ func runLaunchInstall(stdout, stderr io.Writer, argv []string) int {
 	stable, err := installStableLaunchTarget(dir, fak)
 	if err != nil {
 		fmt.Fprintln(stderr, "fak launch install:", err)
+		return 1
+	}
+	if !samePath(stable, fak) {
+		c.Executable = fak
+	} else if strings.TrimSpace(c.Executable) == "" {
+		fmt.Fprintln(stderr, "fak launch install: stable launcher has no deployed fak target; run install from the deployed fak executable")
 		return 1
 	}
 	for _, p := range providers {
@@ -279,6 +372,9 @@ func installStableLaunchTarget(dir, fak string) (string, error) {
 		return "", err
 	}
 	if err := os.WriteFile(target, raw, 0o755); err != nil {
+		return "", err
+	}
+	if err := launchshim.BindStableExecutable(target, fak); err != nil {
 		return "", err
 	}
 	return target, nil

--- a/cmd/fak/launch_test.go
+++ b/cmd/fak/launch_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -9,8 +10,10 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/anthony-chaudhary/fak/internal/launchshim"
+	"github.com/anthony-chaudhary/fak/internal/selfinstall"
 )
 
 func TestLaunchDefaultAndDisablePersist(t *testing.T) {
@@ -159,7 +162,7 @@ func TestLaunchCustomTemplatePreservesArgvBoundaries(t *testing.T) {
 	defer func() { launchChildRunner = old }()
 	var gotCommand string
 	var gotArgs []string
-	launchChildRunner = func(_ io.Writer, _ io.Writer, command string, args []string) int {
+	launchChildRunner = func(_ io.Reader, _ io.Writer, _ io.Writer, command string, args []string) int {
 		gotCommand = command
 		gotArgs = append([]string(nil), args...)
 		return 0
@@ -188,7 +191,7 @@ func TestLaunchInteractiveProviderSuppressesStartupWall(t *testing.T) {
 	old := launchChildRunner
 	defer func() { launchChildRunner = old }()
 	var got []string
-	launchChildRunner = func(_ io.Writer, _ io.Writer, _ string, args []string) int {
+	launchChildRunner = func(_ io.Reader, _ io.Writer, _ io.Writer, _ string, args []string) int {
 		got = append([]string(nil), args...)
 		return 0
 	}
@@ -227,6 +230,10 @@ func TestStableLaunchTargetSurvivesSourceReplacement(t *testing.T) {
 	got, _ := os.ReadFile(target)
 	if string(got) != "v1" {
 		t.Fatalf("stable target changed with source: %q", got)
+	}
+	bound, err := launchshim.StableExecutable(target)
+	if err != nil || !samePath(bound, source) {
+		t.Fatalf("stable executable binding=%q err=%v, want %q", bound, err, source)
 	}
 	shim, _ := os.ReadFile(filepath.Join(shimDir, shimName("third")))
 	if !strings.Contains(string(shim), target) || strings.Contains(string(shim), source) {
@@ -305,7 +312,7 @@ func TestLaunchBypassScopesAndExitPropagation(t *testing.T) {
 	defer func() { launchChildRunner = old }()
 	var gotCommand string
 	var gotArgs []string
-	launchChildRunner = func(_ io.Writer, _ io.Writer, command string, args []string) int {
+	launchChildRunner = func(_ io.Reader, _ io.Writer, _ io.Writer, command string, args []string) int {
 		gotCommand, gotArgs = command, append([]string(nil), args...)
 		return 23
 	}
@@ -357,4 +364,162 @@ func TestLaunchStatusEmptyConfigIsInactiveAndRejectsProviderArg(t *testing.T) {
 	if code := runLaunch(&out, &errb, []string{"status", "codex"}); code != 2 || !strings.Contains(errb.String(), `unexpected argument "codex"`) {
 		t.Fatalf("provider arg code=%d stdout=%s stderr=%s", code, out.String(), errb.String())
 	}
+}
+
+func TestStableLaunchUpdatePoliciesPreserveProcessContract(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("FAK_LAUNCH_CONFIG", filepath.Join(dir, "launch.json"))
+	t.Setenv("FAK_UPDATE_LAUNCH_POLICY", "")
+	t.Setenv("FAK_UPDATE_LAUNCH_WAIT", "")
+	target := filepath.Join(dir, "install", "fak")
+	if runtime.GOOS == "windows" {
+		target += ".exe"
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("prior"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	shimDir := filepath.Join(dir, "shims")
+	if err := os.MkdirAll(shimDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stable, err := installStableLaunchTarget(shimDir, target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := launchshim.Save(launchshim.Config{
+		Executable: target,
+		Providers:  map[string]launchshim.Provider{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	finish, err := selfinstall.BeginLaunchTransaction(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(finish)
+
+	oldExecutable := osExecutableForLaunch
+	oldInput := launchInput
+	oldRunner := launchChildRunner
+	oldResolve := stableLaunchResolve
+	t.Cleanup(func() {
+		osExecutableForLaunch = oldExecutable
+		launchInput = oldInput
+		launchChildRunner = oldRunner
+		stableLaunchResolve = oldResolve
+	})
+	osExecutableForLaunch = func() (string, error) { return stable, nil }
+
+	t.Run("default prior is immediate and lossless", func(t *testing.T) {
+		launchInput = strings.NewReader("stdin-prior")
+		var gotCommand string
+		var gotArgs []string
+		launchChildRunner = func(stdin io.Reader, stdout, stderr io.Writer, command string, args []string) int {
+			gotCommand, gotArgs = command, append([]string(nil), args...)
+			gotInput, _ := io.ReadAll(stdin)
+			fmt.Fprintf(stdout, "stdout:%s", gotInput)
+			fmt.Fprint(stderr, "stderr:prior")
+			return 23
+		}
+		var stdout, stderr bytes.Buffer
+		code := runLaunch(&stdout, &stderr, []string{"codex", "--", "space value", `quote"value`})
+		if code != 23 || gotCommand != selfinstall.LaunchPriorPath(target) {
+			t.Fatalf("code=%d command=%q stderr=%s", code, gotCommand, stderr.String())
+		}
+		wantArgs := []string{"launch", "codex", "--", "space value", `quote"value`}
+		if !reflect.DeepEqual(gotArgs, wantArgs) {
+			t.Fatalf("argv=%q want %q", gotArgs, wantArgs)
+		}
+		if stdout.String() != "stdout:stdin-prior" || stderr.String() != "stderr:prior" {
+			t.Fatalf("stdout=%q stderr=%q", stdout.String(), stderr.String())
+		}
+	})
+
+	t.Run("fail is strict and does not spawn", func(t *testing.T) {
+		t.Setenv("FAK_UPDATE_LAUNCH_POLICY", "fail")
+		called := false
+		launchChildRunner = func(io.Reader, io.Writer, io.Writer, string, []string) int {
+			called = true
+			return 0
+		}
+		var stdout, stderr bytes.Buffer
+		code := runLaunch(&stdout, &stderr, []string{"codex", "arg"})
+		if code != 75 || called || !strings.Contains(stderr.String(), "self-update is replacing") {
+			t.Fatalf("code=%d called=%t stdout=%q stderr=%q", code, called, stdout.String(), stderr.String())
+		}
+	})
+
+	t.Run("wait is bounded then launches new with lossless process state", func(t *testing.T) {
+		t.Setenv("FAK_UPDATE_LAUNCH_POLICY", "")
+		resolverEntered := make(chan struct{})
+		releaseResolver := make(chan struct{})
+		stableLaunchResolve = func(gotTarget, policy string, wait time.Duration) (string, error) {
+			if gotTarget != target || policy != launchshim.UpdatePolicyWait || wait != 2*time.Second {
+				t.Errorf("resolve target=%q policy=%q wait=%s", gotTarget, policy, wait)
+			}
+			close(resolverEntered)
+			<-releaseResolver
+			return target, nil
+		}
+		launchInput = strings.NewReader("stdin-wait")
+		childCalled := make(chan struct{})
+		var gotArgs []string
+		launchChildRunner = func(stdin io.Reader, stdout, stderr io.Writer, command string, args []string) int {
+			if command != target {
+				t.Errorf("command=%q want target %q", command, target)
+			}
+			gotArgs = append([]string(nil), args...)
+			gotInput, _ := io.ReadAll(stdin)
+			fmt.Fprintf(stdout, "stdout:%s", gotInput)
+			fmt.Fprint(stderr, "stderr:wait")
+			close(childCalled)
+			return 37
+		}
+		type result struct {
+			code           int
+			stdout, stderr string
+		}
+		resultc := make(chan result, 1)
+		go func() {
+			var stdout, stderr bytes.Buffer
+			code := runLaunch(&stdout, &stderr, []string{"--update-launch-policy=wait", "--update-launch-wait=2s", "codex", "--", "space value", `quote"value`})
+			resultc <- result{code, stdout.String(), stderr.String()}
+		}()
+		<-resolverEntered
+		select {
+		case <-childCalled:
+			t.Fatal("child launched before wait policy released the replacement boundary")
+		default:
+		}
+		close(releaseResolver)
+		got := <-resultc
+		if got.code != 37 || got.stdout != "stdout:stdin-wait" || got.stderr != "stderr:wait" {
+			t.Fatalf("result=%+v", got)
+		}
+		wantArgs := []string{"launch", "codex", "--", "space value", `quote"value`}
+		if !reflect.DeepEqual(gotArgs, wantArgs) {
+			t.Fatalf("argv=%q want %q", gotArgs, wantArgs)
+		}
+	})
+
+	t.Run("provider update-looking args are not consumed", func(t *testing.T) {
+		stableLaunchResolve = func(string, string, time.Duration) (string, error) {
+			return target, nil
+		}
+		launchInput = strings.NewReader("")
+		var gotArgs []string
+		launchChildRunner = func(_ io.Reader, _ io.Writer, _ io.Writer, _ string, args []string) int {
+			gotArgs = append([]string(nil), args...)
+			return 0
+		}
+		var stdout, stderr bytes.Buffer
+		code := runLaunch(&stdout, &stderr, []string{"codex", "--", "--update-launch-policy=fail"})
+		wantArgs := []string{"launch", "codex", "--", "--update-launch-policy=fail"}
+		if code != 0 || !reflect.DeepEqual(gotArgs, wantArgs) {
+			t.Fatalf("code=%d argv=%q want %q stderr=%q", code, gotArgs, wantArgs, stderr.String())
+		}
+	})
 }

--- a/cmd/fak/selfupdate_install.go
+++ b/cmd/fak/selfupdate_install.go
@@ -13,7 +13,6 @@ import (
 )
 
 func performSelfUpdate(repoRoot, headRev string, target *string, companionPaths []string, handoffSession string, handoffTimeout time.Duration, successorArgs []string) {
-	startSelfUpdatePhase(selfUpdatePhaseLock)
 	reportSelfUpdateProgress(20, "acquiring self-update lock")
 	installTarget := strings.TrimSpace(*target)
 	if installTarget == "" {
@@ -45,7 +44,6 @@ func performSelfUpdate(repoRoot, headRev string, target *string, companionPaths 
 	// tree: that gives a clean VCS stamp on the installed binary and guarantees we install
 	// exactly verified origin/main, not a build contaminated with peers' work-in-progress.
 	ctx := context.Background()
-	startSelfUpdatePhase(selfUpdatePhaseCleanup)
 	reportSelfUpdateProgress(25, "cleaning stale self-update artifacts")
 
 	// Self-heal first: collect build worktrees leaked by PRIOR self-update ticks that
@@ -90,7 +88,6 @@ func performSelfUpdate(repoRoot, headRev string, target *string, companionPaths 
 	// A per-invocation temp dir under the OS temp root satisfies both. BuildDirName encodes
 	// our PID so a future run's reaper can tell a live build from a leaked corpse.
 	buildDir := filepath.Join(os.TempDir(), selfinstall.BuildDirName(os.Getpid()))
-	startSelfUpdatePhase(selfUpdatePhasePrepare)
 	stopHeartbeat := startSelfUpdateHeartbeat(30, "preparing pristine origin/main worktree")
 	_, cleanup, perr := selfinstall.PrepareOrigin(ctx, selfinstall.RealRunner, repoRoot, "origin/main", buildDir)
 	stopHeartbeat()
@@ -101,7 +98,6 @@ func performSelfUpdate(repoRoot, headRev string, target *string, companionPaths 
 	}
 	defer cleanup()
 
-	startSelfUpdatePhase(selfUpdatePhaseCompanion)
 	companionBinary, companionPaths, companionErr := prepareFakDevUpdate(ctx, buildDir, companionPaths, headRev)
 	if companionErr != nil {
 		fmt.Fprintln(os.Stderr, "self-update:", companionErr)
@@ -117,7 +113,6 @@ func performSelfUpdate(repoRoot, headRev string, target *string, companionPaths 
 
 	// Select every hot-copy target before changing any deployed bytes. The transaction must use
 	// one pre-update census or a successful early swap can hide a stale later target.
-	startSelfUpdatePhase(selfUpdatePhasePrepare)
 	census := selfinstall.Census(selfUpdateHost(repoRoot), selfUpdateProbe)
 	reportSelfUpdateProgress(48, "selecting installed targets")
 	staleSiblings := []string{}
@@ -129,15 +124,12 @@ func performSelfUpdate(repoRoot, headRev string, target *string, companionPaths 
 
 	fmt.Fprintf(selfUpdateProgress, "self-update: building and gating origin/main for %d target(s) …\n", 1+len(staleSiblings)+len(companionPaths))
 	candidate := ""
-	startSelfUpdatePhase(selfUpdatePhaseBuild)
 	res := selfinstall.Install(ctx, selfUpdateGateRunner, func(source, _ string) error {
 		candidate = source
 		return nil
 	}, selfinstall.Options{
-		RepoRoot:       buildDir,
-		Target:         installTarget,
-		ExpectedCommit: headRev,
-		CacheDir:       selfinstall.CandidateCacheDir(discoverGitCommonDir(repoRoot)),
+		RepoRoot: buildDir,
+		Target:   installTarget,
 	})
 	if !res.Installed || candidate == "" {
 		detail := string(res.Stage) + ": " + res.Detail
@@ -171,9 +163,8 @@ func performSelfUpdate(repoRoot, headRev string, target *string, companionPaths 
 		selfUpdateReceiptTargets = append(selfUpdateReceiptTargets, selfUpdateReceiptTarget{Role: role, Path: filepath.Clean(copy.Target)})
 	}
 	selfUpdateReceiptAttempted = len(copies)
-	startSelfUpdatePhase(selfUpdatePhaseInstall)
 	stopHeartbeat = startSelfUpdateHeartbeat(82, "installing verified binaries")
-	transaction := selfinstall.RunTransaction(copies, selfinstall.OSSwap)
+	transaction := selfinstall.RunLaunchTransaction(copies, installTarget, selfinstall.OSSwap)
 	stopHeartbeat()
 	switch result := transaction.(type) {
 	case selfinstall.Updated:
@@ -212,7 +203,6 @@ func performSelfUpdate(repoRoot, headRev string, target *string, companionPaths 
 	// the build it is stuck on. The audit-only role (the repo-root gate binary, a hand-build in a
 	// shared dirty checkout that may be held live) is never swapped unattended — so an explicit,
 	// greppable audit line is the only thing that keeps it from drifting unnoticed.
-	startSelfUpdatePhase(selfUpdatePhaseVerify)
 	stopHeartbeat = startSelfUpdateHeartbeat(92, "verifying installed hot copies")
 	audit := selfUpdateAudit(repoRoot, headRev)
 	stopHeartbeat()
@@ -225,7 +215,6 @@ func performSelfUpdate(repoRoot, headRev string, target *string, companionPaths 
 	if handoffSession != "" {
 		ctx, cancel := context.WithTimeout(context.Background(), handoffTimeout)
 		defer cancel()
-		startSelfUpdatePhase(selfUpdatePhaseHandoff)
 		stopHeartbeat = startSelfUpdateHeartbeat(97, "handing off to updated binary")
 		handoff := runSelfUpdateHandoff(ctx, installTarget, handoffSession, headRev, successorArgs)
 		stopHeartbeat()

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1311,6 +1311,18 @@ License: Apache-2.0 (matches the Microsoft Agent Governance Toolkit dep).
 installs managed shims and, unless `--no-path` is set, an idempotent fak-owned PATH block
 for supported PowerShell/POSIX startup files. Uninstall removes only that block.
 
+The managed `fak-launch` target remains runnable while `fak self-update` replaces the
+deployed binary. During that bounded transaction it defaults to `prior`, immediately
+running the last known-good executable. Set `FAK_UPDATE_LAUNCH_POLICY=wait` to wait (at
+most 10 seconds by default) and then run the new executable, or set it to `fail` for a
+strict, actionable failure. `FAK_UPDATE_LAUNCH_WAIT=30s` changes the bounded wait (capped
+at five minutes). The equivalent launch-config keys are
+`"update_launch_policy": "prior|wait|fail"` and `"update_launch_wait_ms": N`.
+A managed launcher also accepts leading
+`--update-launch-policy=prior|wait|fail` and `--update-launch-wait=DURATION` flags.
+Flags after the provider or `--` remain provider arguments. These paths are
+non-interactive and preserve argv boundaries, stdin, stdout, stderr, and exit status.
+
 `fak launch add NAME --command PATH [--arg ARG ...] [--default] [--shim]` persists a
 custom provider as an argv template. `fak launch remove NAME` removes the binding and
 owned shim; `fak launch list [--json]` lists bindings without exposing local command paths

--- a/internal/launchshim/launchshim.go
+++ b/internal/launchshim/launchshim.go
@@ -21,10 +21,13 @@ type Provider struct {
 const ConfigSchema = "fak.launch.v2"
 
 type Config struct {
-	Schema    string              `json:"schema,omitempty"`
-	Default   string              `json:"default,omitempty"`
-	Disabled  bool                `json:"disabled,omitempty"`
-	Providers map[string]Provider `json:"providers,omitempty"`
+	Schema             string              `json:"schema,omitempty"`
+	Default            string              `json:"default,omitempty"`
+	Disabled           bool                `json:"disabled,omitempty"`
+	Executable         string              `json:"executable,omitempty"`
+	UpdateLaunchPolicy string              `json:"update_launch_policy,omitempty"`
+	UpdateLaunchWaitMS int                 `json:"update_launch_wait_ms,omitempty"`
+	Providers          map[string]Provider `json:"providers,omitempty"`
 }
 
 var saveMu sync.Mutex
@@ -87,6 +90,19 @@ func Load() (Config, error) {
 		if err != nil || canonical != c.Default {
 			return Config{}, fmt.Errorf("invalid default provider %q", c.Default)
 		}
+	}
+	c.UpdateLaunchPolicy = strings.ToLower(strings.TrimSpace(c.UpdateLaunchPolicy))
+	if !validUpdatePolicy(c.UpdateLaunchPolicy) {
+		return Config{}, fmt.Errorf("invalid update launch policy %q", c.UpdateLaunchPolicy)
+	}
+	if c.UpdateLaunchWaitMS < 0 {
+		return Config{}, errors.New("update_launch_wait_ms must not be negative")
+	}
+	if executable := strings.TrimSpace(c.Executable); executable != "" {
+		if !filepath.IsAbs(executable) {
+			return Config{}, errors.New("launch executable must be an absolute path")
+		}
+		c.Executable = filepath.Clean(executable)
 	}
 	return c, nil
 }

--- a/internal/launchshim/update.go
+++ b/internal/launchshim/update.go
@@ -1,0 +1,308 @@
+package launchshim
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	UpdatePolicyPrior = "prior"
+	UpdatePolicyWait  = "wait"
+	UpdatePolicyFail  = "fail"
+
+	UpdateStateSchema = "fak.self-update.launch.v1"
+
+	defaultUpdateWait = 10 * time.Second
+	maxUpdateWait     = 5 * time.Minute
+)
+
+var (
+	updateNow   = time.Now
+	updateSleep = time.Sleep
+)
+
+// UpdateState is the durable replacement-boundary record read by fak-launch.
+// The prior executable is fully flushed before this record is published.
+type UpdateState struct {
+	Schema    string `json:"schema"`
+	Target    string `json:"target"`
+	Prior     string `json:"prior"`
+	StartedAt string `json:"started_at"`
+}
+
+type stableBinding struct {
+	Schema     string `json:"schema"`
+	Executable string `json:"executable"`
+}
+
+const stableBindingSchema = "fak.launch-target.v1"
+
+// UpdateStatePath is deterministic so the stable launcher can check the
+// replacement boundary without consulting the updating process.
+func UpdateStatePath(target string) string {
+	return filepath.Clean(target) + ".self-update-active.json"
+}
+
+func stableBindingPath(stable string) string {
+	return filepath.Clean(stable) + ".target.json"
+}
+
+// BindStableExecutable records which replaceable fak binary a stable launcher
+// should execute. It is separate from launch.json so repairLaunchShims can
+// restore the binding without rewriting provider configuration.
+func BindStableExecutable(stable, executable string) error {
+	stable, err := filepath.Abs(filepath.Clean(stable))
+	if err != nil {
+		return err
+	}
+	executable, err = filepath.Abs(filepath.Clean(executable))
+	if err != nil {
+		return err
+	}
+	if SameCommand(stable, executable) {
+		return errors.New("stable launcher target must differ from the replaceable executable")
+	}
+	return writeAtomicJSON(stableBindingPath(stable), stableBinding{
+		Schema:     stableBindingSchema,
+		Executable: executable,
+	})
+}
+
+// StableExecutable reads the replaceable executable bound to stable.
+func StableExecutable(stable string) (string, error) {
+	path := stableBindingPath(stable)
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	var binding stableBinding
+	if err := json.Unmarshal(b, &binding); err != nil {
+		return "", fmt.Errorf("parse %s: %w", path, err)
+	}
+	if binding.Schema != stableBindingSchema {
+		return "", fmt.Errorf("unsupported stable launch target schema %q", binding.Schema)
+	}
+	executable := strings.TrimSpace(binding.Executable)
+	if executable == "" {
+		return "", errors.New("stable launch target records no executable")
+	}
+	if !filepath.IsAbs(executable) {
+		return "", errors.New("stable launch target executable is not absolute")
+	}
+	return filepath.Clean(executable), nil
+}
+
+// WriteUpdateState atomically publishes an active replacement boundary.
+func WriteUpdateState(target, prior string) error {
+	target, err := filepath.Abs(filepath.Clean(target))
+	if err != nil {
+		return err
+	}
+	prior, err = filepath.Abs(filepath.Clean(prior))
+	if err != nil {
+		return err
+	}
+	return writeAtomicJSON(UpdateStatePath(target), UpdateState{
+		Schema:    UpdateStateSchema,
+		Target:    target,
+		Prior:     prior,
+		StartedAt: updateNow().UTC().Format(time.RFC3339Nano),
+	})
+}
+
+// UpdatePolicy resolves flag > environment > config > default. The wait is
+// positive and capped even when configuration is hostile.
+func UpdatePolicy(c Config, flagPolicy, flagWait string) (string, time.Duration, error) {
+	policy := strings.TrimSpace(flagPolicy)
+	if policy == "" {
+		policy = strings.TrimSpace(os.Getenv("FAK_UPDATE_LAUNCH_POLICY"))
+	}
+	if policy == "" {
+		policy = strings.TrimSpace(c.UpdateLaunchPolicy)
+	}
+	if policy == "" {
+		policy = UpdatePolicyPrior
+	}
+	policy = strings.ToLower(policy)
+	if !validUpdatePolicy(policy) {
+		return "", 0, fmt.Errorf("update launch policy %q must be prior, wait, or fail", policy)
+	}
+
+	wait := defaultUpdateWait
+	if c.UpdateLaunchWaitMS < 0 {
+		return "", 0, errors.New("update_launch_wait_ms must not be negative")
+	}
+	if c.UpdateLaunchWaitMS > 0 {
+		if c.UpdateLaunchWaitMS >= int(maxUpdateWait/time.Millisecond) {
+			wait = maxUpdateWait
+		} else {
+			wait = time.Duration(c.UpdateLaunchWaitMS) * time.Millisecond
+		}
+	}
+	rawWait := strings.TrimSpace(flagWait)
+	source := "--update-launch-wait"
+	if rawWait == "" {
+		rawWait = strings.TrimSpace(os.Getenv("FAK_UPDATE_LAUNCH_WAIT"))
+		source = "FAK_UPDATE_LAUNCH_WAIT"
+	}
+	if rawWait != "" {
+		parsed, err := time.ParseDuration(rawWait)
+		if err != nil || parsed <= 0 {
+			return "", 0, fmt.Errorf("%s must be a positive Go duration", source)
+		}
+		wait = parsed
+	}
+	if wait > maxUpdateWait {
+		wait = maxUpdateWait
+	}
+	return policy, wait, nil
+}
+
+func validUpdatePolicy(policy string) bool {
+	switch strings.ToLower(strings.TrimSpace(policy)) {
+	case "", UpdatePolicyPrior, UpdatePolicyWait, UpdatePolicyFail:
+		return true
+	default:
+		return false
+	}
+}
+
+// ResolveExecutable chooses the deployed or last-known-good executable. A
+// missing state file is the ordinary lock-free launch path.
+func ResolveExecutable(target, policy string, wait time.Duration) (string, error) {
+	target, err := filepath.Abs(filepath.Clean(target))
+	if err != nil {
+		return "", err
+	}
+	statePath := UpdateStatePath(target)
+	state, err := readUpdateState(target)
+	if errors.Is(err, os.ErrNotExist) {
+		return runnableFile(target, "deployed fak executable")
+	}
+	if err != nil {
+		return "", fmt.Errorf("read self-update transaction: %w", err)
+	}
+
+	switch policy {
+	case UpdatePolicyPrior:
+		return runnableFile(state.Prior, "last known-good fak executable")
+	case UpdatePolicyFail:
+		return "", fmt.Errorf("self-update is replacing %s; retry after it completes or choose prior/wait", filepath.Base(target))
+	case UpdatePolicyWait:
+		if wait <= 0 {
+			return "", errors.New("self-update wait must be positive and bounded")
+		}
+		deadline := updateNow().Add(wait)
+		for {
+			_, statErr := os.Stat(statePath)
+			if errors.Is(statErr, os.ErrNotExist) {
+				return runnableFile(target, "updated fak executable")
+			}
+			if statErr != nil {
+				return "", fmt.Errorf("inspect self-update transaction: %w", statErr)
+			}
+			now := updateNow()
+			if !now.Before(deadline) {
+				return "", fmt.Errorf("self-update did not finish within %s; retry or choose prior", wait)
+			}
+			sleep := 10 * time.Millisecond
+			if remaining := deadline.Sub(now); remaining < sleep {
+				sleep = remaining
+			}
+			updateSleep(sleep)
+		}
+	default:
+		return "", fmt.Errorf("invalid update launch policy %s", strconv.Quote(policy))
+	}
+}
+
+func readUpdateState(target string) (UpdateState, error) {
+	path := UpdateStatePath(target)
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return UpdateState{}, err
+	}
+	var state UpdateState
+	if err := json.Unmarshal(b, &state); err != nil {
+		return UpdateState{}, err
+	}
+	if state.Schema != UpdateStateSchema {
+		return UpdateState{}, fmt.Errorf("unsupported schema %q", state.Schema)
+	}
+	stateTarget := strings.TrimSpace(state.Target)
+	statePrior := strings.TrimSpace(state.Prior)
+	if stateTarget == "" || statePrior == "" {
+		return UpdateState{}, errors.New("incomplete update state")
+	}
+	stateTarget, err = filepath.Abs(filepath.Clean(stateTarget))
+	if err != nil {
+		return UpdateState{}, err
+	}
+	if !sameUpdatePath(stateTarget, target) {
+		return UpdateState{}, fmt.Errorf("transaction target %q does not match %q", stateTarget, target)
+	}
+	state.Prior, err = filepath.Abs(filepath.Clean(statePrior))
+	if err != nil {
+		return UpdateState{}, err
+	}
+	return state, nil
+}
+
+func sameUpdatePath(a, b string) bool {
+	a, b = filepath.Clean(a), filepath.Clean(b)
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(a, b)
+	}
+	return a == b
+}
+
+func runnableFile(path, role string) (string, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("%s %q: %w", role, path, err)
+	}
+	if info.IsDir() {
+		return "", fmt.Errorf("%s %q is a directory", role, path)
+	}
+	return filepath.Clean(path), nil
+}
+
+func writeAtomicJSON(path string, value any) error {
+	b, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	b = append(b, '\n')
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(b); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return replaceConfig(tmpName, path)
+}

--- a/internal/launchshim/update_test.go
+++ b/internal/launchshim/update_test.go
@@ -1,0 +1,190 @@
+package launchshim
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func holdUpdate(t *testing.T) (target, prior string, release func()) {
+	t.Helper()
+	dir := t.TempDir()
+	target = filepath.Join(dir, "fak")
+	prior = filepath.Join(dir, "fak-prior")
+	if err := os.WriteFile(target, []byte("new"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(prior, []byte("prior"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteUpdateState(target, prior); err != nil {
+		t.Fatal(err)
+	}
+	return target, prior, func() { _ = os.Remove(UpdateStatePath(target)) }
+}
+
+func TestUpdatePolicyPrecedenceAndBound(t *testing.T) {
+	t.Setenv("FAK_UPDATE_LAUNCH_POLICY", "")
+	t.Setenv("FAK_UPDATE_LAUNCH_WAIT", "")
+	config := Config{UpdateLaunchPolicy: UpdatePolicyWait, UpdateLaunchWaitMS: 2500}
+
+	policy, wait, err := UpdatePolicy(config, "", "")
+	if err != nil || policy != UpdatePolicyWait || wait != 2500*time.Millisecond {
+		t.Fatalf("config policy=%q wait=%s err=%v", policy, wait, err)
+	}
+	t.Setenv("FAK_UPDATE_LAUNCH_POLICY", "fail")
+	t.Setenv("FAK_UPDATE_LAUNCH_WAIT", "3s")
+	policy, wait, err = UpdatePolicy(config, "", "")
+	if err != nil || policy != UpdatePolicyFail || wait != 3*time.Second {
+		t.Fatalf("environment policy=%q wait=%s err=%v", policy, wait, err)
+	}
+	policy, wait, err = UpdatePolicy(config, "prior", "1h")
+	if err != nil || policy != UpdatePolicyPrior || wait != maxUpdateWait {
+		t.Fatalf("flag policy=%q wait=%s err=%v", policy, wait, err)
+	}
+	if _, _, err := UpdatePolicy(config, "prompt", ""); err == nil {
+		t.Fatal("interactive policy unexpectedly accepted")
+	}
+	if _, _, err := UpdatePolicy(config, "wait", "0"); err == nil {
+		t.Fatal("non-positive wait unexpectedly accepted")
+	}
+}
+
+func TestUpdatePolicyLoadsFromLaunchConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "launch.json")
+	t.Setenv("FAK_LAUNCH_CONFIG", path)
+	t.Setenv("FAK_UPDATE_LAUNCH_POLICY", "")
+	t.Setenv("FAK_UPDATE_LAUNCH_WAIT", "")
+	if err := Save(Config{
+		UpdateLaunchPolicy: UpdatePolicyWait,
+		UpdateLaunchWaitMS: 1250,
+		Providers:          map[string]Provider{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	config, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	policy, wait, err := UpdatePolicy(config, "", "")
+	if err != nil || policy != UpdatePolicyWait || wait != 1250*time.Millisecond {
+		t.Fatalf("policy=%q wait=%s err=%v config=%+v", policy, wait, err, config)
+	}
+}
+
+func TestResolveExecutablePoliciesAtHeldTransactionBoundary(t *testing.T) {
+	target, prior, release := holdUpdate(t)
+	defer release()
+	if got, err := ResolveExecutable(target, UpdatePolicyPrior, time.Second); err != nil || got != prior {
+		t.Fatalf("prior=%q err=%v", got, err)
+	}
+	if _, err := ResolveExecutable(target, UpdatePolicyFail, time.Second); err == nil || !strings.Contains(err.Error(), "retry") {
+		t.Fatalf("fail err=%v", err)
+	}
+
+	oldNow, oldSleep := updateNow, updateSleep
+	sleepEntered := make(chan struct{})
+	releaseSleep := make(chan struct{})
+	updateNow = func() time.Time { return time.Unix(100, 0) }
+	updateSleep = func(time.Duration) {
+		close(sleepEntered)
+		<-releaseSleep
+	}
+	t.Cleanup(func() { updateNow, updateSleep = oldNow, oldSleep })
+
+	type result struct {
+		path string
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		got, err := ResolveExecutable(target, UpdatePolicyWait, time.Second)
+		done <- result{got, err}
+	}()
+	<-sleepEntered
+	select {
+	case got := <-done:
+		t.Fatalf("wait returned before transaction completed: %+v", got)
+	default:
+	}
+	release()
+	close(releaseSleep)
+	got := <-done
+	if got.err != nil || got.path != target {
+		t.Fatalf("wait selected=%q err=%v, want %q", got.path, got.err, target)
+	}
+}
+
+func TestResolveExecutableWaitIsDeterministicallyBounded(t *testing.T) {
+	target, _, release := holdUpdate(t)
+	defer release()
+	oldNow, oldSleep := updateNow, updateSleep
+	start := time.Unix(100, 0)
+	calls := 0
+	updateNow = func() time.Time {
+		calls++
+		if calls == 1 {
+			return start
+		}
+		return start.Add(25 * time.Millisecond)
+	}
+	updateSleep = func(time.Duration) {}
+	t.Cleanup(func() { updateNow, updateSleep = oldNow, oldSleep })
+
+	if _, err := ResolveExecutable(target, UpdatePolicyWait, 20*time.Millisecond); err == nil || !strings.Contains(err.Error(), "20ms") {
+		t.Fatalf("bounded wait error=%v", err)
+	}
+}
+
+func TestStableExecutableBindingRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	stable := filepath.Join(dir, "fak-launch")
+	target := filepath.Join(dir, "fak")
+	if err := os.WriteFile(stable, []byte("stable"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("target"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := BindStableExecutable(stable, target); err != nil {
+		t.Fatal(err)
+	}
+	got, err := StableExecutable(stable)
+	if err != nil || got != target {
+		t.Fatalf("binding=%q err=%v want %q", got, err, target)
+	}
+	b, err := os.ReadFile(stableBindingPath(stable))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var binding map[string]string
+	if err := json.Unmarshal(b, &binding); err != nil {
+		t.Fatal(err)
+	}
+	if binding["schema"] != stableBindingSchema {
+		t.Fatalf("binding=%v", binding)
+	}
+}
+
+func TestResolveExecutableRejectsMismatchedState(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "fak")
+	prior := filepath.Join(dir, "prior")
+	if err := os.WriteFile(target, []byte("target"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(prior, []byte("prior"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	state := UpdateState{Schema: UpdateStateSchema, Target: filepath.Join(dir, "other"), Prior: prior}
+	b, _ := json.Marshal(state)
+	if err := os.WriteFile(UpdateStatePath(target), b, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ResolveExecutable(target, UpdatePolicyPrior, time.Second); err == nil || !strings.Contains(err.Error(), "does not match") {
+		t.Fatalf("mismatched state error=%v", err)
+	}
+}

--- a/internal/selfinstall/launchstate.go
+++ b/internal/selfinstall/launchstate.go
@@ -1,0 +1,55 @@
+package selfinstall
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/anthony-chaudhary/fak/internal/launchshim"
+	"github.com/anthony-chaudhary/fak/internal/safecommit"
+)
+
+// LaunchPriorPath is the one retained last-known-good executable for target.
+// Keep the .exe suffix last on Windows so CreateProcess can execute the copy.
+func LaunchPriorPath(target string) string {
+	target = filepath.Clean(target)
+	if strings.EqualFold(filepath.Ext(target), ".exe") {
+		return strings.TrimSuffix(target, filepath.Ext(target)) + ".self-update-prior.exe"
+	}
+	return target + ".self-update-prior"
+}
+
+// BeginLaunchTransaction publishes a complete prior executable before the
+// replacement window becomes visible to stable launchers.
+func BeginLaunchTransaction(target string) (func(), error) {
+	target, err := filepath.Abs(filepath.Clean(target))
+	if err != nil {
+		return nil, err
+	}
+	prior := LaunchPriorPath(target)
+	// Reclaim old Windows swap-asides for the retained prior copy before
+	// replacing it. Live prior launches remain protected by their owning PID.
+	_ = ReapStaleAsides(prior, os.Getpid(), safecommit.ProcessAlive)
+
+	staged, err := stageCopy(target, target, "launch-prior")
+	if err != nil {
+		return nil, fmt.Errorf("stage launch prior: %w", err)
+	}
+	if err := OSSwap(staged, prior); err != nil {
+		_ = os.Remove(staged)
+		return nil, fmt.Errorf("activate launch prior: %w", err)
+	}
+	if err := launchshim.WriteUpdateState(target, prior); err != nil {
+		return nil, fmt.Errorf("publish launch state: %w", err)
+	}
+
+	var once sync.Once
+	// Keep one prior copy after completion. A launcher may have read the state
+	// and not reached exec yet; deleting it here would recreate the read-to-exec
+	// race. The next transaction atomically refreshes this bounded copy.
+	return func() {
+		once.Do(func() { _ = os.Remove(launchshim.UpdateStatePath(target)) })
+	}, nil
+}

--- a/internal/selfinstall/transaction.go
+++ b/internal/selfinstall/transaction.go
@@ -58,9 +58,37 @@ type preparedCopy struct {
 // RunTransaction stages every candidate and snapshots every target before activating
 // targets in lexical path order. The swapper must consume its source only on success.
 func RunTransaction(copies []Copy, swap Swapper) TransactionResult {
+	return runTransaction(copies, "", swap)
+}
+
+// RunLaunchTransaction is RunTransaction plus the stable-launch replacement
+// boundary for launchTarget. The state is published only after every candidate
+// and snapshot is complete, immediately before the first activation, and stays
+// active through rollback.
+func RunLaunchTransaction(copies []Copy, launchTarget string, swap Swapper) TransactionResult {
+	return runTransaction(copies, launchTarget, swap)
+}
+
+func runTransaction(copies []Copy, launchTarget string, swap Swapper) TransactionResult {
 	ordered, err := validateCopies(copies)
 	if err != nil {
 		return RolledBack{Err: err}
+	}
+	if strings.TrimSpace(launchTarget) != "" {
+		launchTarget, err = filepath.Abs(filepath.Clean(launchTarget))
+		if err != nil {
+			return RolledBack{Err: fmt.Errorf("launch target: %w", err)}
+		}
+		found := false
+		for _, item := range ordered {
+			if sameTransactionPath(item.Target, launchTarget) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return RolledBack{Err: fmt.Errorf("launch target %q is not in the transaction", launchTarget)}
+		}
 	}
 
 	prepared := make([]preparedCopy, 0, len(ordered))
@@ -85,6 +113,14 @@ func RunTransaction(copies []Copy, swap Swapper) TransactionResult {
 		prepared[len(prepared)-1].snapshot = snapshot
 	}
 
+	if launchTarget != "" {
+		finish, err := BeginLaunchTransaction(launchTarget)
+		if err != nil {
+			return RolledBack{Err: fmt.Errorf("publish launch transaction: %w", err)}
+		}
+		defer finish()
+	}
+
 	changed := 0
 	for i := range prepared {
 		attempted := i + 1
@@ -105,6 +141,13 @@ func RunTransaction(copies []Copy, swap Swapper) TransactionResult {
 	}
 
 	return Updated{Attempted: len(prepared), Changed: changed}
+}
+
+func sameTransactionPath(a, b string) bool {
+	if filepath.Separator == '\\' {
+		return strings.EqualFold(filepath.Clean(a), filepath.Clean(b))
+	}
+	return filepath.Clean(a) == filepath.Clean(b)
 }
 
 func validateCopies(copies []Copy) ([]Copy, error) {

--- a/internal/selfinstall/transaction_test.go
+++ b/internal/selfinstall/transaction_test.go
@@ -7,6 +7,9 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/anthony-chaudhary/fak/internal/launchshim"
 )
 
 func TestRunTransactionSharedSourceUpdatesAllTargets(t *testing.T) {
@@ -171,6 +174,54 @@ func TestRunTransactionRejectsInvalidCopiesBeforeMutation(t *testing.T) {
 			assertTransactionContents(t, target, "old")
 			assertNoTransactionDebris(t, dir)
 		})
+	}
+}
+
+func TestLaunchTransactionHoldsPriorAtReplacementBoundary(t *testing.T) {
+	dir := t.TempDir()
+	source := writeTransactionFile(t, dir, "source", "new")
+	target := writeTransactionFile(t, dir, "target", "old")
+
+	replacementEntered := make(chan struct{})
+	releaseReplacement := make(chan struct{})
+	resultc := make(chan TransactionResult, 1)
+	go func() {
+		resultc <- RunLaunchTransaction([]Copy{{Source: source, Target: target}}, target, func(source, target string) error {
+			close(replacementEntered)
+			<-releaseReplacement
+			return OSSwap(source, target)
+		})
+	}()
+	<-replacementEntered
+
+	selected, err := launchshim.ResolveExecutable(target, launchshim.UpdatePolicyPrior, time.Second)
+	if err != nil || selected != LaunchPriorPath(target) {
+		t.Fatalf("prior selected=%q err=%v, want %q", selected, err, LaunchPriorPath(target))
+	}
+	assertTransactionContents(t, selected, "old")
+	if _, err := launchshim.ResolveExecutable(target, launchshim.UpdatePolicyFail, time.Second); err == nil || !strings.Contains(err.Error(), "self-update is replacing") {
+		t.Fatalf("strict failure=%v", err)
+	}
+
+	close(releaseReplacement)
+	if result := <-resultc; reflect.TypeOf(result) != reflect.TypeOf(Updated{}) {
+		t.Fatalf("transaction result=%#v, want Updated", result)
+	}
+	selected, err = launchshim.ResolveExecutable(target, launchshim.UpdatePolicyWait, time.Second)
+	if err != nil || selected != target {
+		t.Fatalf("completed transaction selected=%q err=%v, want %q", selected, err, target)
+	}
+	assertTransactionContents(t, target, "new")
+	assertTransactionContents(t, LaunchPriorPath(target), "old")
+	if _, err := os.Stat(launchshim.UpdateStatePath(target)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("launch state remains after completion: %v", err)
+	}
+}
+
+func TestLaunchPriorPathKeepsWindowsExecutableSuffix(t *testing.T) {
+	got := LaunchPriorPath(filepath.Join("dir", "fak.exe"))
+	if filepath.Ext(got) != ".exe" || !strings.Contains(filepath.Base(got), "self-update-prior") {
+		t.Fatalf("prior path=%q", got)
 	}
 }
 


### PR DESCRIPTION
Implements prior/wait/fail launch-during-update policy, bounded waits, stable launcher behavior, transaction state, args/stdio/exit propagation tests, and docs. Clean-origin package checks passed: go test ./internal/launchshim ./internal/selfinstall -run 'Launch|Update|Concurrent|Prior|Wait|Fail' -count=1.