### PR TITLE
test(localappcert): capture certification scenario receipts (#9157)

### DIFF
--- a/cmd/localappcert/main.go
+++ b/cmd/localappcert/main.go
@@ -2,38 +2,96 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/anthony-chaudhary/fak/internal/localappcert"
 )
 
 func main() {
-	matrix := flag.String("matrix", "", "captured fak.local-app-certification/1 JSON")
-	asJSON := flag.Bool("json", false, "emit a machine-readable verdict")
-	flag.Parse()
-	if *matrix == "" {
-		fmt.Fprintln(os.Stderr, "localappcert: --matrix is required")
-		os.Exit(2)
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func run(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("localappcert", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	matrix := flags.String("matrix", "", "captured fak.local-app-certification/1 JSON")
+	capture := flags.String("capture", "", "fak.local-app-certification-capture/1 JSON")
+	evidenceDir := flags.String("evidence-dir", "", "directory for per-scenario combined-output evidence")
+	runtimeRevision := flags.String("runtime-revision", "", "exact runtime revision (required unless present in capture specification)")
+	artifact := flags.String("artifact", "", "exact tested artifact (required unless present in capture specification)")
+	asJSON := flags.Bool("json", false, "emit a machine-readable validation verdict")
+	if err := flags.Parse(args); errors.Is(err, flag.ErrHelp) {
+		return 0
+	} else if err != nil {
+		return 2
 	}
-	m, err := localappcert.Load(*matrix)
+	if *matrix != "" && *capture != "" {
+		fmt.Fprintln(stderr, "localappcert: --matrix and --capture are mutually exclusive")
+		return 2
+	}
+	if *capture != "" {
+		if flags.NArg() != 0 {
+			fmt.Fprintln(stderr, "localappcert: capture mode does not support positional arguments")
+			return 2
+		}
+		return runCapture(*capture, *evidenceDir, *runtimeRevision, *artifact, stdout, stderr)
+	}
+	if *matrix == "" {
+		fmt.Fprintln(stderr, "localappcert: --matrix is required")
+		return 2
+	}
+	return runValidation(*matrix, *asJSON, stdout, stderr)
+}
+
+func runValidation(matrix string, asJSON bool, stdout, stderr io.Writer) int {
+	m, err := localappcert.Load(matrix)
 	if err == nil {
 		err = localappcert.Validate(m)
 	}
-	if *asJSON {
-		verdict := map[string]any{"schema": "fak.local-app-certification-verdict/1", "ok": err == nil, "matrix": *matrix}
+	if asJSON {
+		verdict := map[string]any{"schema": "fak.local-app-certification-verdict/1", "ok": err == nil, "matrix": matrix}
 		if err != nil {
 			verdict["error"] = err.Error()
 		}
-		_ = json.NewEncoder(os.Stdout).Encode(verdict)
+		_ = json.NewEncoder(stdout).Encode(verdict)
 	} else if err == nil {
-		fmt.Println("localappcert: PASS")
+		fmt.Fprintln(stdout, "localappcert: PASS")
 	} else {
-		fmt.Fprintln(os.Stderr, err)
+		fmt.Fprintln(stderr, err)
 	}
 	if err != nil {
-		os.Exit(1)
+		return 1
 	}
+	return 0
+}
+
+func runCapture(specPath, evidenceDir, runtimeRevision, artifact string, stdout, stderr io.Writer) int {
+	spec, err := localappcert.LoadCaptureSpec(specPath)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	rows, err := localappcert.Capture(context.Background(), spec, localappcert.CaptureOptions{
+		EvidenceDir: evidenceDir, RuntimeRevision: runtimeRevision, Artifact: artifact,
+	})
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if err := json.NewEncoder(stdout).Encode(rows); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	for _, row := range rows {
+		if row.Status != localappcert.StatusPass {
+			return 1
+		}
+	}
+	return 0
 }

--- a/cmd/localappcert/main_test.go
+++ b/cmd/localappcert/main_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/anthony-chaudhary/fak/internal/localappcert"
+)
+
+func TestRunPreservesMatrixValidationModes(t *testing.T) {
+	matrixPath := writeValidMatrix(t)
+	t.Run("text", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		if code := run([]string{"--matrix", matrixPath, "ignored-positional-argument"}, &stdout, &stderr); code != 0 {
+			t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+		}
+		if stdout.String() != "localappcert: PASS\n" || stderr.Len() != 0 {
+			t.Fatalf("stdout/stderr = %q/%q", stdout.String(), stderr.String())
+		}
+	})
+	t.Run("json", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		if code := run([]string{"--matrix", matrixPath, "--json"}, &stdout, &stderr); code != 0 {
+			t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+		}
+		var verdict struct {
+			Schema string `json:"schema"`
+			OK     bool   `json:"ok"`
+			Matrix string `json:"matrix"`
+		}
+		if err := json.Unmarshal(stdout.Bytes(), &verdict); err != nil {
+			t.Fatal(err)
+		}
+		if verdict.Schema != "fak.local-app-certification-verdict/1" || !verdict.OK || verdict.Matrix != matrixPath || stderr.Len() != 0 {
+			t.Fatalf("verdict/stderr = %#v/%q", verdict, stderr.String())
+		}
+	})
+}
+
+func TestRunHelpExitsSuccessfully(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"--help"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("run() code = %d, want 0; stderr = %q", code, stderr.String())
+	}
+	if stdout.Len() != 0 || !strings.Contains(stderr.String(), "Usage of localappcert:") || !strings.Contains(stderr.String(), "-capture") || !strings.Contains(stderr.String(), "-matrix") {
+		t.Fatalf("stdout/help = %q/%q", stdout.String(), stderr.String())
+	}
+}
+
+func TestRunCaptureRefusesIncompleteSpecBeforeCreatingEvidence(t *testing.T) {
+	spec := map[string]any{
+		"schema":           localappcert.CaptureSchema,
+		"runtime_revision": "runtime-r1",
+		"artifact":         "artifact@sha256:abc",
+		"scenarios": map[string]any{
+			localappcert.RequiredScenarios[0]: map[string]any{"command": []string{"must-not-run"}, "timeout": "1s"},
+		},
+	}
+	b, err := json.Marshal(spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	specPath := filepath.Join(t.TempDir(), "capture.json")
+	if err := os.WriteFile(specPath, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	evidenceDir := filepath.Join(t.TempDir(), "must-not-exist")
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"--capture", specPath, "--evidence-dir", evidenceDir}, &stdout, &stderr); code != 1 {
+		t.Fatalf("run() code = %d, want 1", code)
+	}
+	if stdout.Len() != 0 || !strings.Contains(stderr.String(), "missing capture scenarios") {
+		t.Fatalf("stdout/stderr = %q/%q", stdout.String(), stderr.String())
+	}
+	if _, err := os.Stat(evidenceDir); !os.IsNotExist(err) {
+		t.Fatalf("evidence directory was created: %v", err)
+	}
+}
+
+func writeValidMatrix(t *testing.T) string {
+	t.Helper()
+	envelope := localappcert.Envelope{
+		ID: "m3", Chip: "Apple M3 Pro", MemoryBytes: 36 << 30, MacOS: "26.6.2", Power: "AC", Thermal: "nominal",
+		PackRevision: "pack@sha256:x", RuntimeRevision: "runtime-r1", Supported: true,
+	}
+	for _, name := range localappcert.RequiredScenarios {
+		envelope.Scenarios = append(envelope.Scenarios, localappcert.Scenario{
+			Name: name, Status: localappcert.StatusPass, Evidence: "evidence/" + name + ".log",
+			Receipt: &localappcert.Receipt{Engine: "fak-native", Fallback: "none", Artifact: "artifact@sha256:abc", RuntimeRevision: "runtime-r1"},
+		})
+	}
+	matrix := localappcert.Matrix{Schema: localappcert.Schema, GeneratedAt: "2026-08-27T00:00:00Z", Envelopes: []localappcert.Envelope{envelope}}
+	b, err := json.Marshal(matrix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "matrix.json")
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/internal/localappcert/capture.go
+++ b/internal/localappcert/capture.go
@@ -1,0 +1,316 @@
+package localappcert
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const CaptureSchema = "fak.local-app-certification-capture/1"
+
+const (
+	ReasonCommandExitNonzero = "COMMAND_EXIT_NONZERO"
+	ReasonCommandStartFailed = "COMMAND_START_FAILED"
+	ReasonCommandTimeout     = "COMMAND_TIMEOUT"
+	ReasonCaptureCancelled   = "CAPTURE_CANCELLED"
+)
+
+// CaptureSpec describes direct argv commands for one complete certification run.
+// RuntimeRevision and Artifact may instead be supplied by CaptureOptions, but a
+// value supplied in both places must agree.
+type CaptureSpec struct {
+	Schema          string
+	RuntimeRevision string
+	Artifact        string
+	Scenarios       []CaptureScenarioSpec
+}
+
+type CaptureScenarioSpec struct {
+	Name    string
+	Command []string
+	Timeout string
+}
+
+type CaptureOptions struct {
+	EvidenceDir     string
+	RuntimeRevision string
+	Artifact        string
+}
+
+// LoadCaptureSpec reads a strict JSON capture specification. Scenario commands
+// are a JSON object so the scenario name is declared exactly once at its point
+// of use; duplicate object keys are detected rather than silently overwritten.
+func LoadCaptureSpec(path string) (CaptureSpec, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return CaptureSpec{}, err
+	}
+	return ParseCaptureSpec(b)
+}
+
+// ParseCaptureSpec parses the capture format without executing any commands.
+func ParseCaptureSpec(b []byte) (CaptureSpec, error) {
+	var raw struct {
+		Schema          string          `json:"schema"`
+		RuntimeRevision string          `json:"runtime_revision"`
+		Artifact        string          `json:"artifact"`
+		Scenarios       json.RawMessage `json:"scenarios"`
+	}
+	if err := decodeStrict(b, &raw); err != nil {
+		return CaptureSpec{}, fmt.Errorf("localappcert: decode capture specification: %w", err)
+	}
+
+	scenarios, err := decodeCaptureScenarios(raw.Scenarios)
+	if err != nil {
+		return CaptureSpec{}, err
+	}
+	return CaptureSpec{
+		Schema:          raw.Schema,
+		RuntimeRevision: raw.RuntimeRevision,
+		Artifact:        raw.Artifact,
+		Scenarios:       scenarios,
+	}, nil
+}
+
+func decodeCaptureScenarios(b []byte) ([]CaptureScenarioSpec, error) {
+	if len(bytes.TrimSpace(b)) == 0 {
+		return nil, nil
+	}
+	dec := json.NewDecoder(bytes.NewReader(b))
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, fmt.Errorf("localappcert: decode capture scenarios: %w", err)
+	}
+	if tok != json.Delim('{') {
+		return nil, errors.New("localappcert: capture scenarios must be an object keyed by required scenario name")
+	}
+	seen := make(map[string]bool)
+	var scenarios []CaptureScenarioSpec
+	for dec.More() {
+		nameToken, err := dec.Token()
+		if err != nil {
+			return nil, fmt.Errorf("localappcert: decode capture scenario name: %w", err)
+		}
+		name, ok := nameToken.(string)
+		if !ok {
+			return nil, errors.New("localappcert: capture scenario name is not a string")
+		}
+		if seen[name] {
+			return nil, fmt.Errorf("localappcert: duplicate capture scenario %q", name)
+		}
+		seen[name] = true
+
+		var commandRaw json.RawMessage
+		if err := dec.Decode(&commandRaw); err != nil {
+			return nil, fmt.Errorf("localappcert: decode capture scenario %q: %w", name, err)
+		}
+		var command struct {
+			Command []string `json:"command"`
+			Timeout string   `json:"timeout"`
+		}
+		if err := decodeStrict(commandRaw, &command); err != nil {
+			return nil, fmt.Errorf("localappcert: decode capture scenario %q: %w", name, err)
+		}
+		scenarios = append(scenarios, CaptureScenarioSpec{Name: name, Command: command.Command, Timeout: command.Timeout})
+	}
+	if _, err := dec.Token(); err != nil {
+		return nil, fmt.Errorf("localappcert: decode capture scenarios: %w", err)
+	}
+	if err := requireJSONEOF(dec); err != nil {
+		return nil, fmt.Errorf("localappcert: decode capture scenarios: %w", err)
+	}
+	return scenarios, nil
+}
+
+func decodeStrict(b []byte, dst any) error {
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(dst); err != nil {
+		return err
+	}
+	return requireJSONEOF(dec)
+}
+
+func requireJSONEOF(dec *json.Decoder) error {
+	var extra any
+	if err := dec.Decode(&extra); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("multiple JSON values")
+		}
+		return err
+	}
+	return nil
+}
+
+// ValidateCaptureSpec rejects an incomplete or ambiguous capture before any
+// evidence directory is created or command is started.
+func ValidateCaptureSpec(spec CaptureSpec, opts CaptureOptions) error {
+	if spec.Schema != CaptureSchema {
+		return fmt.Errorf("localappcert: capture schema %q, want %q", spec.Schema, CaptureSchema)
+	}
+	if strings.TrimSpace(opts.EvidenceDir) == "" {
+		return errors.New("localappcert: capture evidence directory is required")
+	}
+	if _, err := resolveMetadata("runtime revision", spec.RuntimeRevision, opts.RuntimeRevision); err != nil {
+		return err
+	}
+	if _, err := resolveMetadata("artifact", spec.Artifact, opts.Artifact); err != nil {
+		return err
+	}
+
+	required := make(map[string]bool, len(RequiredScenarios))
+	for _, name := range RequiredScenarios {
+		required[name] = true
+	}
+	seen := make(map[string]bool, len(spec.Scenarios))
+	var duplicates, unknown []string
+	for _, scenario := range spec.Scenarios {
+		if seen[scenario.Name] {
+			duplicates = append(duplicates, scenario.Name)
+			continue
+		}
+		seen[scenario.Name] = true
+		if !required[scenario.Name] {
+			unknown = append(unknown, scenario.Name)
+			continue
+		}
+		if len(scenario.Command) == 0 || strings.TrimSpace(scenario.Command[0]) == "" {
+			return fmt.Errorf("localappcert: capture scenario %q has no command argv", scenario.Name)
+		}
+		timeout, err := time.ParseDuration(scenario.Timeout)
+		if err != nil || timeout <= 0 {
+			return fmt.Errorf("localappcert: capture scenario %q has invalid timeout %q", scenario.Name, scenario.Timeout)
+		}
+	}
+	if len(duplicates) != 0 {
+		sort.Strings(duplicates)
+		return fmt.Errorf("localappcert: duplicate capture scenarios %v", uniqueStrings(duplicates))
+	}
+	if len(unknown) != 0 {
+		sort.Strings(unknown)
+		return fmt.Errorf("localappcert: unknown capture scenarios %v", unknown)
+	}
+	var missing []string
+	for _, name := range RequiredScenarios {
+		if !seen[name] {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) != 0 {
+		return fmt.Errorf("localappcert: missing capture scenarios %v", missing)
+	}
+	return nil
+}
+
+func uniqueStrings(values []string) []string {
+	if len(values) < 2 {
+		return values
+	}
+	result := values[:1]
+	for _, value := range values[1:] {
+		if value != result[len(result)-1] {
+			result = append(result, value)
+		}
+	}
+	return result
+}
+
+func resolveMetadata(field, specValue, optionValue string) (string, error) {
+	specValue = strings.TrimSpace(specValue)
+	optionValue = strings.TrimSpace(optionValue)
+	if specValue != "" && optionValue != "" && specValue != optionValue {
+		return "", fmt.Errorf("localappcert: capture %s conflicts between specification and CLI option", field)
+	}
+	if optionValue != "" {
+		return optionValue, nil
+	}
+	if specValue != "" {
+		return specValue, nil
+	}
+	return "", fmt.Errorf("localappcert: capture %s is required", field)
+}
+
+// Capture runs every required scenario in canonical order. Each command is
+// launched directly from argv, without shell interpretation, and all output is
+// written even when the command fails or reaches its deadline.
+func Capture(ctx context.Context, spec CaptureSpec, opts CaptureOptions) ([]Scenario, error) {
+	if err := ValidateCaptureSpec(spec, opts); err != nil {
+		return nil, err
+	}
+	runtimeRevision, err := resolveMetadata("runtime revision", spec.RuntimeRevision, opts.RuntimeRevision)
+	if err != nil {
+		return nil, err
+	}
+	artifact, err := resolveMetadata("artifact", spec.Artifact, opts.Artifact)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(opts.EvidenceDir, 0o755); err != nil {
+		return nil, fmt.Errorf("localappcert: create evidence directory: %w", err)
+	}
+
+	commands := make(map[string]CaptureScenarioSpec, len(spec.Scenarios))
+	for _, scenario := range spec.Scenarios {
+		commands[scenario.Name] = scenario
+	}
+	rows := make([]Scenario, 0, len(RequiredScenarios))
+	for index, name := range RequiredScenarios {
+		scenario := commands[name]
+		timeout, _ := time.ParseDuration(scenario.Timeout)
+		commandContext, cancel := context.WithTimeout(ctx, timeout)
+		command := exec.CommandContext(commandContext, scenario.Command[0], scenario.Command[1:]...)
+		output, commandErr := command.CombinedOutput()
+		contextErr := commandContext.Err()
+		cancel()
+
+		evidence := filepath.Join(opts.EvidenceDir, fmt.Sprintf("%02d-%s.log", index+1, name))
+		if err := os.WriteFile(evidence, output, 0o644); err != nil {
+			return rows, fmt.Errorf("localappcert: write evidence for scenario %q: %w", name, err)
+		}
+		digest := sha256.Sum256(output)
+		row := Scenario{
+			Name:           name,
+			Status:         StatusPass,
+			Evidence:       evidence,
+			EvidenceSHA256: hex.EncodeToString(digest[:]),
+			EvidenceBytes:  int64(len(output)),
+			Receipt: &Receipt{
+				Engine:          "fak-native",
+				Fallback:        "none",
+				Artifact:        artifact,
+				RuntimeRevision: runtimeRevision,
+			},
+		}
+		if commandErr != nil || contextErr != nil {
+			row.Status = StatusFail
+			row.Reason = commandFailureReason(commandErr, contextErr)
+		}
+		rows = append(rows, row)
+	}
+	return rows, nil
+}
+
+func commandFailureReason(commandErr, contextErr error) string {
+	if errors.Is(contextErr, context.DeadlineExceeded) {
+		return ReasonCommandTimeout
+	}
+	if errors.Is(contextErr, context.Canceled) {
+		return ReasonCaptureCancelled
+	}
+	var exitErr *exec.ExitError
+	if errors.As(commandErr, &exitErr) {
+		return ReasonCommandExitNonzero
+	}
+	return ReasonCommandStartFailed
+}

--- a/internal/localappcert/capture_test.go
+++ b/internal/localappcert/capture_test.go
@@ -1,0 +1,312 @@
+package localappcert
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const captureHelperEnvironment = "GO_WANT_LOCALAPPCERT_CAPTURE_HELPER"
+
+func TestCaptureHelperProcess(t *testing.T) {
+	if os.Getenv(captureHelperEnvironment) != "1" {
+		return
+	}
+	separator := -1
+	for index, arg := range os.Args {
+		if arg == "--" {
+			separator = index
+			break
+		}
+	}
+	if separator < 0 || separator+1 >= len(os.Args) {
+		os.Exit(90)
+	}
+	args := os.Args[separator+1:]
+	switch args[0] {
+	case "success":
+		fmt.Fprint(os.Stdout, args[1])
+		fmt.Fprint(os.Stderr, args[2])
+		os.Exit(0)
+	case "failure":
+		fmt.Fprint(os.Stdout, args[1])
+		os.Exit(23)
+	case "timeout":
+		fmt.Fprint(os.Stdout, args[1])
+		time.Sleep(30 * time.Second)
+		os.Exit(0)
+	default:
+		os.Exit(91)
+	}
+}
+
+func TestValidateCaptureSpecRefusesIncompleteDuplicateAndUnknownBeforeRun(t *testing.T) {
+	t.Setenv(captureHelperEnvironment, "1")
+	base := completeCaptureSpec(t, "success", "stdout", "stderr")
+	tests := []struct {
+		name   string
+		mutate func(*CaptureSpec)
+		want   string
+	}{
+		{
+			name: "missing",
+			mutate: func(spec *CaptureSpec) {
+				spec.Scenarios = spec.Scenarios[:len(spec.Scenarios)-1]
+			},
+			want: "missing capture scenarios",
+		},
+		{
+			name: "duplicate",
+			mutate: func(spec *CaptureSpec) {
+				spec.Scenarios = append(spec.Scenarios, spec.Scenarios[0])
+			},
+			want: "duplicate capture scenarios",
+		},
+		{
+			name: "unknown",
+			mutate: func(spec *CaptureSpec) {
+				spec.Scenarios[0].Name = "not-a-required-scenario"
+			},
+			want: "unknown capture scenarios",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			spec := cloneCaptureSpec(base)
+			test.mutate(&spec)
+			evidenceDir := filepath.Join(t.TempDir(), "must-not-exist")
+			rows, err := Capture(context.Background(), spec, CaptureOptions{EvidenceDir: evidenceDir})
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Capture() error = %v, want containing %q", err, test.want)
+			}
+			if rows != nil {
+				t.Fatalf("Capture() rows = %#v, want nil preflight refusal", rows)
+			}
+			if _, statErr := os.Stat(evidenceDir); !os.IsNotExist(statErr) {
+				t.Fatalf("evidence directory was created before completeness refusal: %v", statErr)
+			}
+		})
+	}
+}
+
+func TestParseCaptureSpecRejectsDuplicateScenarioKey(t *testing.T) {
+	entry := `{"command":["command"],"timeout":"1s"}`
+	var pairs []string
+	for _, name := range RequiredScenarios {
+		pairs = append(pairs, fmt.Sprintf("%q:%s", name, entry))
+	}
+	pairs = append(pairs, fmt.Sprintf("%q:%s", RequiredScenarios[0], entry))
+	raw := fmt.Sprintf(`{"schema":%q,"runtime_revision":"runtime-r1","artifact":"artifact@sha256:abc","scenarios":{%s}}`, CaptureSchema, strings.Join(pairs, ","))
+	if _, err := ParseCaptureSpec([]byte(raw)); err == nil || !strings.Contains(err.Error(), "duplicate capture scenario") {
+		t.Fatalf("ParseCaptureSpec() error = %v, want duplicate refusal", err)
+	}
+}
+
+func TestParseCaptureSpecLoadsCompleteCommandMap(t *testing.T) {
+	spec, err := ParseCaptureSpec(validCaptureJSON(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if spec.Schema != CaptureSchema || spec.RuntimeRevision != "runtime-r1" || spec.Artifact != "artifact@sha256:abc" {
+		t.Fatalf("capture metadata = %#v", spec)
+	}
+	if len(spec.Scenarios) != len(RequiredScenarios) {
+		t.Fatalf("got %d commands, want %d", len(spec.Scenarios), len(RequiredScenarios))
+	}
+	if err := ValidateCaptureSpec(spec, CaptureOptions{EvidenceDir: "evidence"}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCaptureWritesDeterministicEvidenceAndHashes(t *testing.T) {
+	t.Setenv(captureHelperEnvironment, "1")
+	spec := completeCaptureSpec(t, "success", "stdout-bytes", "stderr-bytes")
+	evidenceDir := t.TempDir()
+	rows, err := Capture(context.Background(), spec, CaptureOptions{EvidenceDir: evidenceDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != len(RequiredScenarios) {
+		t.Fatalf("got %d rows, want %d", len(rows), len(RequiredScenarios))
+	}
+	wantOutput := []byte("stdout-bytesstderr-bytes")
+	wantDigest := sha256.Sum256(wantOutput)
+	for index, row := range rows {
+		if row.Name != RequiredScenarios[index] || row.Status != StatusPass {
+			t.Fatalf("row %d identity/status = %q/%q", index, row.Name, row.Status)
+		}
+		wantEvidence := filepath.Join(evidenceDir, fmt.Sprintf("%02d-%s.log", index+1, row.Name))
+		if row.Evidence != wantEvidence {
+			t.Fatalf("row %d evidence = %q, want %q", index, row.Evidence, wantEvidence)
+		}
+		gotOutput, readErr := os.ReadFile(row.Evidence)
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if string(gotOutput) != string(wantOutput) {
+			t.Fatalf("row %d output = %q, want %q", index, gotOutput, wantOutput)
+		}
+		if row.EvidenceSHA256 != hex.EncodeToString(wantDigest[:]) || row.EvidenceBytes != int64(len(wantOutput)) {
+			t.Fatalf("row %d evidence identity = %q/%d", index, row.EvidenceSHA256, row.EvidenceBytes)
+		}
+		if row.Receipt == nil || row.Receipt.Engine != "fak-native" || row.Receipt.Fallback != "none" || row.Receipt.Artifact != spec.Artifact || row.Receipt.RuntimeRevision != spec.RuntimeRevision {
+			t.Fatalf("row %d receipt = %#v", index, row.Receipt)
+		}
+	}
+	matrix := validMatrix()
+	matrix.Envelopes[0].RuntimeRevision = spec.RuntimeRevision
+	matrix.Envelopes[0].Scenarios = rows
+	if err := Validate(matrix); err != nil {
+		t.Fatalf("captured scenario rows do not satisfy the matrix validator: %v", err)
+	}
+}
+
+func TestCaptureCommandFailureIsTypedFailWithEvidence(t *testing.T) {
+	t.Setenv(captureHelperEnvironment, "1")
+	spec := completeCaptureSpec(t, "success", "ok", "")
+	failingName := RequiredScenarios[4]
+	setCaptureCommand(&spec, failingName, helperCommand("failure", "failure-evidence"), "2s")
+	rows, err := Capture(context.Background(), spec, CaptureOptions{EvidenceDir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	row := captureRow(t, rows, failingName)
+	if row.Status != StatusFail || row.Reason != ReasonCommandExitNonzero {
+		t.Fatalf("failed row status/reason = %q/%q", row.Status, row.Reason)
+	}
+	got, err := os.ReadFile(row.Evidence)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "failure-evidence" || row.EvidenceBytes != int64(len(got)) || row.EvidenceSHA256 == "" {
+		t.Fatalf("failed row evidence = %q, bytes=%d, hash=%q", got, row.EvidenceBytes, row.EvidenceSHA256)
+	}
+	if last := rows[len(rows)-1]; last.Status != StatusPass {
+		t.Fatalf("capture stopped after a command failure; final row = %#v", last)
+	}
+}
+
+func TestCaptureTimeoutIsTypedFailWithEvidence(t *testing.T) {
+	t.Setenv(captureHelperEnvironment, "1")
+	spec := completeCaptureSpec(t, "success", "ok", "")
+	timedOutName := RequiredScenarios[2]
+	// Starting a fresh copy of the Go test binary can take hundreds of
+	// milliseconds on a loaded or antivirus-scanned host. Leave ample startup
+	// time so this witness proves output was captured before the running command
+	// timed out, rather than racing process creation itself.
+	setCaptureCommand(&spec, timedOutName, helperCommand("timeout", "before-timeout"), "1s")
+	started := time.Now()
+	rows, err := Capture(context.Background(), spec, CaptureOptions{EvidenceDir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if elapsed := time.Since(started); elapsed > 5*time.Second {
+		t.Fatalf("per-scenario timeout took %v", elapsed)
+	}
+	row := captureRow(t, rows, timedOutName)
+	if row.Status != StatusFail || row.Reason != ReasonCommandTimeout {
+		t.Fatalf("timed-out row status/reason = %q/%q", row.Status, row.Reason)
+	}
+	got, err := os.ReadFile(row.Evidence)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "before-timeout" || row.EvidenceBytes != int64(len(got)) || row.EvidenceSHA256 == "" {
+		t.Fatalf("timed-out row evidence = %q, bytes=%d, hash=%q", got, row.EvidenceBytes, row.EvidenceSHA256)
+	}
+}
+
+func TestCaptureCannotSpoofFallback(t *testing.T) {
+	raw := validCaptureJSON(t)
+	var document map[string]any
+	if err := json.Unmarshal(raw, &document); err != nil {
+		t.Fatal(err)
+	}
+	document["fallback"] = "llama.cpp"
+	spoofed, err := json.Marshal(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ParseCaptureSpec(spoofed); err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("ParseCaptureSpec() spoof error = %v", err)
+	}
+
+	t.Setenv(captureHelperEnvironment, "1")
+	spec := completeCaptureSpec(t, "success", "ok", "")
+	rows, err := Capture(context.Background(), spec, CaptureOptions{EvidenceDir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, row := range rows {
+		if row.Receipt == nil || row.Receipt.Engine != "fak-native" || row.Receipt.Fallback != "none" {
+			t.Fatalf("capture minted spoofable receipt: %#v", row.Receipt)
+		}
+	}
+}
+
+func completeCaptureSpec(t *testing.T, behavior, stdout, stderr string) CaptureSpec {
+	t.Helper()
+	spec := CaptureSpec{Schema: CaptureSchema, RuntimeRevision: "runtime-r1", Artifact: "artifact@sha256:abc"}
+	for _, name := range RequiredScenarios {
+		spec.Scenarios = append(spec.Scenarios, CaptureScenarioSpec{
+			Name: name, Command: helperCommand(behavior, stdout, stderr), Timeout: "2s",
+		})
+	}
+	return spec
+}
+
+func helperCommand(args ...string) []string {
+	return append([]string{os.Args[0], "-test.run=TestCaptureHelperProcess", "--"}, args...)
+}
+
+func cloneCaptureSpec(spec CaptureSpec) CaptureSpec {
+	clone := spec
+	clone.Scenarios = append([]CaptureScenarioSpec(nil), spec.Scenarios...)
+	for index := range clone.Scenarios {
+		clone.Scenarios[index].Command = append([]string(nil), clone.Scenarios[index].Command...)
+	}
+	return clone
+}
+
+func setCaptureCommand(spec *CaptureSpec, name string, command []string, timeout string) {
+	for index := range spec.Scenarios {
+		if spec.Scenarios[index].Name == name {
+			spec.Scenarios[index].Command = command
+			spec.Scenarios[index].Timeout = timeout
+			return
+		}
+	}
+}
+
+func captureRow(t *testing.T, rows []Scenario, name string) Scenario {
+	t.Helper()
+	for _, row := range rows {
+		if row.Name == name {
+			return row
+		}
+	}
+	t.Fatalf("capture has no row %q", name)
+	return Scenario{}
+}
+
+func validCaptureJSON(t *testing.T) []byte {
+	t.Helper()
+	scenarios := make(map[string]any, len(RequiredScenarios))
+	for _, name := range RequiredScenarios {
+		scenarios[name] = map[string]any{"command": []string{"command"}, "timeout": "1s"}
+	}
+	b, err := json.Marshal(map[string]any{
+		"schema": CaptureSchema, "runtime_revision": "runtime-r1", "artifact": "artifact@sha256:abc", "scenarios": scenarios,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}

--- a/internal/localappcert/cert.go
+++ b/internal/localappcert/cert.go
@@ -18,6 +18,7 @@ type Status string
 
 const (
 	StatusPass        Status = "PASS"
+	StatusFail        Status = "FAIL"
 	StatusUnsupported Status = "UNSUPPORTED"
 )
 
@@ -40,11 +41,13 @@ type Receipt struct {
 }
 
 type Scenario struct {
-	Name     string   `json:"name"`
-	Status   Status   `json:"status"`
-	Evidence string   `json:"evidence,omitempty"`
-	Reason   string   `json:"reason,omitempty"`
-	Receipt  *Receipt `json:"receipt,omitempty"`
+	Name           string   `json:"name"`
+	Status         Status   `json:"status"`
+	Evidence       string   `json:"evidence,omitempty"`
+	EvidenceSHA256 string   `json:"evidence_sha256,omitempty"`
+	EvidenceBytes  int64    `json:"evidence_bytes"`
+	Reason         string   `json:"reason,omitempty"`
+	Receipt        *Receipt `json:"receipt,omitempty"`
 }
 
 type Envelope struct {


### PR DESCRIPTION
Adds deterministic certification scenario receipt capture, CLI support, and focused tests. Clean-origin checks: go test ./internal/localappcert ./cmd/localappcert -count=1. This advances #9157; closure still requires confirming the issue's real-device matrix acceptance.