### PR TITLE
feat(agent): bind shared work receipt to Qwen cohorts #9075

### DIFF
--- a/internal/agent/chat.go
+++ b/internal/agent/chat.go
@@ -402,6 +402,7 @@ type Completion struct {
 	// receipt and this planner executed the model math in-kernel. It is captured at
 	// the logits/decode seam, never reconstructed from text or gateway timing.
 	NativeInference *NativeInferenceReceipt
+	InKernelBatch   *InKernelBatchReceipt
 	// DecodeTrace is populated only for an explicitly requested in-kernel decode.
 	// Its events are authored at the native token-commit seam; proxy text and SSE
 	// fragments are never eligible sources.

--- a/internal/agent/inkernel_batch_coordinator.go
+++ b/internal/agent/inkernel_batch_coordinator.go
@@ -38,6 +38,12 @@ func runQwenSharedReceiptProbe(bs *model.BatchSession, ids []int, active []bool)
 	return fn(bs, ids, active)
 }
 
+type InKernelBatchReceipt struct {
+	CohortID     uint64 `json:"cohort_id"`
+	CohortSize   int    `json:"cohort_size"`
+	SharedPanels int    `json:"shared_panels"`
+	SharedMACs   int64  `json:"shared_macs"`
+}
 type inKernelCoalesceResult struct {
 	result inKernelGenerateResult
 	err    error
@@ -51,6 +57,7 @@ type inKernelCoalesceRequest struct {
 	result     chan inKernelCoalesceResult
 	done       chan struct{}
 	decodePass atomic.Uint32
+	receipt    InKernelBatchReceipt
 }
 
 type inKernelCoalesceContextKey struct{}
@@ -86,6 +93,7 @@ func (p *InKernelPlanner) runCoalescedGenerate(ctx context.Context, run func(con
 		p.drainCoalescedGenerates()
 	}
 	out := <-req.result
+	out.result.batchReceipt = req.receipt
 	return out.result, out.err
 }
 
@@ -133,6 +141,8 @@ func (p *InKernelPlanner) runDecodeCohort(cohort []*inKernelCoalesceRequest) {
 	}
 
 	var decodeErr error
+	var panels int
+	var macs int64
 	func() {
 		defer func() {
 			if r := recover(); r != nil {
@@ -146,12 +156,15 @@ func (p *InKernelPlanner) runDecodeCohort(cohort []*inKernelCoalesceRequest) {
 		if p.coalesceBatchHook != nil {
 			p.coalesceBatchHook(len(lanes))
 		}
-		panels, macs := inKernelDecodeLanesBatched(context.Background(), lanes, p.m, p.quant)
+		panels, macs = inKernelDecodeLanesBatched(context.Background(), lanes, p.m, p.quant)
 		if p.coalesceSharedHook != nil {
 			p.coalesceSharedHook(panels, macs)
 		}
 	}()
+	cohortID := p.coalesceCohortID.Add(1)
+	receipt := InKernelBatchReceipt{CohortID: cohortID, CohortSize: len(lanes), SharedPanels: panels, SharedMACs: macs}
 	for _, req := range prepared {
+		req.receipt = receipt
 		req.proceed <- decodeErr
 	}
 	for _, req := range cohort {

--- a/internal/agent/inkernel_batch_coordinator_test.go
+++ b/internal/agent/inkernel_batch_coordinator_test.go
@@ -96,6 +96,21 @@ func TestInKernelPlannerCoalescesConcurrentQwenTurns(t *testing.T) {
 	}
 	readyOnce.Do(func() { close(ready) })
 	wg.Wait()
+	var cohortID uint64
+	for i := range answers {
+		if answers[i].c == nil || answers[i].c.InKernelBatch == nil {
+			t.Fatalf("coalesced[%d] missing batch receipt", i)
+		}
+		r := answers[i].c.InKernelBatch
+		if r.CohortSize != len(messages) || r.SharedPanels == 0 || r.SharedMACs == 0 {
+			t.Fatalf("coalesced[%d] receipt=%+v", i, r)
+		}
+		if cohortID == 0 {
+			cohortID = r.CohortID
+		} else if r.CohortID != cohortID {
+			t.Fatalf("coalesced receipts identify different cohorts: %d != %d", r.CohortID, cohortID)
+		}
+	}
 	for i := range answers {
 		if answers[i].err != nil {
 			t.Fatalf("coalesced[%d]: %v", i, answers[i].err)

--- a/internal/agent/inkernel_planner.go
+++ b/internal/agent/inkernel_planner.go
@@ -110,6 +110,7 @@ type InKernelPlanner struct {
 	coalesceReadyHook  func()
 	coalesceBatchHook  func(int)
 	coalesceSharedHook func(panels int, macs int64)
+	coalesceCohortID   atomic.Uint64
 
 	reqMemMu      sync.Mutex
 	lastReqMemory RequestMemoryStats
@@ -672,6 +673,7 @@ type inKernelGenerateResult struct {
 	sourceTier        radixkv.SnapshotTier
 	prefillS, decodeS float64
 	stopped           bool
+	batchReceipt      InKernelBatchReceipt
 }
 
 func (p *InKernelPlanner) generateReusedRecovering(ctx context.Context, ids []int, maxNew int, temp, topP float64, topK int, logitBias model.LogitBias, freqPenalty, presPenalty float64, stops map[int]bool, emit func(int) bool, measurementOpt ...*nativeInferenceMeasurement) (res inKernelGenerateResult, err error) {
@@ -1011,6 +1013,10 @@ func (p *InKernelPlanner) Complete(ctx context.Context, messages []Message, tool
 	}
 	if sp.NativeInferenceReceipt {
 		comp.NativeInference = p.buildNativeInferenceReceipt(measurement, prefillS, decodeS)
+	}
+	if genRes.batchReceipt.CohortID != 0 {
+		receipt := genRes.batchReceipt
+		comp.InKernelBatch = &receipt
 	}
 	if sp.DecodeTrace {
 		events := make([]NativeDecodeTraceEvent, len(measurement.traceEvents))


### PR DESCRIPTION
## Summary
- propagate one coordinator-generated cohort identity to every request result
- expose actual shared panels and MACs on each Completion
- strengthen the deterministic test so both requests must carry the same nonzero receipt

## Verification
- go test ./internal/agent -run 'InKernel.*(Batch|Coalesc|Cancel|OOM|Reuse)|Qwen' -count=1
- WSL: go test -race ./internal/agent -run '^TestInKernelPlannerCoalescesConcurrentQwenTurns$' -count=1
- go vet ./internal/agent
- git diff --check

Not ready yet: production receipt remains dependent on #9074 Apple Metal witness run 33128933064.