### PR TITLE
test(agent): bind Qwen cohort cleanup receipts #9075

### DIFF
--- a/internal/agent/inkernel_batch_coordinator.go
+++ b/internal/agent/inkernel_batch_coordinator.go
@@ -39,10 +39,11 @@ func runQwenSharedReceiptProbe(bs *model.BatchSession, ids []int, active []bool)
 }
 
 type InKernelBatchReceipt struct {
-	CohortID     uint64 `json:"cohort_id"`
-	CohortSize   int    `json:"cohort_size"`
-	SharedPanels int    `json:"shared_panels"`
-	SharedMACs   int64  `json:"shared_macs"`
+	CohortID      uint64 `json:"cohort_id"`
+	CohortSize    int    `json:"cohort_size"`
+	SharedPanels  int    `json:"shared_panels"`
+	SharedMACs    int64  `json:"shared_macs"`
+	SessionCloses uint32 `json:"session_closes"`
 }
 type inKernelCoalesceResult struct {
 	result inKernelGenerateResult
@@ -50,14 +51,16 @@ type inKernelCoalesceResult struct {
 }
 
 type inKernelCoalesceRequest struct {
-	ctx        context.Context
-	run        func(context.Context) (inKernelGenerateResult, error)
-	prepared   chan *decodeLane
-	proceed    chan error
-	result     chan inKernelCoalesceResult
-	done       chan struct{}
-	decodePass atomic.Uint32
-	receipt    InKernelBatchReceipt
+	ctx          context.Context
+	run          func(context.Context) (inKernelGenerateResult, error)
+	prepared     chan *decodeLane
+	proceed      chan error
+	result       chan inKernelCoalesceResult
+	done         chan struct{}
+	decodePass   atomic.Uint32
+	receipt      InKernelBatchReceipt
+	closes       atomic.Uint32
+	receiptReady chan struct{}
 }
 
 type inKernelCoalesceContextKey struct{}
@@ -68,12 +71,13 @@ func (p *InKernelPlanner) coalescesQwenDecode() bool {
 
 func (p *InKernelPlanner) runCoalescedGenerate(ctx context.Context, run func(context.Context) (inKernelGenerateResult, error)) (inKernelGenerateResult, error) {
 	req := &inKernelCoalesceRequest{
-		ctx:      ctx,
-		run:      run,
-		prepared: make(chan *decodeLane, 1),
-		proceed:  make(chan error, 1),
-		result:   make(chan inKernelCoalesceResult, 1),
-		done:     make(chan struct{}),
+		ctx:          ctx,
+		run:          run,
+		prepared:     make(chan *decodeLane, 1),
+		proceed:      make(chan error, 1),
+		result:       make(chan inKernelCoalesceResult, 1),
+		done:         make(chan struct{}),
+		receiptReady: make(chan struct{}),
 	}
 	p.coalesceMu.Lock()
 	p.coalesceReady = append(p.coalesceReady, req)
@@ -93,6 +97,7 @@ func (p *InKernelPlanner) runCoalescedGenerate(ctx context.Context, run func(con
 		p.drainCoalescedGenerates()
 	}
 	out := <-req.result
+	<-req.receiptReady
 	out.result.batchReceipt = req.receipt
 	return out.result, out.err
 }
@@ -161,19 +166,28 @@ func (p *InKernelPlanner) runDecodeCohort(cohort []*inKernelCoalesceRequest) {
 			p.coalesceSharedHook(panels, macs)
 		}
 	}()
-	cohortID := p.coalesceCohortID.Add(1)
-	receipt := InKernelBatchReceipt{CohortID: cohortID, CohortSize: len(lanes), SharedPanels: panels, SharedMACs: macs}
 	for _, req := range prepared {
-		req.receipt = receipt
 		req.proceed <- decodeErr
 	}
 	for _, req := range cohort {
 		<-req.done
 	}
+	cohortID := p.coalesceCohortID.Add(1)
+	receipt := InKernelBatchReceipt{CohortID: cohortID, CohortSize: len(lanes), SharedPanels: panels, SharedMACs: macs}
+	for _, req := range prepared {
+		receipt.SessionCloses += req.closes.Load()
+	}
+	for _, req := range cohort {
+		req.receipt = receipt
+		close(req.receiptReady)
+	}
 }
 
 func coalescedDecode(ctx context.Context, lane *decodeLane) (bool, error) {
 	req, ok := ctx.Value(inKernelCoalesceContextKey{}).(*inKernelCoalesceRequest)
+	if ok {
+		defer req.closes.Add(1)
+	}
 	if !ok {
 		return false, nil
 	}

--- a/internal/agent/inkernel_batch_coordinator_test.go
+++ b/internal/agent/inkernel_batch_coordinator_test.go
@@ -102,7 +102,7 @@ func TestInKernelPlannerCoalescesConcurrentQwenTurns(t *testing.T) {
 			t.Fatalf("coalesced[%d] missing batch receipt", i)
 		}
 		r := answers[i].c.InKernelBatch
-		if r.CohortSize != len(messages) || r.SharedPanels == 0 || r.SharedMACs == 0 {
+		if r.CohortSize != len(messages) || r.SharedPanels == 0 || r.SharedMACs == 0 || r.SessionCloses != uint32(len(messages)) {
 			t.Fatalf("coalesced[%d] receipt=%+v", i, r)
 		}
 		if cohortID == 0 {


### PR DESCRIPTION
## Summary
- delay cohort receipt publication until every request goroutine has returned and its deferred Session.Close has run
- record exact cleanup count on the same cohort receipt carried by every Completion
- require cleanup count == cohort size in the deterministic and race witnesses

## Verification
- go test ./internal/agent -run 'InKernel.*(Batch|Coalesc|Cancel|OOM|Reuse)|Qwen' -count=1
- WSL: go test -race ./internal/agent -run '^TestInKernelPlannerCoalescesConcurrentQwenTurns$' -count=1
- go vet ./internal/agent
- git diff --check

Still not closure evidence: #9074 Apple run 33129925198 is queued, and the shared panel receipt remains test-injected until real Metal execution is green.