### PR TITLE
fix(devindex): ignore bare inline filenames (#9327)

### DIFF
--- a/internal/devindex/devindex.go
+++ b/internal/devindex/devindex.go
@@ -453,7 +453,7 @@ func (c *Catalog) parseDocsFrom(source, text string) {
 	}
 }
 
-var inlineCodePathRE = regexp.MustCompile("`((?:docs/)?[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*\\.(?:md|txt))`")
+var inlineCodePathRE = regexp.MustCompile("`((?:docs/|[A-Za-z0-9_.-]+/)[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*\\.(?:md|txt))`")
 var anyMarkdownLinkRE = regexp.MustCompile(`\[[^]]+\]\(([^)]+\.(?:md|txt))(?:#[^)]+)?\)`)
 
 func markdownLinkedDocs(line, source string) []Doc {

--- a/internal/devindex/inline_paths_test.go
+++ b/internal/devindex/inline_paths_test.go
@@ -1,0 +1,23 @@
+package devindex
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMarkdownInlinePathsIgnoreBareFilenames(t *testing.T) {
+	line := "keep `keep_allowlist.txt`, review `internal/orphanscan/keep_allowlist.txt`, and read [missing](docs/missing.md)"
+	got := markdownInlinePaths(line)
+	want := []string{"internal/orphanscan/keep_allowlist.txt", "docs/missing.md"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("markdownInlinePaths() = %#v, want %#v", got, want)
+	}
+}
+
+func TestMarkdownInlinePathsKeepQualifiedDocsPath(t *testing.T) {
+	got := markdownInlinePaths("See `docs/guide.md` and `README.md`.")
+	want := []string{"docs/guide.md"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("markdownInlinePaths() = %#v, want %#v", got, want)
+	}
+}


### PR DESCRIPTION
## Fresh completion witness

- Baseline-open issue #9327.
- Narrows inline-code path recognition to qualified repository paths; explicit Markdown links remain checked.
- Adds positive/negative fixture for bare keep_allowlist.txt, qualified paths, and explicit missing links.

Tests: go test ./internal/devindex -run 'MarkdownInlinePaths' -count=1 (PASS). Full package currently exposes unrelated pre-existing totality/live-tree failures, listed separately in worker evidence.

Closes #9327