### PR TITLE
fix(agent): prevent replay after accepted Qwen cohort #9075

### DIFF
--- a/internal/agent/inkernel_batch_coordinator.go
+++ b/internal/agent/inkernel_batch_coordinator.go
@@ -192,9 +192,9 @@ func coalescedDecode(ctx context.Context, lane *decodeLane) (bool, error) {
 		return false, nil
 	}
 	if req.decodePass.Add(1) > 1 {
-		// OOM retry stays under the coordinator's device lock, but retries this
-		// request alone after the failed cohort forward has returned.
-		_, _ = inKernelDecodeLanesBatched(ctx, []*decodeLane{lane}, lane.s.M, lane.s.Quant)
+		// The first coordinated pass may already have advanced this lane's KV/GDN
+		// state before a later operation failed. Replaying Session.Step would apply
+		// the accepted token twice, so cohort failures are terminal and fail closed.
 		return true, lane.err
 	}
 	req.prepared <- lane

--- a/internal/agent/inkernel_batch_coordinator_test.go
+++ b/internal/agent/inkernel_batch_coordinator_test.go
@@ -177,3 +177,27 @@ func TestInKernelPlannerCoalescesConcurrentQwenTurns(t *testing.T) {
 		t.Fatalf("default-off=%#v err=%v", got, err)
 	}
 }
+
+func TestCoalescedDecodeDoesNotReplayAfterAcceptedPass(t *testing.T) {
+	var calls int
+	restoreProbe := installQwenSharedReceiptProbeForTest(func(*model.BatchSession, []int, []bool) ([][]float32, int, int64, bool) {
+		calls++
+		return nil, 0, 0, true
+	})
+	defer restoreProbe()
+
+	req := &inKernelCoalesceRequest{}
+	req.decodePass.Store(1) // one cohort pass was already accepted and may have mutated state
+	ln := &decodeLane{s: model.NewSynthetic(tinyConcurrencyConfig()).NewSession()}
+	ctx := context.WithValue(context.Background(), inKernelCoalesceContextKey{}, req)
+	coordinated, err := coalescedDecode(ctx, ln)
+	if !coordinated || err != nil {
+		t.Fatalf("coordinated=%v err=%v", coordinated, err)
+	}
+	if calls != 0 {
+		t.Fatalf("accepted coordinated pass replayed %d model forwards", calls)
+	}
+	if got := req.decodePass.Load(); got != 2 {
+		t.Fatalf("decode pass count=%d, want 2 attempts with only the first executed", got)
+	}
+}


### PR DESCRIPTION
## Summary
- fail closed when an accepted coordinated Qwen pass is re-entered
- remove the old singleton replay that could apply a token twice after KV/GDN mutation
- add a deterministic no-second-forward witness

## Verification
- `go test ./internal/agent -run 'InKernel.*(Batch|Coalesc|Cancel|OOM|Reuse)|Qwen|CoalescedDecode' -count=1`
- WSL: `go test -race ./internal/agent -run '^TestCoalescedDecodeDoesNotReplayAfterAcceptedPass$|^TestInKernelPlannerCoalescesConcurrentQwenTurns$' -count=1`
- `go vet ./internal/agent`
- `git diff --check`

Not closure evidence yet: real Apple Metal execution remains unwitnessed.