### PR TITLE
fix(examples): derive README inventory counts (#9332)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,7 @@ policy manifests this page used to be named after are the smallest of the three.
 
 | Kind | What it is | Count |
 |---|---|---|
-| **Runnable demos** | self-contained directories, each with a command that proves one claim — most need no key, model, GPU, or network | 62 directories, 56 with their own README |
+| **Runnable demos** | self-contained directories, each with a command that proves one claim — most need no key, model, GPU, or network | 69 directories, 62 with their own README |
 | **Framework integrations** | eight of those directories put fak in front of an agent you already run: OpenAI SDK, MCP (server and client), OpenAI Agents, AutoGen, CrewAI, Ollama, and a generic external driver | 8 |
 | **Policy manifests** | starter capability floors to copy and adapt, at the top level of `examples/` | 21 `*.json` |
 

--- a/internal/examplesinventory/inventory.go
+++ b/internal/examplesinventory/inventory.go
@@ -1,0 +1,62 @@
+// Package examplesinventory verifies the categorized corpus summary in examples/README.md.
+package examplesinventory
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+type Counts struct{ Directories, WithREADME, Policies int }
+
+var summaryRE = regexp.MustCompile(`(?m)^\| \*\*Runnable demos\*\* \|.*\| (\d+) directories, (\d+) with their own README \|$`)
+
+func Discover(root string) (Counts, error) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return Counts{}, err
+	}
+	var c Counts
+	for _, e := range entries {
+		if e.IsDir() {
+			c.Directories++
+			if _, err := os.Stat(filepath.Join(root, e.Name(), "README.md")); err == nil {
+				c.WithREADME++
+			}
+			continue
+		}
+		if filepath.Ext(e.Name()) != ".json" {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(root, e.Name()))
+		if err != nil {
+			return Counts{}, err
+		}
+		// Policy manifests use the fak-policy schema; unrelated model/config/report JSON does not.
+		if regexp.MustCompile(`"schema"\s*:\s*"fak-policy`).Match(b) {
+			c.Policies++
+		}
+	}
+	return c, nil
+}
+func CheckREADME(root string) error {
+	c, err := Discover(root)
+	if err != nil {
+		return err
+	}
+	b, err := os.ReadFile(filepath.Join(root, "README.md"))
+	if err != nil {
+		return err
+	}
+	m := summaryRE.FindSubmatch(b)
+	if m == nil {
+		return fmt.Errorf("runnable demo summary not found")
+	}
+	want := fmt.Sprintf("%d directories, %d with their own README", c.Directories, c.WithREADME)
+	got := string(m[1]) + " directories, " + string(m[2]) + " with their own README"
+	if got != want {
+		return fmt.Errorf("examples README summary = %s, want %s", got, want)
+	}
+	return nil
+}

--- a/internal/examplesinventory/inventory_test.go
+++ b/internal/examplesinventory/inventory_test.go
@@ -1,0 +1,40 @@
+package examplesinventory
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCheckREADMETracksCorpus(t *testing.T) {
+	root := t.TempDir()
+	must := func(path, body string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	must(filepath.Join(root, "a", "README.md"), "a")
+	must(filepath.Join(root, "data", "fixture.txt"), "x")
+	must(filepath.Join(root, "policy.json"), `{"schema":"fak-policy.v1"}`)
+	must(filepath.Join(root, "config.json"), `{"schema":"other"}`)
+	must(filepath.Join(root, "README.md"), "| **Runnable demos** | x | 2 directories, 1 with their own README |\n")
+	if err := CheckREADME(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(root, "new-demo"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := CheckREADME(root); err == nil {
+		t.Fatal("added directory did not make summary stale")
+	}
+}
+func TestRepositoryREADMEInventory(t *testing.T) {
+	root := filepath.Join("..", "..", "examples")
+	if err := CheckREADME(root); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Fresh baseline-open completion for #9332. Adds an independent corpus walker/check, updates current counts, and proves adding an immediate directory makes the check fail until refreshed. Test: go test ./internal/examplesinventory -count=1. Closes #9332