### PR TITLE
fix(resume): honor hold flags after session ID (#9343)

### DIFF
--- a/cmd/fak/resume.go
+++ b/cmd/fak/resume.go
@@ -1046,14 +1046,20 @@ func runResumeHold(stdout, stderr io.Writer, argv []string) int {
 	regDirFlag := fs.String("reg-dir", "", "registry dir holding resume_drivestate.jsonl (default: the same regDir the watchdog resolves — $FLEET_REG_DIR, else the host Fleet registry, else <repo>/tools/_registry)")
 	list := fs.Bool("list", false, "list the current effective operator holds instead of setting one")
 	asJSON := fs.Bool("json", false, "with --list, emit the holds as JSON")
-	if !parseFlags(fs, argv) {
+	if listRequestedRaw(argv) {
+		if !parseFlags(fs, argv) {
+			return 2
+		}
+		return renderResumeHolds(stdout, stderr, resolveSweepRegDir(*regDirFlag), *asJSON)
+	}
+	sid, parsed := parseInterspersedResumeHold(fs, argv, stderr)
+	if !parsed {
 		return 2
 	}
 	regDir := resolveSweepRegDir(*regDirFlag)
-	if *list || fs.NArg() == 0 {
+	if *list {
 		return renderResumeHolds(stdout, stderr, regDir, *asJSON)
 	}
-	sid := strings.TrimSpace(fs.Arg(0))
 	st, ok := normalizeHoldState(*state)
 	if !ok {
 		fmt.Fprintf(stderr, "fak resume hold: bad --state %q (want paused, draining, or stopped)\n", *state)

--- a/cmd/fak/resume_hold_args.go
+++ b/cmd/fak/resume_hold_args.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// parseInterspersedResumeHold accepts the documented "session-id --flag value"
+// form while preserving the ordinary flags-first form. Exactly one session ID is
+// returned; unknown flags and extra positionals remain usage errors.
+func parseInterspersedResumeHold(fs *flag.FlagSet, argv []string, stderr io.Writer) (string, bool) {
+	var positional []string
+	var flags []string
+	for i := 0; i < len(argv); i++ {
+		arg := argv[i]
+		if strings.HasPrefix(arg, "-") {
+			flags = append(flags, arg)
+			if !strings.Contains(arg, "=") {
+				name := strings.TrimLeft(arg, "-")
+				f := fs.Lookup(name)
+				if f == nil {
+					flags = append(flags, argv[i+1:]...)
+					break
+				}
+				if _, ok := f.Value.(interface{ IsBoolFlag() bool }); !ok && i+1 < len(argv) {
+					i++
+					flags = append(flags, argv[i])
+				}
+			}
+		} else {
+			positional = append(positional, arg)
+		}
+	}
+	if !parseFlags(fs, flags) {
+		return "", false
+	}
+	positional = append(positional, fs.Args()...)
+	if len(positional) != 1 {
+		fmt.Fprintf(stderr, "fak resume hold: want exactly one session-id, got %d\n", len(positional))
+		return "", false
+	}
+	return strings.TrimSpace(positional[0]), true
+}
+
+func listRequestedRaw(argv []string) bool {
+	for _, arg := range argv {
+		if arg == "--list" || arg == "-list" || arg == "--list=true" || arg == "-list=true" {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/fak/resume_hold_args_test.go
+++ b/cmd/fak/resume_hold_args_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResumeHoldAcceptsIDFirstFlags(t *testing.T) {
+	for _, args := range [][]string{{"session-1", "--state", "stopped", "--reason", "operator intent"}, {"--state", "stopped", "--reason", "operator intent", "session-1"}} {
+		dir := t.TempDir()
+		args = append([]string{"--reg-dir", dir}, args...)
+		var out, err bytes.Buffer
+		if rc := runResumeHold(&out, &err, args); rc != 0 {
+			t.Fatalf("%v rc=%d err=%s", args, rc, err.String())
+		}
+		b, e := os.ReadFile(filepath.Join(dir, "resume_drivestate.jsonl"))
+		if e != nil {
+			t.Fatal(e)
+		}
+		var row map[string]any
+		if e = json.Unmarshal(bytes.TrimSpace(b), &row); e != nil {
+			t.Fatal(e)
+		}
+		if row["state"] != "stopped" || row["reason"] != "operator intent" {
+			t.Fatalf("row=%v", row)
+		}
+	}
+}
+func TestResumeHoldRejectsExtraPositionals(t *testing.T) {
+	var out, err bytes.Buffer
+	if rc := runResumeHold(&out, &err, []string{"one", "two", "--reg-dir", t.TempDir()}); rc != 2 {
+		t.Fatalf("rc=%d", rc)
+	}
+}


### PR DESCRIPTION
Fresh baseline-open completion. Accepts both documented ID-first and flags-first forms, rejects extra positionals, and verifies durable stopped state plus reason. Test: go test ./cmd/fak -run 'ResumeHoldAcceptsIDFirstFlags|ResumeHoldRejectsExtraPositionals|ResumeHoldWritesListsAndValidates' -count=1. Closes #9343