### PR TITLE
test(agent): witness real Qwen Metal cohorts #9075

### DIFF
--- a/.github/workflows/metal-decode-bench.yml
+++ b/.github/workflows/metal-decode-bench.yml
@@ -46,6 +46,9 @@ jobs:
           go test ./internal/model/ \
             -run '^TestQwen35HybridQ4KStepBatchActiveMatchesSerial$' \
             -count=1 -v
+          go test ./internal/agent/ \
+            -run '^TestInKernelPlannerCoalescesRealQwenMetalTurns$' \
+            -count=1 -v
       # The measurement: n separate command buffers (Single) vs one batched (Batch), ms/layer.
       # The Single/Batch ms ratio is the #1382 command-buffer-collapse speedup on the mlp_decode cost.
       - name: benchmark - batched vs single fused expert MLP

--- a/internal/agent/inkernel_batch_coordinator_darwin_test.go
+++ b/internal/agent/inkernel_batch_coordinator_darwin_test.go
@@ -1,0 +1,103 @@
+//go:build darwin && arm64 && cgo
+
+package agent
+
+import (
+	"context"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/anthony-chaudhary/fak/internal/metalgemm"
+	"github.com/anthony-chaudhary/fak/internal/model"
+)
+
+// TestInKernelPlannerCoalescesRealQwenMetalTurns is the planner-owned execution
+// witness for #9075. It deliberately installs no shared-receipt probe: nonzero
+// receipt values can only come back from BatchSession's real Qwen Metal path.
+func TestInKernelPlannerCoalescesRealQwenMetalTurns(t *testing.T) {
+	if !metalgemm.Available() {
+		t.Skip("Metal unavailable")
+	}
+	m := model.NewQwen35HybridQ4KMetalFixture(t)
+	t.Cleanup(func() {
+		if err := m.CloseWeights(); err != nil {
+			t.Fatalf("close model weights: %v", err)
+		}
+	})
+
+	t.Setenv("FAK_INKERNEL_QWEN35_METAL_GDN_SEQUENCE", "on")
+	p := NewInKernelPlanner(m, loadProbeTok(t), "synthetic-qwen35-metal-cohort", true, nil, true)
+	p.maxNew = 2
+	p.batchDecode = true
+
+	const cohortSize = 4 // the real hybrid Q4_K path admits B=4..8
+	ready := make(chan struct{})
+	p.coalesceReadyHook = func() { <-ready }
+	var batchMu sync.Mutex
+	var batches []int
+	p.coalesceBatchHook = func(n int) {
+		batchMu.Lock()
+		batches = append(batches, n)
+		batchMu.Unlock()
+	}
+	messages := make([][]Message, cohortSize)
+	for i := range messages {
+		messages[i] = []Message{{Role: RoleUser, Content: string(rune('a' + i))}}
+	}
+	type answer struct {
+		completion *Completion
+		err        error
+	}
+	answers := make([]answer, cohortSize)
+	var wg sync.WaitGroup
+	for i := range answers {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			answers[i].completion, answers[i].err = p.Complete(context.Background(), messages[i], nil)
+		}(i)
+	}
+	deadline := time.After(10 * time.Second)
+	for {
+		p.coalesceMu.Lock()
+		n := len(p.coalesceReady)
+		p.coalesceMu.Unlock()
+		if n == cohortSize {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("planner queued %d/%d requests", n, cohortSize)
+		default:
+			runtime.Gosched()
+		}
+	}
+	close(ready)
+	wg.Wait()
+
+	var cohortID uint64
+	for i, answer := range answers {
+		if answer.err != nil {
+			t.Fatalf("coalesced[%d]: %v", i, answer.err)
+		}
+		if answer.completion == nil || answer.completion.InKernelBatch == nil {
+			t.Fatalf("coalesced[%d] missing receipt", i)
+		}
+		receipt := answer.completion.InKernelBatch
+		if receipt.CohortSize != cohortSize || receipt.SharedPanels == 0 || receipt.SharedMACs == 0 || receipt.SessionCloses != cohortSize {
+			t.Fatalf("coalesced[%d] real Metal receipt=%+v", i, receipt)
+		}
+		if cohortID == 0 {
+			cohortID = receipt.CohortID
+		} else if receipt.CohortID != cohortID {
+			t.Fatalf("coalesced[%d] cohort=%d, want %d", i, receipt.CohortID, cohortID)
+		}
+	}
+	batchMu.Lock()
+	defer batchMu.Unlock()
+	if len(batches) == 0 || batches[0] != cohortSize {
+		t.Fatalf("planner batches=%v, want first batch B=%d", batches, cohortSize)
+	}
+}

--- a/internal/model/qwen35_batch_decode_darwin_test.go
+++ b/internal/model/qwen35_batch_decode_darwin_test.go
@@ -187,3 +187,18 @@ func qwen35BatchCompareSession(t *testing.T, lane int, want, got *Session) {
 		assertMaxAbsAtMost(t, "recurrent", wr, r, 2e-4)
 	}
 }
+
+// NewQwen35HybridQ4KMetalFixture exposes the already-bounded real Metal fixture
+// to cross-package integration tests. It uses the same mixed Q4_K/Q8 weights and
+// topology as TestQwen35HybridQ4KStepBatchActiveMatchesSerial.
+func NewQwen35HybridQ4KMetalFixture(t *testing.T) *Model {
+	t.Helper()
+	cfg := qwen35HybridQ4KTestCfg()
+	cfg.ModelType = "qwen3_5_text"
+	cfg.QKNorm = true
+	cfg.QKNormEps = 3e-5
+	m := NewSynthetic(cfg)
+	m.Quantize()
+	fillQ4KMajority(t, m, cfg)
+	return m
+}


### PR DESCRIPTION
## Summary
- add a Darwin/arm64 planner-level Qwen cohort fixture that installs no synthetic receipt probe
- bind every completion to the real `BatchSession` Metal shared-panel/MAC receipt and exact cohort cleanup count
- run the planner witness beside the existing model/Metal parity tests in the manual Apple workflow

## Local verification
- `go test ./internal/agent ./internal/model -count=1`
- `go test ./internal/agent -run '^TestCoalescedDecodeDoesNotReplayAfterAcceptedPass$|^TestInKernelPlannerCoalescesConcurrentQwenTurns$' -count=1`
- `go vet ./internal/agent ./internal/model`
- `git diff --check`

## Apple witness
Not witnessed yet. The new exact command is:

```bash
go test ./internal/agent/ -run '^TestInKernelPlannerCoalescesRealQwenMetalTurns$' -count=1 -v
```

Keep #9075 open until that command is green on Apple Metal and the full acceptance audit passes.