### PR TITLE
test(agent): witness Qwen Metal cancel isolation #9075

### DIFF
--- a/internal/agent/inkernel_batch_coordinator_darwin_test.go
+++ b/internal/agent/inkernel_batch_coordinator_darwin_test.go
@@ -4,6 +4,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"runtime"
 	"sync"
 	"testing"
@@ -32,7 +33,10 @@ func TestInKernelPlannerCoalescesRealQwenMetalTurns(t *testing.T) {
 	p.maxNew = 2
 	p.batchDecode = true
 
-	const cohortSize = 4 // the real hybrid Q4_K path admits B=4..8
+	const (
+		requestCount = 5
+		activeCount  = 4 // cancel one request; real hybrid Q4_K still receives B=4
+	)
 	ready := make(chan struct{})
 	p.coalesceReadyHook = func() { <-ready }
 	var batchMu sync.Mutex
@@ -42,7 +46,7 @@ func TestInKernelPlannerCoalescesRealQwenMetalTurns(t *testing.T) {
 		batches = append(batches, n)
 		batchMu.Unlock()
 	}
-	messages := make([][]Message, cohortSize)
+	messages := make([][]Message, requestCount)
 	for i := range messages {
 		messages[i] = []Message{{Role: RoleUser, Content: string(rune('a' + i))}}
 	}
@@ -50,13 +54,19 @@ func TestInKernelPlannerCoalescesRealQwenMetalTurns(t *testing.T) {
 		completion *Completion
 		err        error
 	}
-	answers := make([]answer, cohortSize)
+	answers := make([]answer, requestCount)
+	ctxs := make([]context.Context, requestCount)
+	for i := range ctxs {
+		ctxs[i] = context.Background()
+	}
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	ctxs[0] = cancelCtx
 	var wg sync.WaitGroup
 	for i := range answers {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			answers[i].completion, answers[i].err = p.Complete(context.Background(), messages[i], nil)
+			answers[i].completion, answers[i].err = p.Complete(ctxs[i], messages[i], nil)
 		}(i)
 	}
 	deadline := time.After(10 * time.Second)
@@ -64,21 +74,26 @@ func TestInKernelPlannerCoalescesRealQwenMetalTurns(t *testing.T) {
 		p.coalesceMu.Lock()
 		n := len(p.coalesceReady)
 		p.coalesceMu.Unlock()
-		if n == cohortSize {
+		if n == requestCount {
 			break
 		}
 		select {
 		case <-deadline:
-			t.Fatalf("planner queued %d/%d requests", n, cohortSize)
+			t.Fatalf("planner queued %d/%d requests", n, requestCount)
 		default:
 			runtime.Gosched()
 		}
 	}
+	cancel()
 	close(ready)
 	wg.Wait()
 
+	if !errors.Is(answers[0].err, context.Canceled) {
+		t.Fatalf("canceled lane err=%v", answers[0].err)
+	}
 	var cohortID uint64
-	for i, answer := range answers {
+	for i, answer := range answers[1:] {
+		i++
 		if answer.err != nil {
 			t.Fatalf("coalesced[%d]: %v", i, answer.err)
 		}
@@ -86,7 +101,7 @@ func TestInKernelPlannerCoalescesRealQwenMetalTurns(t *testing.T) {
 			t.Fatalf("coalesced[%d] missing receipt", i)
 		}
 		receipt := answer.completion.InKernelBatch
-		if receipt.CohortSize != cohortSize || receipt.SharedPanels == 0 || receipt.SharedMACs == 0 || receipt.SessionCloses != cohortSize {
+		if receipt.CohortSize != activeCount || receipt.SharedPanels == 0 || receipt.SharedMACs == 0 || receipt.SessionCloses != activeCount {
 			t.Fatalf("coalesced[%d] real Metal receipt=%+v", i, receipt)
 		}
 		if cohortID == 0 {
@@ -97,7 +112,7 @@ func TestInKernelPlannerCoalescesRealQwenMetalTurns(t *testing.T) {
 	}
 	batchMu.Lock()
 	defer batchMu.Unlock()
-	if len(batches) == 0 || batches[0] != cohortSize {
-		t.Fatalf("planner batches=%v, want first batch B=%d", batches, cohortSize)
+	if len(batches) == 0 || batches[0] != activeCount {
+		t.Fatalf("planner batches=%v, want first batch B=%d", batches, activeCount)
 	}
 }


### PR DESCRIPTION
## Summary
- strengthen the real planner-owned Qwen Metal fixture with request-scoped cancellation
- queue five requests, cancel one at the batch boundary, and preserve a real B=4 Metal cohort for the peers
- require canceled-lane isolation plus shared cohort receipt and exact cleanup for all surviving requests

## Verification
- go test ./internal/agent -run '^TestCoalescedDecodeDoesNotReplayAfterAcceptedPass$|^TestInKernelPlannerCoalescesConcurrentQwenTurns$' -count=1
- go vet ./internal/agent
- git diff --check

Apple Metal execution is not witnessed yet. Keep #9075 open until the Darwin test is green.