### PR TITLE
perf(model): admit Qwen hybrid B2-B3 Metal batches #9074

### DIFF
--- a/internal/model/qwen35_batch_decode.go
+++ b/internal/model/qwen35_batch_decode.go
@@ -5,7 +5,7 @@ package model
 var qwen35HybridQ4KBatchStep func(*BatchSession, []int) ([][]float32, bool)
 
 func (bs *BatchSession) qwen35HybridQ4KBatchOK(batch int) bool {
-	return bs != nil && bs.M != nil && batch >= 4 && batch <= 8 &&
+	return bs != nil && bs.M != nil && batch >= 2 && batch <= 8 &&
 		bs.M.Cfg.IsQwen35Hybrid() && bs.M.Cfg.BlockTopology == PreNorm && !bs.M.Cfg.IsMoE() && qwen35HybridQ4KBatchStep != nil
 }
 

--- a/internal/model/qwen35_batch_decode_darwin_test.go
+++ b/internal/model/qwen35_batch_decode_darwin_test.go
@@ -3,6 +3,7 @@
 package model
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -10,6 +11,19 @@ import (
 )
 
 func TestQwen35HybridQ4KStepBatchActiveMatchesSerial(t *testing.T) {
+	for _, active := range [][]bool{
+		{true, true},
+		{true, true, true},
+		{true, false, true, true, true},
+	} {
+		active := active
+		t.Run(qwen35BatchCaseName(active), func(t *testing.T) {
+			qwen35HybridQ4KStepBatchActiveMatchesSerial(t, active)
+		})
+	}
+}
+
+func qwen35HybridQ4KStepBatchActiveMatchesSerial(t *testing.T, active []bool) {
 	if !metalgemm.Available() {
 		t.Skip("Metal unavailable")
 	}
@@ -27,7 +41,7 @@ func TestQwen35HybridQ4KStepBatchActiveMatchesSerial(t *testing.T) {
 		releaseMetalQ4KResidency(m)
 	})
 
-	const lanes = 5 // four active rows after ragged compaction
+	lanes := len(active)
 	serial := make([]*Session, lanes)
 	batched := make([]*Session, lanes)
 	prompts := make([][]int, lanes)
@@ -42,9 +56,19 @@ func TestQwen35HybridQ4KStepBatchActiveMatchesSerial(t *testing.T) {
 		defer batched[i].Close()
 	}
 
-	active := []bool{true, false, true, true, true}
-	ids := []int{41, 43, 47, 53, 59}
-	beforeInactive := qwen35BatchStateSnapshot(t, batched[1])
+	ids := make([]int, lanes)
+	for i := range ids {
+		ids[i] = []int{41, 43, 47, 53, 59}[i]
+	}
+	var beforeInactive qwen35BatchSnapshot
+	inactive := -1
+	for i, enabled := range active {
+		if !enabled {
+			inactive = i
+			beforeInactive = qwen35BatchStateSnapshot(t, batched[i])
+			break
+		}
+	}
 	want := make([][]float32, lanes)
 	for i := range serial {
 		if active[i] {
@@ -70,9 +94,21 @@ func TestQwen35HybridQ4KStepBatchActiveMatchesSerial(t *testing.T) {
 		}
 		qwen35BatchCompareSession(t, i, serial[i], batched[i])
 	}
-	if after := qwen35BatchStateSnapshot(t, batched[1]); !reflect.DeepEqual(beforeInactive, after) {
-		t.Fatal("inactive lane state mutated")
+	if inactive >= 0 {
+		if after := qwen35BatchStateSnapshot(t, batched[inactive]); !reflect.DeepEqual(beforeInactive, after) {
+			t.Fatal("inactive lane state mutated")
+		}
 	}
+}
+
+func qwen35BatchCaseName(active []bool) string {
+	activeCount := 0
+	for _, enabled := range active {
+		if enabled {
+			activeCount++
+		}
+	}
+	return fmt.Sprintf("B%d_active%d", len(active), activeCount)
 }
 
 func qwen35BatchPreparedSession(t *testing.T, m *Model, prompt []int) *Session {

--- a/internal/model/qwen35_batch_decode_metal.go
+++ b/internal/model/qwen35_batch_decode_metal.go
@@ -11,7 +11,7 @@ func init() { qwen35HybridQ4KBatchStep = stepBatchQwen35HybridQ4KMetal }
 func stepBatchQwen35HybridQ4KMetal(bs *BatchSession, ids []int) ([][]float32, bool) {
 	B, m, cfg := len(ids), bs.M, bs.M.Cfg
 	H, hd, nH, nKV := cfg.HiddenSize, cfg.HeadDim, cfg.NumHeads, cfg.NumKVHeads
-	if B < 4 || B > 8 || !metalgemm.Available() || len(bs.Seqs) != B || cfg.ModelType != "qwen3_5_text" || !cfg.AttnOutputGate || !cfg.QKNorm || cfg.rotaryDim() < 2 {
+	if B < 2 || B > 8 || !metalgemm.Available() || len(bs.Seqs) != B || cfg.ModelType != "qwen3_5_text" || !cfg.AttnOutputGate || !cfg.QKNorm || cfg.rotaryDim() < 2 {
 		return nil, false
 	}
 	for _, s := range bs.Seqs {

--- a/internal/model/qwen35_batch_decode_test.go
+++ b/internal/model/qwen35_batch_decode_test.go
@@ -23,9 +23,9 @@ func TestQwen35HybridQ4KBatchGateAndRaggedReceipt(t *testing.T) {
 	m := NewSynthetic(cfg)
 	old := qwen35HybridQ4KBatchStep
 	defer func() { qwen35HybridQ4KBatchStep = old }()
-	calls := 0
+	var batches []int
 	qwen35HybridQ4KBatchStep = func(bs *BatchSession, ids []int) ([][]float32, bool) {
-		calls++
+		batches = append(batches, len(ids))
 		bs.lastStepSharedPanels = 7
 		bs.recordStepMACs(len(ids))
 		out := make([][]float32, len(ids))
@@ -34,22 +34,29 @@ func TestQwen35HybridQ4KBatchGateAndRaggedReceipt(t *testing.T) {
 		}
 		return out, true
 	}
+	for _, batch := range []int{2, 3, 8} {
+		ids := make([]int, batch)
+		for i := range ids {
+			ids[i] = 8 + i
+		}
+		bs := m.NewBatchSession(batch)
+		got := bs.StepBatch(ids)
+		if batches[len(batches)-1] != batch || bs.LastStepSharedPanels() != 7 || bs.LastStepMACs() == 0 {
+			t.Fatalf("B=%d batches=%v panels=%d macs=%d", batch, batches, bs.LastStepSharedPanels(), bs.LastStepMACs())
+		}
+		for i := range got {
+			if got[i][0] != float32(ids[i]) {
+				t.Fatalf("B=%d row %d=%v", batch, i, got[i])
+			}
+		}
+	}
+
 	bs := m.NewBatchSession(4)
 	got := bs.StepBatchActive([]int{4, 5, 6, 7}, []bool{true, false, true, true})
-	if calls != 0 || bs.LastStepSharedPanels() != 0 {
-		t.Fatalf("B=3 must stay serial: calls=%d receipt=%d", calls, bs.LastStepSharedPanels())
+	if batches[len(batches)-1] != 3 || bs.LastStepSharedPanels() != 7 || bs.LastStepMACs() == 0 {
+		t.Fatalf("ragged batches=%v panels=%d macs=%d", batches, bs.LastStepSharedPanels(), bs.LastStepMACs())
 	}
 	if got[1] != nil {
 		t.Fatal("inactive lane produced logits")
-	}
-
-	got = bs.StepBatch([]int{8, 9, 10, 11})
-	if calls != 1 || bs.LastStepSharedPanels() != 7 || bs.LastStepMACs() == 0 {
-		t.Fatalf("calls=%d panels=%d macs=%d", calls, bs.LastStepSharedPanels(), bs.LastStepMACs())
-	}
-	for i := range got {
-		if got[i][0] != float32(8+i) {
-			t.Fatalf("row %d=%v", i, got[i])
-		}
 	}
 }


### PR DESCRIPTION
## Summary
- admit the existing Qwen hybrid Q4_K Metal shared path for the issue's required B=2..8 envelope instead of B=4..8 only
- add host gate/receipt coverage for B=2, B=3, B=8, and ragged active B=3
- extend the exact Darwin state-parity witness across B=2, B=3, and the existing ragged B=5/active=4 case

## Verification
- go test ./internal/model -run '^TestQwen35HybridQ4KBatchGateAndRaggedReceipt$|^TestStepBatchExecutionReceiptRequiresSharedPanel$' -count=1
- go vet ./internal/model
- git diff --check

Apple Metal B=2/B=3 execution is not witnessed yet. Keep #9074 and #9075 open until the focused Darwin workflow is green.