### PR TITLE
fix(sessiondiag): fix unbound startup recovery counts

### DIFF
--- a/cmd/fak/session_journal_audit_test.go
+++ b/cmd/fak/session_journal_audit_test.go
@@ -98,3 +98,31 @@ func TestSessionJournalAuditPresentWithoutPostLaunchProgressIsNonzeroRed(t *test
 		t.Fatalf("stdout missing RED present-no-progress row: %s", stdout.String())
 	}
 }
+
+func TestSessionJournalAuditReportsExcludedUnboundStartup(t *testing.T) {
+	userRoot := t.TempDir()
+	regDir := t.TempDir()
+	t.Setenv("CODEX_HOME", "")
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	const identity = "0198f76a-67c2-7d11-a8f5-8f3d82149734"
+	rows := strings.Join([]string{
+		`{"ts":"2026-08-29T09:00:00Z","uuid":"` + identity + `","trace":"guard-trace-9849","provider":"codex","via":"guard-sessionstart","source":"startup"}`,
+		`{"ts":"2026-08-29T10:00:00Z","uuid":"` + identity + `","trace":"model-controlled-trace","provider":"codex","via":"guard-sessionstart","source":"startup"}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(regDir, "resume_identity.jsonl"), []byte(rows), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	oldNow := sessionJournalAuditNow
+	t.Cleanup(func() { sessionJournalAuditNow = oldNow })
+	sessionJournalAuditNow = func() time.Time { return time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC) }
+
+	var stdout, stderr bytes.Buffer
+	code := runSessionJournalAudit(&stdout, &stderr, []string{"--since", "24h", "--reg-dir", regDir, "--home", userRoot})
+	if code != 0 {
+		t.Fatalf("code=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	got := stdout.String()
+	if !strings.Contains(got, "excluded_synthetic_or_unbound=1") || !strings.Contains(got, sessiondiag.JournalStatusSyntheticOrUnbound) {
+		t.Fatalf("human verdict=%q", got)
+	}
+}

--- a/internal/sessiondiag/journal_audit.go
+++ b/internal/sessiondiag/journal_audit.go
@@ -23,6 +23,7 @@ const (
 	JournalStatusAdvanced                    = "advanced"
 	JournalStatusMissingTranscript           = "missing_transcript"
 	JournalStatusPresentNoPostLaunchProgress = "present_no_post_launch_progress"
+	JournalStatusSyntheticOrUnbound          = "synthetic_or_unbound_identity"
 )
 
 // JournalLaunchIdentity is one provider-session identity observed at SessionStart.
@@ -103,6 +104,7 @@ type JournalAuditCounts struct {
 	MissingTranscript           int            `json:"missing_transcript"`
 	PresentNoPostLaunchProgress int            `json:"present_no_post_launch_progress"`
 	ExcludedUnsupportedProvider int            `json:"excluded_unsupported_provider"`
+	ExcludedSyntheticOrUnbound  int            `json:"excluded_synthetic_or_unbound"`
 	AuthorityErrors             int            `json:"authority_errors"`
 	ByProvider                  map[string]int `json:"by_provider"`
 }
@@ -221,6 +223,8 @@ func AuditRecentLaunches(opt JournalAuditOptions) JournalAuditReport {
 		case JournalStatusPresentNoPostLaunchProgress:
 			rep.Counts.ExactTranscripts++
 			rep.Counts.PresentNoPostLaunchProgress++
+		case JournalStatusSyntheticOrUnbound:
+			rep.Counts.ExcludedSyntheticOrUnbound++
 		default:
 			rep.Counts.MissingTranscript++
 		}
@@ -234,13 +238,20 @@ func AuditRecentLaunches(opt JournalAuditOptions) JournalAuditReport {
 		rep.Summary = fmt.Sprintf("authority unreadable (%d error(s)); no healthy verdict is possible", rep.Counts.AuthorityErrors)
 	case rep.Counts.MissingTranscript > 0 || rep.Counts.PresentNoPostLaunchProgress > 0:
 		rep.Verdict = JournalVerdictRed
-		rep.Summary = fmt.Sprintf("%d/%d recent launch identities advanced; missing=%d present_without_post_launch_progress=%d", rep.Counts.Advanced, rep.Counts.Identities, rep.Counts.MissingTranscript, rep.Counts.PresentNoPostLaunchProgress)
+		rep.Summary = fmt.Sprintf("%d/%d recent launch identities advanced; missing=%d present_without_post_launch_progress=%d excluded_synthetic_or_unbound=%d", rep.Counts.Advanced, rep.Counts.Identities, rep.Counts.MissingTranscript, rep.Counts.PresentNoPostLaunchProgress, rep.Counts.ExcludedSyntheticOrUnbound)
 	default:
-		rep.Summary = fmt.Sprintf("all %d recent launch identities advanced in provider journals", rep.Counts.Identities)
+		rep.Summary = fmt.Sprintf("all %d recent launch identities advanced in provider journals; excluded_synthetic_or_unbound=%d", rep.Counts.Identities, rep.Counts.ExcludedSyntheticOrUnbound)
 	}
 	return rep
 }
 
+func isSyntheticOrUnboundLaunch(launch JournalLaunchIdentity) bool {
+	if strings.ToLower(strings.TrimSpace(launch.Source)) != "startup" {
+		return false
+	}
+	trace := strings.ToLower(strings.TrimSpace(launch.Trace))
+	return trace == "model-controlled-trace" || strings.HasPrefix(trace, "guard-trace-")
+}
 func journalAuditRow(identityPath string, launch JournalLaunchIdentity, evidence []journalEvidence, authorityErrors *[]JournalAuthorityError) JournalAuditRow {
 	row := JournalAuditRow{
 		Identity: launch.Identity,
@@ -252,6 +263,10 @@ func journalAuditRow(identityPath string, launch JournalLaunchIdentity, evidence
 			Provider: launch.Provider, Source: launch.Source,
 		},
 		Status: JournalStatusMissingTranscript,
+	}
+	if isSyntheticOrUnboundLaunch(launch) && len(evidence) == 0 {
+		row.Status = JournalStatusSyntheticOrUnbound
+		return row
 	}
 	byProvider := map[string][]journalEvidence{}
 	for _, item := range evidence {

--- a/internal/sessiondiag/journal_audit_test.go
+++ b/internal/sessiondiag/journal_audit_test.go
@@ -181,3 +181,34 @@ func writeJournalAuditFixture(t *testing.T, path, body string) {
 		t.Fatal(err)
 	}
 }
+
+func TestJournalAuditExcludesDuplicateUnboundStartupIdentity(t *testing.T) {
+	userRoot := t.TempDir()
+	now := time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
+	const identity = "0198f76a-67c2-7d11-a8f5-8f3d82149734"
+	report := AuditRecentLaunches(JournalAuditOptions{
+		Now: now, Window: 24 * time.Hour, UserHome: userRoot, IdentityPath: filepath.Join(userRoot, "resume_identity.jsonl"),
+		Identities: []JournalLaunchIdentity{
+			{Identity: identity, Trace: "guard-trace-9849", LaunchAt: now.Add(-3 * time.Hour), Provider: "codex", Via: "guard-sessionstart", Source: "startup"},
+			{Identity: identity, Trace: "model-controlled-trace", LaunchAt: now.Add(-2 * time.Hour), Provider: "codex", Via: "guard-sessionstart", Source: "startup"},
+		},
+	})
+	if report.Verdict != JournalVerdictGreen || report.Counts.Identities != 1 || report.Counts.ExcludedSyntheticOrUnbound != 1 || report.Counts.MissingTranscript != 0 || len(report.Rows) != 1 {
+		t.Fatalf("report=%+v", report)
+	}
+	if report.Rows[0].Status != JournalStatusSyntheticOrUnbound {
+		t.Fatalf("row=%+v", report.Rows[0])
+	}
+}
+
+func TestJournalAuditKeepsExactNonSyntheticLaunchMissingTranscriptRed(t *testing.T) {
+	userRoot := t.TempDir()
+	now := time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
+	report := AuditRecentLaunches(JournalAuditOptions{
+		Now: now, Window: 24 * time.Hour, UserHome: userRoot, IdentityPath: filepath.Join(userRoot, "resume_identity.jsonl"),
+		Identities: []JournalLaunchIdentity{{Identity: "real-codex-thread", Trace: "trace-real", LaunchAt: now.Add(-time.Hour), Provider: "codex", Via: "guard-sessionstart", Source: "resume"}},
+	})
+	if report.Verdict != JournalVerdictRed || report.Counts.MissingTranscript != 1 || report.Counts.ExcludedSyntheticOrUnbound != 0 || report.Rows[0].Status != JournalStatusMissingTranscript {
+		t.Fatalf("report=%+v", report)
+	}
+}


### PR DESCRIPTION
Closes #10034

- classify duplicate guard/model-controlled startup identities without an exact provider transcript as synthetic_or_unbound_identity
- exclude them from missing/crash counts while reporting the excluded count in JSON and human summaries
- preserve fail-closed missing_transcript for real exact launches

Witness:
- go test ./internal/sessiondiag -count=1
- go test ./cmd/fak -run SessionJournalAudit -count=1
- go vet ./internal/sessiondiag ./cmd/fak
- dos commit audit 9aad723ce9: OK, diff-witnessed