### PR TITLE
perf(model): implement GDN snapshot copy-on-write (#12550)

### DIFF
--- a/internal/model/kv.go
+++ b/internal/model/kv.go
@@ -42,6 +42,7 @@ func (m *Model) SessionFromPrefix(prefix *KVCache) *Session {
 // sessions Cache is sufficient. Device hybrid sessions additionally carry attention
 // KV and recurrent Qwen state; keeping all three in one owner prevents partial restores.
 type PrefixSnapshot struct {
+	mu         sync.Mutex
 	owner      *Session
 	epoch      uint64
 	Cache      *KVCache
@@ -61,7 +62,8 @@ type PrefixSnapshot struct {
 	targetHiddenTokens  []int
 }
 
-// PrefixSnapshot captures a deep clone suitable for shared-prefix admission.
+// PrefixSnapshot captures an independently owned prefix. Qwen recurrent layers
+// share immutable device pairs until a branch first mutates that layer.
 func (s *Session) PrefixSnapshot() (*PrefixSnapshot, error) {
 	s.cacheGeometryMu.RLock()
 	defer s.cacheGeometryMu.RUnlock()
@@ -99,9 +101,14 @@ func (s *Session) PrefixSnapshot() (*PrefixSnapshot, error) {
 
 // Clone makes a second independent owner for lookup; the cache retains the original.
 func (p *PrefixSnapshot) Clone() (*PrefixSnapshot, error) {
+	if p == nil {
+		return nil, nil
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	started := prefixProfileStart()
 	defer func() { emitPrefixProfile(started, "device_clone", "complete", p, nil) }()
-	if p == nil || p.Cache == nil {
+	if p.Cache == nil {
 		return nil, nil
 	}
 	out := &PrefixSnapshot{
@@ -128,14 +135,19 @@ func (p *PrefixSnapshot) Clone() (*PrefixSnapshot, error) {
 
 // Restore installs this snapshot into a fresh backend session and transfers ownership.
 func (p *PrefixSnapshot) Restore(s *Session) error {
-	if p != nil && p.owner != nil {
+	if p == nil {
+		return fmt.Errorf("model: invalid prefix snapshot restore")
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.owner != nil {
 		p.owner.cacheGeometryMu.RLock()
 		defer p.owner.cacheGeometryMu.RUnlock()
 	}
-	if p != nil && p.owner != nil && p.epoch != p.owner.cacheGeometryEpoch {
+	if p.owner != nil && p.epoch != p.owner.cacheGeometryEpoch {
 		return fmt.Errorf("model: stale prefix snapshot after cache rebuild")
 	}
-	if p == nil || s == nil || p.Cache == nil {
+	if s == nil || p.Cache == nil {
 		return fmt.Errorf("model: invalid prefix snapshot restore")
 	}
 	if p.Backend != s.Backend {
@@ -175,6 +187,8 @@ func (p *PrefixSnapshot) Close() {
 	if p == nil {
 		return
 	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	if p.halKV != nil {
 		p.halKV.Free()
 		p.halKV = nil

--- a/internal/model/qwen35_backend_contract_test.go
+++ b/internal/model/qwen35_backend_contract_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/anthony-chaudhary/fak/internal/compute"
 )
@@ -34,6 +35,7 @@ type markerOnlyQwen35CUDA struct{ *refusingQwen35CUDA }
 func (*markerOnlyQwen35CUDA) Qwen35GDNPath() string { return Qwen35GDNCUDAPath }
 
 var errInjectedQwen35GDN = errors.New("injected Qwen35 GDN operation failure")
+var errInjectedQwen35Clone = errors.New("injected Qwen35 recurrent clone failure")
 
 // recordingQwen35Backend is a model-dispatch witness, not a second GDN oracle. Its
 // Qwen35GDNDecode implementation delegates the normalized input to the existing
@@ -60,6 +62,9 @@ type recordingQwen35Backend struct {
 	stateTicks      map[compute.Buffer]float32
 	stateContinuous bool
 	cloneCalls      int
+	cloneFailAt     int
+	clonedBuffers   []compute.Buffer
+	freeHook        func()
 	badRoute        string
 	failAt          int
 	deviceMemory    bool
@@ -115,19 +120,35 @@ func (b *recordingQwen35Backend) Read(t compute.Tensor) []float32 {
 func (b *recordingQwen35Backend) Free(t compute.Tensor) {
 	b.lifecycleMu.Lock()
 	b.freeCalls[t.Buf()]++
+	hook := b.freeHook
+	b.freeHook = nil
 	b.lifecycleMu.Unlock()
 	b.Backend.Free(t)
+	if hook != nil {
+		hook()
+	}
 }
 
 func (b *recordingQwen35Backend) CloneTensor(t compute.Tensor) (compute.Tensor, error) {
 	b.lifecycleMu.Lock()
 	b.cloneCalls++
+	call := b.cloneCalls
+	failAt := b.cloneFailAt
 	b.lifecycleMu.Unlock()
+	if failAt > 0 && call == failAt {
+		return compute.Tensor{}, errInjectedQwen35Clone
+	}
 	cloner, ok := b.Backend.(compute.TensorCloner)
 	if !ok {
 		return compute.Tensor{}, errors.New("recording backend cannot clone tensor")
 	}
-	return cloner.CloneTensor(t)
+	out, err := cloner.CloneTensor(t)
+	if err == nil {
+		b.lifecycleMu.Lock()
+		b.clonedBuffers = append(b.clonedBuffers, out.Buf())
+		b.lifecycleMu.Unlock()
+	}
+	return out, err
 }
 
 func (b *recordingQwen35Backend) MatMul(w, x compute.Tensor) compute.Tensor {
@@ -788,6 +809,86 @@ func TestQwen35RecurrentSnapshotCopyOnWriteIsolation(t *testing.T) {
 	for buffer := range allStateBuffers {
 		if got := be.freeCalls[buffer]; got != 1 {
 			t.Fatalf("recurrent state %p freed %d times, want exactly once", buffer, got)
+		}
+	}
+
+	// A transactional pair clone may need to discard the convolution clone when
+	// cloning recurrent state fails. That compensating Free must run only after
+	// the handle and owner locks are released because backend cleanup may re-enter
+	// Session.closeQwen35HALState.
+	failureModel := NewSynthetic(qwen35HybridTestCfg())
+	failureBackend := newRecordingQwen35Backend(failureModel)
+	failureRoot, err := failureModel.NewBackendSessionChecked(failureBackend)
+	if err != nil {
+		t.Fatal(err)
+	}
+	failureRoot.Prefill([]int{5})
+	failureBuffers := make(map[compute.Buffer]struct{})
+	rememberFailureState := func(s *Session) {
+		t.Helper()
+		for _, layer := range failureBackend.linearLayers {
+			state := s.qwen35HAL.layers[layer]
+			failureBuffers[state.conv.Buf()] = struct{}{}
+			failureBuffers[state.recurrent.Buf()] = struct{}{}
+		}
+	}
+	rememberFailureState(failureRoot)
+	failureSnapshot, err := failureRoot.PrefixSnapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	failureBranch, err := failureModel.NewBackendSessionChecked(failureBackend)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rememberFailureState(failureBranch)
+	if err := failureSnapshot.Restore(failureBranch); err != nil {
+		t.Fatal(err)
+	}
+	failureSnapshot.Close()
+	failureBackend.cloneFailAt = failureBackend.cloneCalls + 2
+	reentered := make(chan struct{})
+	failureBackend.freeHook = func() {
+		failureBranch.closeQwen35HALState()
+		close(reentered)
+	}
+	mutationDone := make(chan error, 1)
+	failureState := failureBranch.qwen35HAL
+	go func() {
+		_, _, _, mutationErr := failureState.mutateLayer(failureBackend, failureBackend.linearLayers[0], func(conv, recurrent compute.Tensor) (compute.Tensor, compute.Tensor, compute.Tensor, error) {
+			return compute.Tensor{}, conv, recurrent, nil
+		})
+		mutationDone <- mutationErr
+	}()
+	select {
+	case mutationErr := <-mutationDone:
+		if !errors.Is(mutationErr, errInjectedQwen35Clone) {
+			t.Fatalf("recurrent clone failure=%v, want injected error", mutationErr)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("recurrent clone cleanup deadlocked during re-entrant close")
+	}
+	select {
+	case <-reentered:
+	default:
+		t.Fatal("partial-clone cleanup did not invoke re-entrant Free callback")
+	}
+	if failureBranch.qwen35HAL != nil {
+		t.Fatal("re-entrant close retained failed branch recurrent ownership")
+	}
+	if len(failureBackend.clonedBuffers) != 1 {
+		t.Fatalf("successful partial clones=%d, want convolution only", len(failureBackend.clonedBuffers))
+	}
+	partialClone := failureBackend.clonedBuffers[0]
+	failureBuffers[partialClone] = struct{}{}
+	if got := failureBackend.freeCalls[partialClone]; got != 1 {
+		t.Fatalf("partial convolution clone freed %d times, want once", got)
+	}
+	failureBranch.Close()
+	failureRoot.Close()
+	for buffer := range failureBuffers {
+		if got := failureBackend.freeCalls[buffer]; got != 1 {
+			t.Fatalf("failure-path state %p freed %d times, want exactly once", buffer, got)
 		}
 	}
 }

--- a/internal/model/qwen35_backend_contract_test.go
+++ b/internal/model/qwen35_backend_contract_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/anthony-chaudhary/fak/internal/compute"
@@ -41,6 +42,7 @@ var errInjectedQwen35GDN = errors.New("injected Qwen35 GDN operation failure")
 // so wrapper Read/Host counters expose only forbidden model-side fallback.
 type recordingQwen35Backend struct {
 	compute.Backend
+	lifecycleMu     sync.Mutex
 	model           *Model
 	reference       *Session
 	linearLayers    []int
@@ -111,12 +113,16 @@ func (b *recordingQwen35Backend) Read(t compute.Tensor) []float32 {
 }
 
 func (b *recordingQwen35Backend) Free(t compute.Tensor) {
+	b.lifecycleMu.Lock()
 	b.freeCalls[t.Buf()]++
+	b.lifecycleMu.Unlock()
 	b.Backend.Free(t)
 }
 
 func (b *recordingQwen35Backend) CloneTensor(t compute.Tensor) (compute.Tensor, error) {
+	b.lifecycleMu.Lock()
 	b.cloneCalls++
+	b.lifecycleMu.Unlock()
 	cloner, ok := b.Backend.(compute.TensorCloner)
 	if !ok {
 		return compute.Tensor{}, errors.New("recording backend cannot clone tensor")
@@ -517,9 +523,272 @@ func TestQwen35PrefixSnapshotClonesAndRestoresAllHybridDeviceState(t *testing.T)
 	if restored.qwen35HAL == nil || len(restored.qwen35HAL.layers) != len(s.qwen35HAL.layers) {
 		t.Fatal("recurrent state omitted")
 	}
+	if be.cloneCalls != 0 {
+		t.Fatalf("snapshot clone eagerly copied recurrent tensors: clone calls=%d, want 0", be.cloneCalls)
+	}
+}
+
+func TestQwen35RecurrentSnapshotCopyOnWriteIsolation(t *testing.T) {
+	type pairImage struct {
+		conv, recurrent         compute.Buffer
+		convData, recurrentData []float32
+	}
+
+	m := NewSynthetic(qwen35HybridTestCfg())
+	be := newRecordingQwen35Backend(m)
+	root, err := m.NewBackendSessionChecked(be)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root.Prefill([]int{3, 7, 11})
 	linear := len(be.linearLayers)
-	if be.cloneCalls < 4*linear {
-		t.Fatalf("clone calls=%d want at least %d", be.cloneCalls, 4*linear)
+	if linear == 0 {
+		t.Fatal("test model has no recurrent layers")
+	}
+	image := func(s *Session, layer int) pairImage {
+		t.Helper()
+		s.qwen35HAL.mu.Lock()
+		defer s.qwen35HAL.mu.Unlock()
+		state := &s.qwen35HAL.layers[layer]
+		return pairImage{
+			conv: state.conv.Buf(), recurrent: state.recurrent.Buf(),
+			convData:      append([]float32(nil), be.Backend.Read(state.conv)...),
+			recurrentData: append([]float32(nil), be.Backend.Read(state.recurrent)...),
+		}
+	}
+	assertBitsEqual := func(label string, got, want []float32) {
+		t.Helper()
+		if len(got) != len(want) {
+			t.Fatalf("%s elements=%d, want %d", label, len(got), len(want))
+		}
+		for i := range got {
+			if math.Float32bits(got[i]) != math.Float32bits(want[i]) {
+				t.Fatalf("%s changed at %d: got %08x want %08x", label, i, math.Float32bits(got[i]), math.Float32bits(want[i]))
+			}
+		}
+	}
+	allStateBuffers := make(map[compute.Buffer]struct{})
+	captureBuffers := func(s *Session) {
+		t.Helper()
+		for _, layer := range be.linearLayers {
+			got := image(s, layer)
+			allStateBuffers[got.conv] = struct{}{}
+			allStateBuffers[got.recurrent] = struct{}{}
+		}
+	}
+
+	baseline := make(map[int]pairImage, linear)
+	for _, layer := range be.linearLayers {
+		baseline[layer] = image(root, layer)
+	}
+	captureBuffers(root)
+	root.qwen35HAL.sequenceAccepted = true
+	root.qwen35HAL.sequenceFailure = errors.New("session-local sentinel")
+	root.qwen35HAL.prefillRoute.RequestedPath = "session-local"
+	root.qwen35HAL.qsaGatheredK = []float32{1}
+
+	snap, err := root.PrefixSnapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sibling, err := snap.Clone()
+	if err != nil {
+		snap.Close()
+		t.Fatal(err)
+	}
+	if be.cloneCalls != 0 {
+		t.Fatalf("read-only sibling snapshots made %d eager tensor copies, want 0", be.cloneCalls)
+	}
+	for name, q := range map[string]*qwen35HALState{"snapshot": snap.qwen35, "sibling": sibling.qwen35} {
+		if q.sequenceAccepted || q.sequenceFailure != nil || q.prefillRoute.RequestedPath != "" || q.qsaGatheredK != nil {
+			t.Fatalf("%s shared session-local sequence/QSA/receipt state: %#v", name, q)
+		}
+	}
+
+	branchA, err := m.NewBackendSessionChecked(be)
+	if err != nil {
+		t.Fatal(err)
+	}
+	captureBuffers(branchA)
+	branchB, err := m.NewBackendSessionChecked(be)
+	if err != nil {
+		branchA.Close()
+		t.Fatal(err)
+	}
+	captureBuffers(branchB)
+	if err := snap.Restore(branchA); err != nil {
+		t.Fatal(err)
+	}
+	if err := sibling.Restore(branchB); err != nil {
+		t.Fatal(err)
+	}
+	snap.Close()
+	snap.Close()
+	sibling.Close()
+	sibling.Close()
+
+	beforeFirstWrite := be.cloneCalls
+	branchA.Step(13)
+	if got, want := be.cloneCalls-beforeFirstWrite, 2*linear; got != want {
+		t.Fatalf("branch A first write tensor copies=%d, want one pair per layer (%d)", got, want)
+	}
+	captureBuffers(branchA)
+	for _, layer := range be.linearLayers {
+		if got, original := image(branchA, layer), baseline[layer]; got.conv == original.conv || got.recurrent == original.recurrent {
+			t.Fatalf("branch A layer %d retained shared state on first write", layer)
+		}
+	}
+	branchA.Step(17)
+	if be.cloneCalls != beforeFirstWrite+2*linear {
+		t.Fatalf("branch A second write cloned again: clone calls=%d want %d", be.cloneCalls, beforeFirstWrite+2*linear)
+	}
+	branchABeforeB := make(map[int]pairImage, linear)
+	for _, layer := range be.linearLayers {
+		branchABeforeB[layer] = image(branchA, layer)
+		got, original := image(branchB, layer), baseline[layer]
+		if got.conv != original.conv || got.recurrent != original.recurrent {
+			t.Fatalf("untouched branch B layer %d changed identity before first write", layer)
+		}
+		assertBitsEqual("untouched branch B convolution layer "+itoa(layer), got.convData, original.convData)
+		assertBitsEqual("untouched branch B recurrent layer "+itoa(layer), got.recurrentData, original.recurrentData)
+	}
+
+	beforeBranchB := be.cloneCalls
+	branchB.Step(19)
+	if got, want := be.cloneCalls-beforeBranchB, 2*linear; got != want {
+		t.Fatalf("branch B first write tensor copies=%d, want %d", got, want)
+	}
+	captureBuffers(branchB)
+	for _, layer := range be.linearLayers {
+		gotA, beforeB := image(branchA, layer), branchABeforeB[layer]
+		if gotA.conv != beforeB.conv || gotA.recurrent != beforeB.recurrent {
+			t.Fatalf("branch B write changed branch A layer %d identity", layer)
+		}
+		assertBitsEqual("branch A convolution after branch B write layer "+itoa(layer), gotA.convData, beforeB.convData)
+		assertBitsEqual("branch A recurrent after branch B write layer "+itoa(layer), gotA.recurrentData, beforeB.recurrentData)
+		gotB := image(branchB, layer)
+		if gotA.conv == gotB.conv || gotA.recurrent == gotB.recurrent || (reflect.DeepEqual(gotA.convData, gotB.convData) && reflect.DeepEqual(gotA.recurrentData, gotB.recurrentData)) {
+			t.Fatalf("branch A/B layer %d did not isolate identity and bytes", layer)
+		}
+		got, original := image(root, layer), baseline[layer]
+		if got.conv != original.conv || got.recurrent != original.recurrent {
+			t.Fatalf("untouched root layer %d changed identity", layer)
+		}
+		assertBitsEqual("untouched convolution layer "+itoa(layer), got.convData, original.convData)
+		assertBitsEqual("untouched recurrent layer "+itoa(layer), got.recurrentData, original.recurrentData)
+	}
+
+	// Two siblings may reach first write together. Per-owner locking serializes the
+	// refcount transition while each branch receives its own physical pair.
+	concurrentSnap, err := root.PrefixSnapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	concurrentSibling, err := concurrentSnap.Clone()
+	if err != nil {
+		t.Fatal(err)
+	}
+	concurrentA, err := m.NewBackendSessionChecked(be)
+	if err != nil {
+		t.Fatal(err)
+	}
+	captureBuffers(concurrentA)
+	concurrentB, err := m.NewBackendSessionChecked(be)
+	if err != nil {
+		t.Fatal(err)
+	}
+	captureBuffers(concurrentB)
+	if err := concurrentSnap.Restore(concurrentA); err != nil {
+		t.Fatal(err)
+	}
+	if err := concurrentSibling.Restore(concurrentB); err != nil {
+		t.Fatal(err)
+	}
+	concurrentSnap.Close()
+	concurrentSibling.Close()
+	firstLayer := be.linearLayers[0]
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	mutatePair := func(conv, recurrent compute.Tensor, delta float32) {
+		convData := be.Backend.Read(conv)
+		recurrentData := be.Backend.Read(recurrent)
+		convData[0] += delta
+		recurrentData[0] += delta
+	}
+	mutateScalar := func(s *Session, delta float32) {
+		<-start
+		_, _, _, mutateErr := s.qwen35HAL.mutateLayer(be, firstLayer, func(conv, recurrent compute.Tensor) (compute.Tensor, compute.Tensor, compute.Tensor, error) {
+			mutatePair(conv, recurrent, delta)
+			return compute.Tensor{}, conv, recurrent, nil
+		})
+		errs <- mutateErr
+	}
+	mutateWholeSequence := func(s *Session, delta float32) {
+		<-start
+		_, mutateErr := s.qwen35HAL.mutateSequence(be, func(states []compute.Qwen35SequenceState) (compute.Qwen35SequencePrefillResult, error) {
+			state := states[firstLayer]
+			mutatePair(state.Conv, state.Recurrent, delta)
+			return compute.Qwen35SequencePrefillResult{}, nil
+		})
+		errs <- mutateErr
+	}
+	beforeConcurrent := be.cloneCalls
+	go mutateWholeSequence(concurrentA, 2)
+	go mutateScalar(concurrentB, 3)
+	close(start)
+	for range 2 {
+		if err := <-errs; err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got, want := be.cloneCalls-beforeConcurrent, 2*linear+2; got != want {
+		t.Fatalf("concurrent sequence/scalar first writes copied %d tensors, want %d", got, want)
+	}
+	captureBuffers(concurrentA)
+	captureBuffers(concurrentB)
+	aImage, bImage := image(concurrentA, firstLayer), image(concurrentB, firstLayer)
+	if aImage.conv == bImage.conv || aImage.recurrent == bImage.recurrent {
+		t.Fatal("concurrent branches share a post-write state handle")
+	}
+
+	stale, err := root.PrefixSnapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	staleTarget, err := m.NewBackendSessionChecked(be)
+	if err != nil {
+		t.Fatal(err)
+	}
+	captureBuffers(staleTarget)
+	root.cacheGeometryMu.Lock()
+	root.cacheGeometryEpoch++
+	root.cacheGeometryMu.Unlock()
+	if err := stale.Restore(staleTarget); err == nil || !strings.Contains(err.Error(), "stale prefix snapshot") {
+		t.Fatalf("stale restore error=%v, want ownership-preserving refusal", err)
+	}
+	if stale.qwen35 == nil || stale.Cache == nil {
+		t.Fatal("stale restore transferred ownership before refusing")
+	}
+
+	// The shared owner remembers its allocating backend; final release does not
+	// depend on the snapshot/session wrapper still carrying that pointer.
+	branchA.qwen35HAL.free(nil)
+	branchA.qwen35HAL = nil
+	branchA.Close()
+	branchA.Close()
+	branchB.Close()
+	branchB.Close()
+	concurrentA.Close()
+	concurrentB.Close()
+	staleTarget.Close()
+	stale.Close()
+	stale.Close()
+	root.Close()
+	root.Close()
+	for buffer := range allStateBuffers {
+		if got := be.freeCalls[buffer]; got != 1 {
+			t.Fatalf("recurrent state %p freed %d times, want exactly once", buffer, got)
+		}
 	}
 }
 
@@ -554,8 +823,8 @@ func TestQwen35PrefixSnapshotHostRoundTripOwnsCompleteHybridState(t *testing.T) 
 	}
 	freeBefore := totalFreeCalls(be)
 	snap.Close()
-	if totalFreeCalls(be) <= freeBefore {
-		t.Fatal("closing the hot snapshot did not release its backend-owned tensors")
+	if got := totalFreeCalls(be); got != freeBefore {
+		t.Fatalf("closing a shared read-only snapshot freed live recurrent tensors: frees=%d, want %d", got, freeBefore)
 	}
 
 	restored, err := host.Restore()

--- a/internal/model/qwen35_hal.go
+++ b/internal/model/qwen35_hal.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/anthony-chaudhary/fak/internal/compute"
 )
@@ -43,6 +44,7 @@ func (e *Qwen35QKNormResidencyError) Error() string {
 }
 
 type qwen35HALState struct {
+	mu                  sync.Mutex
 	backend             Qwen35GDNBackend
 	layers              []qwen35HALLayerState
 	sequenceBackend     Qwen35GDNPreprojectedSequenceBackend
@@ -112,8 +114,182 @@ func (s *Session) RequireQwen35SequencePrefillNativePerformance() error {
 }
 
 type qwen35HALLayerState struct {
+	owner     *qwen35HALLayerOwner
 	conv      compute.Tensor
 	recurrent compute.Tensor
+}
+
+// qwen35HALLayerOwner is the physical owner of one convolution/recurrent pair.
+// Snapshot layers retain it without copying device memory; the first branch that
+// writes while refs > 1 receives a transactional pair clone.
+type qwen35HALLayerOwner struct {
+	mu        sync.Mutex
+	refs      int
+	backend   compute.Backend
+	conv      compute.Tensor
+	recurrent compute.Tensor
+}
+
+func newQwen35HALLayerState(backend compute.Backend, conv, recurrent compute.Tensor) qwen35HALLayerState {
+	return qwen35HALLayerState{
+		owner:     &qwen35HALLayerOwner{refs: 1, backend: backend, conv: conv, recurrent: recurrent},
+		conv:      conv,
+		recurrent: recurrent,
+	}
+}
+
+// ownerLocked adopts states restored by the host snapshot path, which predates
+// the shared owner. The containing qwen35HALState.mu must be held by the caller.
+func (l *qwen35HALLayerState) ownerLocked(backend compute.Backend) *qwen35HALLayerOwner {
+	if l.owner == nil && (l.conv.Buf() != nil || l.recurrent.Buf() != nil) {
+		l.owner = &qwen35HALLayerOwner{refs: 1, backend: backend, conv: l.conv, recurrent: l.recurrent}
+	}
+	return l.owner
+}
+
+func (l *qwen35HALLayerState) share(backend compute.Backend) qwen35HALLayerState {
+	owner := l.ownerLocked(backend)
+	if owner == nil {
+		return qwen35HALLayerState{}
+	}
+	owner.mu.Lock()
+	owner.refs++
+	conv, recurrent := owner.conv, owner.recurrent
+	owner.mu.Unlock()
+	return qwen35HALLayerState{owner: owner, conv: conv, recurrent: recurrent}
+}
+
+type qwen35HALLayerRelease struct {
+	backend         compute.Backend
+	conv, recurrent compute.Tensor
+}
+
+// detach releases this handle's reference while the containing state is
+// locked. Physical frees are returned to the caller so backend callbacks never
+// run under qwen35HALState.mu.
+func (l *qwen35HALLayerState) detach(backend compute.Backend) (qwen35HALLayerRelease, bool) {
+	owner := l.ownerLocked(backend)
+	l.owner = nil
+	l.conv = compute.Tensor{}
+	l.recurrent = compute.Tensor{}
+	if owner == nil {
+		return qwen35HALLayerRelease{}, false
+	}
+	owner.mu.Lock()
+	owner.refs--
+	last := owner.refs == 0
+	conv, recurrent, owningBackend := owner.conv, owner.recurrent, owner.backend
+	if last {
+		owner.conv = compute.Tensor{}
+		owner.recurrent = compute.Tensor{}
+	}
+	owner.mu.Unlock()
+	if owningBackend == nil {
+		owningBackend = backend
+	}
+	if !last {
+		return qwen35HALLayerRelease{}, false
+	}
+	return qwen35HALLayerRelease{backend: owningBackend, conv: conv, recurrent: recurrent}, true
+}
+
+// mutableOwnerLocked returns an exclusive owner with owner.mu held. The
+// containing qwen35HALState.mu must already be held. A failed pair clone leaves
+// the shared owner and refcount unchanged.
+func (l *qwen35HALLayerState) mutableOwnerLocked(backend compute.Backend) (*qwen35HALLayerOwner, error) {
+	owner := l.ownerLocked(backend)
+	if owner == nil {
+		return nil, fmt.Errorf("model: missing Qwen3.5 recurrent state")
+	}
+	owner.mu.Lock()
+	if owner.refs == 1 {
+		return owner, nil
+	}
+	cloner, ok := backend.(compute.TensorCloner)
+	if !ok {
+		owner.mu.Unlock()
+		return nil, fmt.Errorf("model: backend %T cannot clone Qwen3.5 recurrent state", backend)
+	}
+	conv, err := cloner.CloneTensor(owner.conv)
+	if err != nil {
+		owner.mu.Unlock()
+		return nil, fmt.Errorf("model: clone Qwen3.5 convolution state: %w", err)
+	}
+	recurrent, err := cloner.CloneTensor(owner.recurrent)
+	if err != nil {
+		if conv.Buf() != nil {
+			backend.Free(conv)
+		}
+		owner.mu.Unlock()
+		return nil, fmt.Errorf("model: clone Qwen3.5 recurrent state: %w", err)
+	}
+	owner.refs--
+	owner.mu.Unlock()
+	owner = &qwen35HALLayerOwner{refs: 1, backend: backend, conv: conv, recurrent: recurrent}
+	owner.mu.Lock()
+	l.owner = owner
+	l.conv, l.recurrent = conv, recurrent
+	return owner, nil
+}
+
+// mutateLayer holds the handle/owner locks across the backend operation. That makes a
+// concurrent snapshot either share the pre-write owner or observe the completed
+// write, never a partially mutated pair.
+func (q *qwen35HALState) mutateLayer(
+	backend compute.Backend,
+	layer int,
+	fn func(conv, recurrent compute.Tensor) (compute.Tensor, compute.Tensor, compute.Tensor, error),
+) (output, nextConv, nextRecurrent compute.Tensor, err error) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if layer < 0 || layer >= len(q.layers) {
+		return compute.Tensor{}, compute.Tensor{}, compute.Tensor{}, fmt.Errorf("model: Qwen3.5 recurrent layer %d out of bounds", layer)
+	}
+	l := &q.layers[layer]
+	owner, err := l.mutableOwnerLocked(backend)
+	if err != nil {
+		return compute.Tensor{}, compute.Tensor{}, compute.Tensor{}, err
+	}
+	defer owner.mu.Unlock()
+	output, nextConv, nextRecurrent, err = fn(owner.conv, owner.recurrent)
+	if err == nil && nextConv.Buf() == owner.conv.Buf() && nextRecurrent.Buf() == owner.recurrent.Buf() {
+		owner.conv, owner.recurrent = nextConv, nextRecurrent
+		l.conv, l.recurrent = nextConv, nextRecurrent
+	}
+	return output, nextConv, nextRecurrent, err
+}
+
+// mutateSequence makes every recurrent pair private, installs only those
+// protected handles in the request, and keeps them locked through the backend's
+// whole-sequence in-place mutation.
+func (q *qwen35HALState) mutateSequence(
+	backend compute.Backend,
+	fn func(states []compute.Qwen35SequenceState) (compute.Qwen35SequencePrefillResult, error),
+) (compute.Qwen35SequencePrefillResult, error) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	states := make([]compute.Qwen35SequenceState, len(q.layers))
+	locked := make([]*qwen35HALLayerOwner, 0, len(q.layers))
+	unlock := func() {
+		for i := len(locked) - 1; i >= 0; i-- {
+			locked[i].mu.Unlock()
+		}
+	}
+	for layer := range q.layers {
+		state := &q.layers[layer]
+		if state.conv.Buf() == nil && state.recurrent.Buf() == nil {
+			continue
+		}
+		owner, err := state.mutableOwnerLocked(backend)
+		if err != nil {
+			unlock()
+			return compute.Qwen35SequencePrefillResult{}, fmt.Errorf("layer %d: %w", layer, err)
+		}
+		locked = append(locked, owner)
+		states[layer] = compute.Qwen35SequenceState{Conv: owner.conv, Recurrent: owner.recurrent}
+	}
+	defer unlock()
+	return fn(states)
 }
 
 type qwen35PartialRoPEBackend interface {
@@ -143,51 +319,34 @@ func (s *Session) initQwen35HALState(gdn Qwen35GDNBackend) {
 		if !cfg.isLinearAttnLayer(l) {
 			continue
 		}
-		state.layers[l] = qwen35HALLayerState{
-			conv: s.uploadHostF32(
-				[]int{cfg.LinearConvKernelDim - 1, convDim},
-				make([]float32, (cfg.LinearConvKernelDim-1)*convDim),
-				compute.MemoryKVCache,
-				"qwen35-gdn-conv-state layer "+itoa(l),
-			),
-			recurrent: s.uploadHostF32(
-				[]int{nV, kHd, vHd},
-				make([]float32, nV*kHd*vHd),
-				compute.MemoryKVCache,
-				"qwen35-gdn-recurrent-state layer "+itoa(l),
-			),
-		}
+		conv := s.uploadHostF32(
+			[]int{cfg.LinearConvKernelDim - 1, convDim},
+			make([]float32, (cfg.LinearConvKernelDim-1)*convDim),
+			compute.MemoryKVCache,
+			"qwen35-gdn-conv-state layer "+itoa(l),
+		)
+		recurrent := s.uploadHostF32(
+			[]int{nV, kHd, vHd},
+			make([]float32, nV*kHd*vHd),
+			compute.MemoryKVCache,
+			"qwen35-gdn-recurrent-state layer "+itoa(l),
+		)
+		state.layers[l] = newQwen35HALLayerState(s.Backend, conv, recurrent)
 	}
 	s.qwen35HAL = state
 }
 
-// cloneQwen35HALState deep-copies the recurrent Qwen3.5/3.6 device state. The
-// state is semantically part of the prefix just as much as attention KV is: restoring
-// only halKV yields plausible but incorrect continuations after a GDN layer.
+// cloneQwen35HALState creates a read-only shared checkpoint of recurrent
+// Qwen3.5/3.6 device state. Mutation performs the physical copy per layer.
 func cloneQwen35HALState(src *qwen35HALState, backend compute.Backend) (*qwen35HALState, error) {
 	if src == nil {
 		return nil, nil
 	}
-	cloner, ok := backend.(compute.TensorCloner)
-	if !ok {
-		return nil, fmt.Errorf("model: backend %T cannot clone Qwen3.5 recurrent state", backend)
-	}
+	src.mu.Lock()
+	defer src.mu.Unlock()
 	out := &qwen35HALState{backend: src.backend, layers: make([]qwen35HALLayerState, len(src.layers))}
 	for i := range src.layers {
-		if src.layers[i].conv.Buf() == nil && src.layers[i].recurrent.Buf() == nil {
-			continue
-		}
-		var err error
-		out.layers[i].conv, err = cloner.CloneTensor(src.layers[i].conv)
-		if err != nil {
-			out.free(backend)
-			return nil, fmt.Errorf("model: clone Qwen3.5 layer %d convolution state: %w", i, err)
-		}
-		out.layers[i].recurrent, err = cloner.CloneTensor(src.layers[i].recurrent)
-		if err != nil {
-			out.free(backend)
-			return nil, fmt.Errorf("model: clone Qwen3.5 layer %d recurrent state: %w", i, err)
-		}
+		out.layers[i] = src.layers[i].share(backend)
 	}
 	return out, nil
 }
@@ -196,38 +355,61 @@ func (q *qwen35HALState) free(backend compute.Backend) {
 	if q == nil {
 		return
 	}
-	if backend != nil {
-		for i := range q.layers {
-			if q.layers[i].conv.Buf() != nil {
-				backend.Free(q.layers[i].conv)
-			}
-			if q.layers[i].recurrent.Buf() != nil {
-				backend.Free(q.layers[i].recurrent)
-			}
-			q.layers[i] = qwen35HALLayerState{}
+	q.mu.Lock()
+	releases := make([]qwen35HALLayerRelease, 0, len(q.layers))
+	for i := range q.layers {
+		if release, last := q.layers[i].detach(backend); last {
+			releases = append(releases, release)
 		}
 	}
 	q.qsaGatheredK = nil
 	q.qsaGatheredV = nil
 	q.qsaBlockScores = nil
-	q.freeSequence()
+	sequenceBackend, sequenceStates := q.detachSequenceLocked()
+	q.mu.Unlock()
+	for _, release := range releases {
+		if release.backend == nil {
+			continue
+		}
+		if release.conv.Buf() != nil {
+			release.backend.Free(release.conv)
+		}
+		if release.recurrent.Buf() != nil {
+			release.backend.Free(release.recurrent)
+		}
+	}
+	freeQwen35SequenceStates(sequenceBackend, sequenceStates)
 }
 
-func (q *qwen35HALState) freeSequence() {
-	if q == nil || q.sequenceBackend == nil {
-		return
-	}
+func (q *qwen35HALState) detachSequenceLocked() (Qwen35GDNPreprojectedSequenceBackend, []Qwen35GDNAuxState) {
 	backend := q.sequenceBackend
 	states := q.sequenceLayers
 	// Clear ownership before invoking backend cleanup so Close remains exact-once
 	// even when a backend reports a teardown error or re-enters a failure path.
 	q.sequenceBackend = nil
 	q.sequenceLayers = nil
+	return backend, states
+}
+
+func freeQwen35SequenceStates(backend Qwen35GDNPreprojectedSequenceBackend, states []Qwen35GDNAuxState) {
+	if backend == nil {
+		return
+	}
 	for _, state := range states {
 		if state.valid() {
 			_ = backend.FreeQwen35GDNAuxState(state)
 		}
 	}
+}
+
+func (q *qwen35HALState) freeSequence() {
+	if q == nil {
+		return
+	}
+	q.mu.Lock()
+	backend, states := q.detachSequenceLocked()
+	q.mu.Unlock()
+	freeQwen35SequenceStates(backend, states)
 }
 
 func (s *Session) closeQwen35HALState() {
@@ -427,22 +609,22 @@ func (s *Session) qwen35LinearHAL(layer int, residual compute.Tensor, eps float3
 	nK, nV, kHd, vHd, _, _, _ := cfg.linearAttnDims()
 	p := func(suffix string) string { return layerName(layer, suffix) }
 	xn := s.Backend.RMSNorm(residual, s.normWeightHAL(p("input_layernorm.weight")), eps)
-	state := &s.qwen35HAL.layers[layer]
-	oldConv, oldRecurrent := state.conv, state.recurrent
-	output, nextConv, nextRecurrent, err := s.qwen35HAL.backend.Qwen35GDNDecode(
-		xn,
-		s.matWeightHAL(p("linear_attn.in_proj_qkv.weight")),
-		s.matWeightHAL(p("linear_attn.in_proj_z.weight")),
-		s.matWeightHAL(p("linear_attn.in_proj_b.weight")),
-		s.matWeightHAL(p("linear_attn.in_proj_a.weight")),
-		s.weightHAL(p("linear_attn.conv1d.weight")),
-		s.weightHAL(p("linear_attn.A_log")),
-		s.weightHAL(p("linear_attn.dt_bias")),
-		s.weightHAL(p("linear_attn.norm.weight")),
-		s.matWeightHAL(p("linear_attn.out_proj.weight")),
-		oldConv, oldRecurrent,
-		nK, nV, kHd, vHd, cfg.LinearConvKernelDim, eps,
-	)
+	output, nextConv, nextRecurrent, err := s.qwen35HAL.mutateLayer(s.Backend, layer, func(oldConv, oldRecurrent compute.Tensor) (compute.Tensor, compute.Tensor, compute.Tensor, error) {
+		return s.qwen35HAL.backend.Qwen35GDNDecode(
+			xn,
+			s.matWeightHAL(p("linear_attn.in_proj_qkv.weight")),
+			s.matWeightHAL(p("linear_attn.in_proj_z.weight")),
+			s.matWeightHAL(p("linear_attn.in_proj_b.weight")),
+			s.matWeightHAL(p("linear_attn.in_proj_a.weight")),
+			s.weightHAL(p("linear_attn.conv1d.weight")),
+			s.weightHAL(p("linear_attn.A_log")),
+			s.weightHAL(p("linear_attn.dt_bias")),
+			s.weightHAL(p("linear_attn.norm.weight")),
+			s.matWeightHAL(p("linear_attn.out_proj.weight")),
+			oldConv, oldRecurrent,
+			nK, nV, kHd, vHd, cfg.LinearConvKernelDim, eps,
+		)
+	})
 	if err != nil {
 		s.failBackendForward(layer, "Qwen35GDNDecode", err)
 	}
@@ -451,16 +633,16 @@ func (s *Session) qwen35LinearHAL(layer int, residual compute.Tensor, eps float3
 	}
 	// The production operation's mutable state contract is in-place. Enforce it here so
 	// a backend cannot silently substitute transient state that Recycle will reclaim.
-	if nextConv.Buf() != oldConv.Buf() || nextRecurrent.Buf() != oldRecurrent.Buf() {
-		if nextConv.Buf() != nil && nextConv.Buf() != oldConv.Buf() {
+	state := s.qwen35HAL.layers[layer]
+	if nextConv.Buf() != state.conv.Buf() || nextRecurrent.Buf() != state.recurrent.Buf() {
+		if nextConv.Buf() != nil && nextConv.Buf() != state.conv.Buf() {
 			s.Backend.Free(nextConv)
 		}
-		if nextRecurrent.Buf() != nil && nextRecurrent.Buf() != oldRecurrent.Buf() {
+		if nextRecurrent.Buf() != nil && nextRecurrent.Buf() != state.recurrent.Buf() {
 			s.Backend.Free(nextRecurrent)
 		}
 		s.failBackendForward(layer, "Qwen35GDNDecode state identity", fmt.Errorf("backend replaced persistent in-place state"))
 	}
-	state.conv, state.recurrent = nextConv, nextRecurrent
 	s.Backend.AddInPlace(residual, output)
 }
 
@@ -899,8 +1081,6 @@ func (s *Session) qwen35SequencePrefillRequestWithEmbedding(ids []int, needLogit
 			layer.GDNDTBias = s.weightHAL(p("linear_attn.dt_bias"))
 			layer.GDNNorm = s.weightHAL(p("linear_attn.norm.weight"))
 			layer.GDNOut = s.matWeightHAL(p("linear_attn.out_proj.weight"))
-			state := s.qwen35HAL.layers[l]
-			req.States[l] = compute.Qwen35SequenceState{Conv: state.conv, Recurrent: state.recurrent}
 		} else {
 			layer.Q = s.matWeightHAL(p("self_attn.q_proj.weight"))
 			layer.K = s.matWeightHAL(p("self_attn.k_proj.weight"))
@@ -985,7 +1165,10 @@ func (s *Session) tryQwen35SequencePrefill(ids []int, needLogits bool) (compute.
 	startPos := s.halKV.Len()
 	finishLineage := s.beginHALTokenLineageWrite(ids)
 	defer finishLineage()
-	result, err := seq.Qwen35SequencePrefill(request)
+	result, err := s.qwen35HAL.mutateSequence(s.Backend, func(states []compute.Qwen35SequenceState) (compute.Qwen35SequencePrefillResult, error) {
+		request.States = states
+		return seq.Qwen35SequencePrefill(request)
+	})
 	if err != nil {
 		return result, true, &BackendForwardOperationError{Backend: s.Backend.Name(), Forward: ForwardQwen35GDN, Path: compute.Qwen35SequencePrefillPath, Layer: -1, Stage: "sequence prefill", Cause: err}
 	}

--- a/internal/model/qwen35_hal.go
+++ b/internal/model/qwen35_hal.go
@@ -164,6 +164,18 @@ type qwen35HALLayerRelease struct {
 	conv, recurrent compute.Tensor
 }
 
+func (r qwen35HALLayerRelease) free() {
+	if r.backend == nil {
+		return
+	}
+	if r.conv.Buf() != nil {
+		r.backend.Free(r.conv)
+	}
+	if r.recurrent.Buf() != nil {
+		r.backend.Free(r.recurrent)
+	}
+}
+
 // detach releases this handle's reference while the containing state is
 // locked. Physical frees are returned to the caller so backend callbacks never
 // run under qwen35HALState.mu.
@@ -196,32 +208,29 @@ func (l *qwen35HALLayerState) detach(backend compute.Backend) (qwen35HALLayerRel
 // mutableOwnerLocked returns an exclusive owner with owner.mu held. The
 // containing qwen35HALState.mu must already be held. A failed pair clone leaves
 // the shared owner and refcount unchanged.
-func (l *qwen35HALLayerState) mutableOwnerLocked(backend compute.Backend) (*qwen35HALLayerOwner, error) {
+func (l *qwen35HALLayerState) mutableOwnerLocked(backend compute.Backend) (*qwen35HALLayerOwner, qwen35HALLayerRelease, error) {
 	owner := l.ownerLocked(backend)
 	if owner == nil {
-		return nil, fmt.Errorf("model: missing Qwen3.5 recurrent state")
+		return nil, qwen35HALLayerRelease{}, fmt.Errorf("model: missing Qwen3.5 recurrent state")
 	}
 	owner.mu.Lock()
 	if owner.refs == 1 {
-		return owner, nil
+		return owner, qwen35HALLayerRelease{}, nil
 	}
 	cloner, ok := backend.(compute.TensorCloner)
 	if !ok {
 		owner.mu.Unlock()
-		return nil, fmt.Errorf("model: backend %T cannot clone Qwen3.5 recurrent state", backend)
+		return nil, qwen35HALLayerRelease{}, fmt.Errorf("model: backend %T cannot clone Qwen3.5 recurrent state", backend)
 	}
 	conv, err := cloner.CloneTensor(owner.conv)
 	if err != nil {
 		owner.mu.Unlock()
-		return nil, fmt.Errorf("model: clone Qwen3.5 convolution state: %w", err)
+		return nil, qwen35HALLayerRelease{}, fmt.Errorf("model: clone Qwen3.5 convolution state: %w", err)
 	}
 	recurrent, err := cloner.CloneTensor(owner.recurrent)
 	if err != nil {
-		if conv.Buf() != nil {
-			backend.Free(conv)
-		}
 		owner.mu.Unlock()
-		return nil, fmt.Errorf("model: clone Qwen3.5 recurrent state: %w", err)
+		return nil, qwen35HALLayerRelease{backend: backend, conv: conv}, fmt.Errorf("model: clone Qwen3.5 recurrent state: %w", err)
 	}
 	owner.refs--
 	owner.mu.Unlock()
@@ -229,7 +238,7 @@ func (l *qwen35HALLayerState) mutableOwnerLocked(backend compute.Backend) (*qwen
 	owner.mu.Lock()
 	l.owner = owner
 	l.conv, l.recurrent = conv, recurrent
-	return owner, nil
+	return owner, qwen35HALLayerRelease{}, nil
 }
 
 // mutateLayer holds the handle/owner locks across the backend operation. That makes a
@@ -240,22 +249,28 @@ func (q *qwen35HALState) mutateLayer(
 	layer int,
 	fn func(conv, recurrent compute.Tensor) (compute.Tensor, compute.Tensor, compute.Tensor, error),
 ) (output, nextConv, nextRecurrent compute.Tensor, err error) {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	if layer < 0 || layer >= len(q.layers) {
-		return compute.Tensor{}, compute.Tensor{}, compute.Tensor{}, fmt.Errorf("model: Qwen3.5 recurrent layer %d out of bounds", layer)
-	}
-	l := &q.layers[layer]
-	owner, err := l.mutableOwnerLocked(backend)
-	if err != nil {
-		return compute.Tensor{}, compute.Tensor{}, compute.Tensor{}, err
-	}
-	defer owner.mu.Unlock()
-	output, nextConv, nextRecurrent, err = fn(owner.conv, owner.recurrent)
-	if err == nil && nextConv.Buf() == owner.conv.Buf() && nextRecurrent.Buf() == owner.recurrent.Buf() {
-		owner.conv, owner.recurrent = nextConv, nextRecurrent
-		l.conv, l.recurrent = nextConv, nextRecurrent
-	}
+	var cleanup qwen35HALLayerRelease
+	output, nextConv, nextRecurrent, err = func() (compute.Tensor, compute.Tensor, compute.Tensor, error) {
+		q.mu.Lock()
+		defer q.mu.Unlock()
+		if layer < 0 || layer >= len(q.layers) {
+			return compute.Tensor{}, compute.Tensor{}, compute.Tensor{}, fmt.Errorf("model: Qwen3.5 recurrent layer %d out of bounds", layer)
+		}
+		l := &q.layers[layer]
+		owner, deferred, mutableErr := l.mutableOwnerLocked(backend)
+		cleanup = deferred
+		if mutableErr != nil {
+			return compute.Tensor{}, compute.Tensor{}, compute.Tensor{}, mutableErr
+		}
+		defer owner.mu.Unlock()
+		out, conv, recurrent, mutateErr := fn(owner.conv, owner.recurrent)
+		if mutateErr == nil && conv.Buf() == owner.conv.Buf() && recurrent.Buf() == owner.recurrent.Buf() {
+			owner.conv, owner.recurrent = conv, recurrent
+			l.conv, l.recurrent = conv, recurrent
+		}
+		return out, conv, recurrent, mutateErr
+	}()
+	cleanup.free()
 	return output, nextConv, nextRecurrent, err
 }
 
@@ -266,30 +281,36 @@ func (q *qwen35HALState) mutateSequence(
 	backend compute.Backend,
 	fn func(states []compute.Qwen35SequenceState) (compute.Qwen35SequencePrefillResult, error),
 ) (compute.Qwen35SequencePrefillResult, error) {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	states := make([]compute.Qwen35SequenceState, len(q.layers))
-	locked := make([]*qwen35HALLayerOwner, 0, len(q.layers))
-	unlock := func() {
-		for i := len(locked) - 1; i >= 0; i-- {
-			locked[i].mu.Unlock()
+	var cleanup qwen35HALLayerRelease
+	result, err := func() (compute.Qwen35SequencePrefillResult, error) {
+		q.mu.Lock()
+		defer q.mu.Unlock()
+		states := make([]compute.Qwen35SequenceState, len(q.layers))
+		locked := make([]*qwen35HALLayerOwner, 0, len(q.layers))
+		unlock := func() {
+			for i := len(locked) - 1; i >= 0; i-- {
+				locked[i].mu.Unlock()
+			}
 		}
-	}
-	for layer := range q.layers {
-		state := &q.layers[layer]
-		if state.conv.Buf() == nil && state.recurrent.Buf() == nil {
-			continue
+		for layer := range q.layers {
+			state := &q.layers[layer]
+			if state.conv.Buf() == nil && state.recurrent.Buf() == nil {
+				continue
+			}
+			owner, deferred, mutableErr := state.mutableOwnerLocked(backend)
+			cleanup = deferred
+			if mutableErr != nil {
+				unlock()
+				return compute.Qwen35SequencePrefillResult{}, fmt.Errorf("layer %d: %w", layer, mutableErr)
+			}
+			locked = append(locked, owner)
+			states[layer] = compute.Qwen35SequenceState{Conv: owner.conv, Recurrent: owner.recurrent}
 		}
-		owner, err := state.mutableOwnerLocked(backend)
-		if err != nil {
-			unlock()
-			return compute.Qwen35SequencePrefillResult{}, fmt.Errorf("layer %d: %w", layer, err)
-		}
-		locked = append(locked, owner)
-		states[layer] = compute.Qwen35SequenceState{Conv: owner.conv, Recurrent: owner.recurrent}
-	}
-	defer unlock()
-	return fn(states)
+		defer unlock()
+		return fn(states)
+	}()
+	cleanup.free()
+	return result, err
 }
 
 type qwen35PartialRoPEBackend interface {
@@ -368,15 +389,7 @@ func (q *qwen35HALState) free(backend compute.Backend) {
 	sequenceBackend, sequenceStates := q.detachSequenceLocked()
 	q.mu.Unlock()
 	for _, release := range releases {
-		if release.backend == nil {
-			continue
-		}
-		if release.conv.Buf() != nil {
-			release.backend.Free(release.conv)
-		}
-		if release.recurrent.Buf() != nil {
-			release.backend.Free(release.recurrent)
-		}
+		release.free()
 	}
 	freeQwen35SequenceStates(sequenceBackend, sequenceStates)
 }


### PR DESCRIPTION
## Summary

- make Qwen3.5/Qwen3.8 recurrent device-state snapshots retain shared per-layer owners instead of eagerly cloning tensors
- copy each convolution/recurrent pair on first mutation, including whole-sequence prefill
- preserve branch isolation, stale-epoch rejection, backend-bound ownership, and exact-once cleanup
- defer failed partial-clone cleanup until state/owner locks are released to permit backend re-entry

## Witnesses

- `go test ./internal/model -run TestQwen35RecurrentSnapshotCopyOnWriteIsolation -count=1`
- `.\test.ps1 -race ./internal/model -run 'TestQwen35(RecurrentSnapshotCopyOnWriteIsolation|GDNPreprojectedSequenceCleanupCloseResetAndAllocationFailure)' -count=1`
- `go vet ./internal/model`
- `dos commit-audit --workspace . 48181c80d`
- `dos commit-audit --workspace . c04f2c7d3`

## Physical acceptance

The required Strix appliance was unreachable from this controller, and current validator support cannot express the requested `qwen35-recurrent-snapshot` / `cow-shadow` A/B receipt. Follow-up: #12556. Keep #12550 open until its physical acceptance receipt exists.